### PR TITLE
feat(#7): TTL ベース自動 refresh + 起動シーケンス統合

### DIFF
--- a/src/image_annotator_lib/core/api_model_discovery.py
+++ b/src/image_annotator_lib/core/api_model_discovery.py
@@ -6,6 +6,8 @@
 
 import datetime
 import json
+import os
+import threading
 from datetime import datetime as dt
 from typing import Any
 
@@ -20,13 +22,21 @@ from ..exceptions.errors import (
 )
 from .config import (
     load_available_api_models,
+    load_last_refresh,
     save_available_api_models,
 )
-from .constants import AVAILABLE_API_MODELS_CONFIG_PATH
+from .constants import (
+    AVAILABLE_API_MODELS_CONFIG_PATH,
+    DEFAULT_API_MODELS_TTL_DAYS,
+    ENV_API_MODELS_TTL_DAYS,
+)
 from .utils import convert_unix_to_iso8601, logger
 
 _OPENROUTER_API_URL = "https://openrouter.ai/api/v1/models"
 _REQUEST_TIMEOUT = 10
+
+# 同時 background refresh を防ぐプロセス内ロック
+_refresh_lock = threading.Lock()
 
 
 def _fetch_from_litellm() -> list[dict[str, Any]]:
@@ -138,10 +148,67 @@ def _fetch_and_update_vision_models() -> dict[str, Any]:
     # === TOML 読み込み → 更新 → 書き込み ===
     existing_toml_data = load_available_api_models()
     updated_toml_data = _update_toml_with_api_results(existing_toml_data, all_models, current_time_iso)
-    save_available_api_models(updated_toml_data)
+    save_available_api_models(updated_toml_data, last_refresh=now)
 
     # TOML 書き込み失敗（save が例外を握りつぶす）でも in-memory の正確なデータを返す
     return updated_toml_data
+
+
+def should_refresh(ttl_days: int | None = None) -> bool:
+    """TTL 超過判定。
+
+    Args:
+        ttl_days: 有効期間（日数）。None の場合は環境変数 IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS、
+                  未設定時は DEFAULT_API_MODELS_TTL_DAYS（7日）を使用。
+
+    Returns:
+        True なら refresh が必要。last_refresh が未記録の場合も True を返す。
+    """
+    if ttl_days is None:
+        env_val = os.environ.get(ENV_API_MODELS_TTL_DAYS)
+        if env_val is not None:
+            try:
+                ttl_days = int(env_val)
+            except ValueError:
+                logger.warning(f"{ENV_API_MODELS_TTL_DAYS}={env_val!r} が整数でないため既定値を使用します。")
+                ttl_days = DEFAULT_API_MODELS_TTL_DAYS
+        else:
+            ttl_days = DEFAULT_API_MODELS_TTL_DAYS
+
+    last = load_last_refresh()
+    if last is None:
+        return True
+
+    age_seconds = (dt.now(datetime.UTC) - last).total_seconds()
+    return age_seconds > ttl_days * 86400
+
+
+def _refresh_worker() -> None:
+    """バックグラウンドスレッドで実行する refresh タスク。例外はすべて捕捉する。"""
+    if not _refresh_lock.acquire(blocking=False):
+        logger.debug("API モデル refresh は既に実行中のため、新規起動をスキップします。")
+        return
+    try:
+        logger.info("バックグラウンド API モデル refresh を開始します。")
+        _fetch_and_update_vision_models()
+        logger.info("バックグラウンド API モデル refresh が完了しました。")
+    except Exception as e:
+        logger.warning(f"バックグラウンド API モデル refresh に失敗しました（次回 TTL 超過時に再試行）: {e}")
+    finally:
+        _refresh_lock.release()
+
+
+def trigger_background_refresh() -> threading.Thread:
+    """バックグラウンドで _fetch_and_update_vision_models() をキックする。
+
+    起動元スレッドをブロックしない。既に refresh 実行中なら _refresh_worker 内でスキップされる。
+
+    Returns:
+        起動した daemon スレッド（テスト用）。
+    """
+    thread = threading.Thread(target=_refresh_worker, daemon=True, name="api-model-refresh")
+    thread.start()
+    return thread
 
 
 def discover_available_vision_models(force_refresh: bool = False) -> dict[str, Any]:

--- a/src/image_annotator_lib/core/api_model_discovery.py
+++ b/src/image_annotator_lib/core/api_model_discovery.py
@@ -179,7 +179,11 @@ def should_refresh(ttl_days: int | None = None) -> bool:
     if last is None:
         return True
 
-    age_seconds = (dt.now(datetime.UTC) - last).total_seconds()
+    try:
+        age_seconds = (dt.now(datetime.UTC) - last).total_seconds()
+    except TypeError:
+        logger.warning(f"last_refresh の型が不正のため refresh を実行します: {last!r}")
+        return True
     return age_seconds > ttl_days * 86400
 
 
@@ -244,7 +248,8 @@ def discover_available_vision_models(force_refresh: bool = False) -> dict[str, A
 
     try:
         logger.info("LiteLLM DB から最新のモデル情報を取得・更新します。")
-        updated_data = _fetch_and_update_vision_models()
+        with _refresh_lock:
+            updated_data = _fetch_and_update_vision_models()
         return {"models": list(updated_data.keys()), "toml_data": updated_data}
 
     except (ApiTimeoutError, ApiRequestError, ApiServerError, WebApiError) as e:

--- a/src/image_annotator_lib/core/config.py
+++ b/src/image_annotator_lib/core/config.py
@@ -1,6 +1,8 @@
 import copy
 import importlib.resources
+import os
 import shutil
+import tempfile
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
@@ -422,8 +424,14 @@ def save_available_api_models(
         full_data_to_save["available_vision_models"] = data
 
         logger.debug(f"動的 API モデル情報を書き込みます: {file_path}")
-        with open(file_path, "w", encoding="utf-8") as f:
-            toml.dump(full_data_to_save, f)
+        fd, tmp_path = tempfile.mkstemp(dir=file_path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                toml.dump(full_data_to_save, f)
+            os.replace(tmp_path, file_path)
+        except Exception:
+            os.unlink(tmp_path)
+            raise
         load_available_api_models.cache_clear()
         logger.debug(f"動的 API モデル情報を正常に書き込みました: {file_path}")
 

--- a/src/image_annotator_lib/core/config.py
+++ b/src/image_annotator_lib/core/config.py
@@ -386,7 +386,10 @@ def load_last_refresh() -> datetime | None:
     if isinstance(value, datetime):
         return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
     try:
-        return datetime.fromisoformat(str(value))
+        dt_val = datetime.fromisoformat(str(value))
+        if dt_val.tzinfo is None:
+            dt_val = dt_val.replace(tzinfo=timezone.utc)
+        return dt_val
     except ValueError:
         logger.warning(f"meta.last_refresh のパースに失敗しました: {value!r}")
         return None
@@ -408,7 +411,8 @@ def save_available_api_models(
 
         # 既存 meta を保持しつつ last_refresh のみ更新
         existing = _load_full_api_models_file()
-        meta: dict[str, Any] = dict(existing.get("meta", {}))
+        raw_meta = existing.get("meta", {})
+        meta: dict[str, Any] = dict(raw_meta) if isinstance(raw_meta, dict) else {}
         if last_refresh is not None:
             meta["last_refresh"] = last_refresh.isoformat()
 

--- a/src/image_annotator_lib/core/config.py
+++ b/src/image_annotator_lib/core/config.py
@@ -1,6 +1,7 @@
 import copy
 import importlib.resources
 import shutil
+from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -317,6 +318,23 @@ config_registry = _ConfigRegistryProxy()
 # --- available_api_models.toml 用のスタンドアロン関数 --- #
 
 
+def _load_full_api_models_file() -> dict[str, Any]:
+    """available_api_models.toml のファイル全体を dict で返す内部ヘルパー。
+
+    キャッシュなし。ファイル不存在・パースエラー時は空 dict を返す。
+    """
+    file_path = AVAILABLE_API_MODELS_CONFIG_PATH
+    if not file_path.is_file():
+        return {}
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            data = toml.load(f)
+        return data if isinstance(data, dict) else {}
+    except (toml.TomlDecodeError, OSError) as e:
+        logger.error(f"{file_path} の読み込みエラー: {e}")
+        return {}
+
+
 @lru_cache(maxsize=1)
 def load_available_api_models() -> dict[str, Any]:
     """`available_api_models.toml` を読み込み、モデルデータを辞書として返す。
@@ -326,15 +344,13 @@ def load_available_api_models() -> dict[str, Any]:
     file_path = AVAILABLE_API_MODELS_CONFIG_PATH
     try:
         logger.debug(f"動的 API モデル情報を読み込みます: {file_path}")
-        # ファイルが存在しない場合でもエラーにならないように先にチェック
         if not file_path.is_file():
             logger.info(
                 f"{file_path} が見つかりません。初回実行の可能性があります。空のデータで開始します。"
             )
             return {}
-        with open(file_path, encoding="utf-8") as f:
-            data = toml.load(f)
-        if not isinstance(data, dict) or "available_vision_models" not in data:
+        data = _load_full_api_models_file()
+        if not data or "available_vision_models" not in data:
             logger.warning(
                 f"{file_path} の形式が不正か、[available_vision_models] セクションがありません。"
             )
@@ -345,35 +361,65 @@ def load_available_api_models() -> dict[str, Any]:
             return {}
         logger.debug(f"動的 API モデル情報を正常に読み込みました: {file_path}")
         return model_data
-    except toml.TomlDecodeError as e:
-        logger.error(f"{file_path} の TOML 解析に失敗しました: {e}")
-        return {}
-    except OSError as e:
-        logger.error(f"{file_path} の読み込み中に I/O エラーが発生しました: {e}")
-        return {}
     except Exception as e:
         logger.exception(f"{file_path} の読み込み中に予期せぬエラーが発生しました: {e}")
         return {}
 
 
-def save_available_api_models(data: dict[str, Any]) -> None:
+def load_api_models_meta() -> dict[str, Any]:
+    """`available_api_models.toml` の `[meta]` セクションを返す。欠落時は空 dict。"""
+    data = _load_full_api_models_file()
+    meta = data.get("meta", {})
+    return meta if isinstance(meta, dict) else {}
+
+
+def load_last_refresh() -> datetime | None:
+    """`meta.last_refresh` を timezone-aware datetime で返す。
+
+    欠落・パース失敗時は None を返す。
+    """
+    meta = load_api_models_meta()
+    value = meta.get("last_refresh")
+    if value is None:
+        return None
+    # toml ライブラリが datetime 型に変換している場合
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    try:
+        return datetime.fromisoformat(str(value))
+    except ValueError:
+        logger.warning(f"meta.last_refresh のパースに失敗しました: {value!r}")
+        return None
+
+
+def save_available_api_models(
+    data: dict[str, Any],
+    last_refresh: datetime | None = None,
+) -> None:
     """与えられたモデルデータを `available_api_models.toml` に書き込む。
 
     Args:
         data: 保存するモデルデータ辞書 (available_vision_models セクションの内容)。
+        last_refresh: 書き込む refresh タイムスタンプ。None の場合は既存 meta を維持。
     """
     file_path = AVAILABLE_API_MODELS_CONFIG_PATH
     try:
-        # ディレクトリが存在しない場合に作成
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # 書き込むデータ全体を構築
-        full_data_to_save = {"available_vision_models": data}
+        # 既存 meta を保持しつつ last_refresh のみ更新
+        existing = _load_full_api_models_file()
+        meta: dict[str, Any] = dict(existing.get("meta", {}))
+        if last_refresh is not None:
+            meta["last_refresh"] = last_refresh.isoformat()
+
+        full_data_to_save: dict[str, Any] = {}
+        if meta:
+            full_data_to_save["meta"] = meta
+        full_data_to_save["available_vision_models"] = data
 
         logger.debug(f"動的 API モデル情報を書き込みます: {file_path}")
         with open(file_path, "w", encoding="utf-8") as f:
             toml.dump(full_data_to_save, f)
-        # キャッシュをクリア (次の load 呼び出しで再読み込みさせる)
         load_available_api_models.cache_clear()
         logger.debug(f"動的 API モデル情報を正常に書き込みました: {file_path}")
 

--- a/src/image_annotator_lib/core/constants.py
+++ b/src/image_annotator_lib/core/constants.py
@@ -31,5 +31,11 @@ DEFAULT_PATHS = {
     "cache_dir": CACHE_DIR,  # プロジェクト models
 }
 
+# --- API モデル discovery TTL 設定 ---
+# available_api_models.toml の自動 refresh 間隔（既定 7 日）
+DEFAULT_API_MODELS_TTL_DAYS = 7
+# TTL を環境変数で上書きするためのキー名
+ENV_API_MODELS_TTL_DAYS = "IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS"
+
 # テンプレートパスも必要に応じてエクスポート (config.py で使う)
 # (直接定数を使うのでエクスポート不要かも)

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -598,6 +598,7 @@ def _discover_and_update_api_models(skip_api_discovery: bool) -> None:
     Args:
         skip_api_discovery: Trueの場合、API検出をスキップする。
     """
+    ttl_expired = False
     if skip_api_discovery:
         logger.info(
             "環境変数 IMAGE_ANNOTATOR_SKIP_API_DISCOVERY=true のため、"
@@ -621,12 +622,8 @@ def _discover_and_update_api_models(skip_api_discovery: bool) -> None:
                 "APIからのモデル情報取得に失敗したため、Web API モデルの自動設定は行われない可能性があります。"
             )
     elif api_model_discovery.should_refresh():
-        # TTL 超過: バックグラウンドで非同期 refresh（起動をブロックしない）
-        api_model_discovery.trigger_background_refresh()
-        logger.info(
-            "TTL 超過のため API モデル情報の background refresh を起動しました。"
-            "次回起動時から最新モデル一覧が反映されます。"
-        )
+        # TTL 超過: _update_config_with_api_models() のファイル読み取り後に起動する（書き込み競合を避けるため）
+        ttl_expired = True
     else:
         logger.debug("API モデル情報は TTL 内のため、既存キャッシュを使用します。")
 
@@ -636,6 +633,14 @@ def _discover_and_update_api_models(skip_api_discovery: bool) -> None:
     else:
         logger.warning(
             f"{AVAILABLE_API_MODELS_CONFIG_PATH} が存在しないため、Web API モデル設定を読み込めません。"
+        )
+
+    # ファイル読み取り完了後にバックグラウンド refresh を起動（read/write 競合を排除）
+    if ttl_expired:
+        api_model_discovery.trigger_background_refresh()
+        logger.info(
+            "TTL 超過のため API モデル情報の background refresh を起動しました。"
+            "次回起動時から最新モデル一覧が反映されます。"
         )
 
 

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -598,30 +598,37 @@ def _discover_and_update_api_models(skip_api_discovery: bool) -> None:
     Args:
         skip_api_discovery: Trueの場合、API検出をスキップする。
     """
-    if not AVAILABLE_API_MODELS_CONFIG_PATH.exists():
-        if skip_api_discovery:
+    if skip_api_discovery:
+        logger.info(
+            "環境変数 IMAGE_ANNOTATOR_SKIP_API_DISCOVERY=true のため、"
+            "API モデル情報の取得をスキップします。"
+        )
+    elif not AVAILABLE_API_MODELS_CONFIG_PATH.exists():
+        # 初回起動: 同期 fetch（後続の annotator_config 更新にデータが必要）
+        logger.info(
+            f"{AVAILABLE_API_MODELS_CONFIG_PATH} が見つかりません。APIから最新情報を取得します..."
+        )
+        try:
+            api_model_discovery._fetch_and_update_vision_models()
             logger.info(
-                "環境変数 IMAGE_ANNOTATOR_SKIP_API_DISCOVERY=true のため、"
-                "API モデル情報の取得をスキップします。"
+                f"API からモデル情報を取得し、{AVAILABLE_API_MODELS_CONFIG_PATH} を更新しました。"
             )
-        else:
-            logger.info(
-                f"{AVAILABLE_API_MODELS_CONFIG_PATH} が見つかりません。APIから最新情報を取得します..."
+        except Exception as api_e:
+            logger.error(
+                f"API からのモデル情報取得中にエラーが発生しました: {api_e}", exc_info=True
             )
-            try:
-                api_model_discovery._fetch_and_update_vision_models()
-                logger.info(
-                    f"API からモデル情報を取得し、{AVAILABLE_API_MODELS_CONFIG_PATH} を更新しました。"
-                )
-            except Exception as api_e:
-                logger.error(
-                    f"API からのモデル情報取得中にエラーが発生しました: {api_e}", exc_info=True
-                )
-                logger.warning(
-                    "APIからのモデル情報取得に失敗したため、Web API モデルの自動設定は行われない可能性があります。"
-                )
+            logger.warning(
+                "APIからのモデル情報取得に失敗したため、Web API モデルの自動設定は行われない可能性があります。"
+            )
+    elif api_model_discovery.should_refresh():
+        # TTL 超過: バックグラウンドで非同期 refresh（起動をブロックしない）
+        api_model_discovery.trigger_background_refresh()
+        logger.info(
+            "TTL 超過のため API モデル情報の background refresh を起動しました。"
+            "次回起動時から最新モデル一覧が反映されます。"
+        )
     else:
-        logger.debug(f"{AVAILABLE_API_MODELS_CONFIG_PATH} が存在します。既存のファイルを使用します。")
+        logger.debug("API モデル情報は TTL 内のため、既存キャッシュを使用します。")
 
     # available_api_models.toml を読み込み、annotator_config.toml を更新
     if AVAILABLE_API_MODELS_CONFIG_PATH.exists():

--- a/tests/unit/core/test_ttl_refresh.py
+++ b/tests/unit/core/test_ttl_refresh.py
@@ -11,6 +11,7 @@ import pytest
 
 import image_annotator_lib.core.api_model_discovery as _disc_module
 from image_annotator_lib.core.api_model_discovery import (
+    discover_available_vision_models,
     should_refresh,
     trigger_background_refresh,
 )
@@ -271,3 +272,65 @@ def test_trigger_background_refresh_dedupe(toml_path: Path) -> None:
         t2.join(timeout=2)
 
     assert call_count == 1, f"fetch が複数回実行されました: {call_count} 回"
+
+
+# --- should_refresh: naive datetime 安全性テスト ---
+
+
+@pytest.mark.unit
+def test_should_refresh_returns_true_on_naive_datetime(toml_path: Path) -> None:
+    """load_last_refresh が naive datetime を返しても TypeError を起こさず True を返す。"""
+    naive_dt = datetime(2026, 1, 1, 0, 0, 0)  # tzinfo なし
+    with patch("image_annotator_lib.core.api_model_discovery.load_last_refresh", return_value=naive_dt):
+        result = should_refresh()
+    assert result is True
+
+
+# --- discover_available_vision_models: ロック直列化テスト ---
+
+
+@pytest.mark.unit
+def test_discover_force_refresh_acquires_refresh_lock(toml_path: Path) -> None:
+    """force_refresh=True 時、_fetch_and_update_vision_models の実行中に _refresh_lock が保持される。"""
+    lock_held_during_fetch: list[bool] = []
+
+    def check_lock() -> dict:
+        lock_held_during_fetch.append(_disc_module._refresh_lock.locked())
+        return {}
+
+    with patch(
+        "image_annotator_lib.core.api_model_discovery._fetch_and_update_vision_models",
+        side_effect=check_lock,
+    ):
+        discover_available_vision_models(force_refresh=True)
+
+    assert lock_held_during_fetch == [True], "fetch 中に _refresh_lock が保持されていません"
+
+
+@pytest.mark.unit
+def test_discover_force_refresh_serializes_with_background_refresh(toml_path: Path) -> None:
+    """force_refresh とバックグラウンド refresh は同時に _fetch を実行しない。"""
+    concurrent_count = 0
+    active_count = 0
+    fetch_started = threading.Event()
+
+    def serialized_fetch() -> dict:
+        nonlocal concurrent_count, active_count
+        active_count += 1
+        if active_count > 1:
+            concurrent_count += 1
+        fetch_started.set()
+        time.sleep(0.05)
+        active_count -= 1
+        return {}
+
+    with patch(
+        "image_annotator_lib.core.api_model_discovery._fetch_and_update_vision_models",
+        side_effect=serialized_fetch,
+    ):
+        bg_thread = trigger_background_refresh()
+        fetch_started.wait(timeout=2)  # バックグラウンドが fetch 中になるまで待つ
+        discover_available_vision_models(force_refresh=True)  # ロック待ちして直列実行
+        bg_thread.join(timeout=2)
+
+    assert concurrent_count == 0, "fetch が同時実行されました"

--- a/tests/unit/core/test_ttl_refresh.py
+++ b/tests/unit/core/test_ttl_refresh.py
@@ -1,0 +1,244 @@
+"""Unit tests for TTL-based auto-refresh of available_api_models.toml."""
+
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+
+import image_annotator_lib.core.api_model_discovery as _disc_module
+from image_annotator_lib.core.api_model_discovery import (
+    should_refresh,
+    trigger_background_refresh,
+)
+from image_annotator_lib.core.config import (
+    load_api_models_meta,
+    load_available_api_models,
+    load_last_refresh,
+    save_available_api_models,
+)
+
+
+# --- フィクスチャ ---
+
+
+@pytest.fixture
+def toml_path(tmp_path: Path) -> Generator[Path, None, None]:
+    """TOML ファイルパスをテスト用一時ディレクトリにリダイレクトする。"""
+    p = tmp_path / "available_api_models.toml"
+    with (
+        patch("image_annotator_lib.core.api_model_discovery.AVAILABLE_API_MODELS_CONFIG_PATH", p),
+        patch("image_annotator_lib.core.config.AVAILABLE_API_MODELS_CONFIG_PATH", p),
+    ):
+        load_available_api_models.cache_clear()
+        yield p
+        load_available_api_models.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def reset_refresh_lock() -> Generator[None, None, None]:
+    """各テストの前後でモジュールレベルの _refresh_lock を新規 Lock に交換する。
+
+    前テストで lock が残るとスレッドが即スキップするため、テスト間分離が必要。
+    """
+    original_lock = _disc_module._refresh_lock
+    _disc_module._refresh_lock = threading.Lock()
+    yield
+    _disc_module._refresh_lock = original_lock
+
+
+@pytest.fixture
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# --- load_last_refresh テスト ---
+
+
+@pytest.mark.unit
+def test_load_last_refresh_returns_none_when_file_missing(toml_path: Path) -> None:
+    assert load_last_refresh() is None
+
+
+@pytest.mark.unit
+def test_load_last_refresh_returns_none_when_meta_section_missing(toml_path: Path) -> None:
+    save_available_api_models({})
+    assert load_last_refresh() is None
+
+
+@pytest.mark.unit
+def test_load_last_refresh_returns_datetime_when_present(toml_path: Path, now_utc: datetime) -> None:
+    save_available_api_models({}, last_refresh=now_utc)
+    result = load_last_refresh()
+    assert result is not None
+    assert abs((result - now_utc).total_seconds()) < 1
+
+
+@pytest.mark.unit
+def test_load_last_refresh_returns_timezone_aware_datetime(toml_path: Path, now_utc: datetime) -> None:
+    save_available_api_models({}, last_refresh=now_utc)
+    result = load_last_refresh()
+    assert result is not None
+    assert result.tzinfo is not None
+
+
+# --- save_available_api_models + [meta] テスト ---
+
+
+@pytest.mark.unit
+def test_save_writes_meta_last_refresh(toml_path: Path, now_utc: datetime) -> None:
+    data = {"google/gemini-test": {"provider": "Google"}}
+    save_available_api_models(data, last_refresh=now_utc)
+
+    meta = load_api_models_meta()
+    assert "last_refresh" in meta
+
+
+@pytest.mark.unit
+def test_save_preserves_meta_when_last_refresh_none(toml_path: Path, now_utc: datetime) -> None:
+    """last_refresh=None で保存しても既存 meta.last_refresh が保持される。"""
+    save_available_api_models({}, last_refresh=now_utc)
+    first_refresh = load_last_refresh()
+
+    save_available_api_models({"some/model": {"provider": "Test"}}, last_refresh=None)
+    second_refresh = load_last_refresh()
+
+    assert first_refresh is not None
+    assert second_refresh is not None
+    assert abs((first_refresh - second_refresh).total_seconds()) < 1
+
+
+@pytest.mark.unit
+def test_save_preserves_existing_model_data(toml_path: Path, now_utc: datetime) -> None:
+    data = {"openai/gpt-4o": {"provider": "OpenAI", "model_name_short": "gpt-4o"}}
+    save_available_api_models(data, last_refresh=now_utc)
+    load_available_api_models.cache_clear()
+    loaded = load_available_api_models()
+    assert "openai/gpt-4o" in loaded
+
+
+# --- should_refresh テスト ---
+
+
+@pytest.mark.unit
+def test_should_refresh_returns_true_when_file_missing(toml_path: Path) -> None:
+    assert should_refresh() is True
+
+
+@pytest.mark.unit
+def test_should_refresh_returns_true_when_last_refresh_missing(toml_path: Path) -> None:
+    save_available_api_models({})
+    assert should_refresh() is True
+
+
+@pytest.mark.unit
+def test_should_refresh_returns_true_when_ttl_exceeded(toml_path: Path) -> None:
+    old_refresh = datetime.now(timezone.utc) - timedelta(days=8)
+    save_available_api_models({}, last_refresh=old_refresh)
+    assert should_refresh(ttl_days=7) is True
+
+
+@pytest.mark.unit
+def test_should_refresh_returns_false_when_within_ttl(toml_path: Path) -> None:
+    recent_refresh = datetime.now(timezone.utc) - timedelta(days=1)
+    save_available_api_models({}, last_refresh=recent_refresh)
+    assert should_refresh(ttl_days=7) is False
+
+
+@pytest.mark.unit
+def test_should_refresh_returns_true_exactly_at_ttl_boundary(toml_path: Path) -> None:
+    """TTL ちょうどは「期限切れ」と判定される（> 判定）。"""
+    boundary_refresh = datetime.now(timezone.utc) - timedelta(days=7, seconds=1)
+    save_available_api_models({}, last_refresh=boundary_refresh)
+    assert should_refresh(ttl_days=7) is True
+
+
+@pytest.mark.unit
+def test_should_refresh_respects_env_var(toml_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    recent_refresh = datetime.now(timezone.utc) - timedelta(days=2)
+    save_available_api_models({}, last_refresh=recent_refresh)
+
+    monkeypatch.setenv("IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS", "1")
+    assert should_refresh() is True
+
+    monkeypatch.setenv("IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS", "30")
+    assert should_refresh() is False
+
+
+@pytest.mark.unit
+def test_should_refresh_uses_default_ttl_on_invalid_env_var(
+    toml_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recent_refresh = datetime.now(timezone.utc) - timedelta(days=1)
+    save_available_api_models({}, last_refresh=recent_refresh)
+
+    monkeypatch.setenv("IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS", "not_a_number")
+    # 既定 TTL=7 日なので 1 日前なら False
+    assert should_refresh() is False
+
+
+# --- trigger_background_refresh テスト ---
+
+
+@pytest.mark.unit
+def test_trigger_background_refresh_does_not_block(toml_path: Path) -> None:
+    """refresh が完了するまで待たず、即座に返ること。"""
+    barrier = threading.Event()
+
+    def slow_fetch() -> None:
+        barrier.wait(timeout=5)
+
+    with patch(
+        "image_annotator_lib.core.api_model_discovery._fetch_and_update_vision_models",
+        side_effect=slow_fetch,
+    ):
+        start = time.monotonic()
+        thread = trigger_background_refresh()
+        elapsed = time.monotonic() - start
+
+    barrier.set()
+    thread.join(timeout=2)
+
+    assert elapsed < 0.5, f"trigger_background_refresh がブロックしました: {elapsed:.3f}s"
+
+
+@pytest.mark.unit
+def test_trigger_background_refresh_swallows_exceptions(toml_path: Path) -> None:
+    """_fetch_and_update_vision_models が例外を送出してもプロセスが継続すること。"""
+    with patch(
+        "image_annotator_lib.core.api_model_discovery._fetch_and_update_vision_models",
+        side_effect=RuntimeError("network error"),
+    ):
+        thread = trigger_background_refresh()
+        thread.join(timeout=2)
+
+    assert not thread.is_alive()
+
+
+@pytest.mark.unit
+def test_trigger_background_refresh_dedupe(toml_path: Path) -> None:
+    """同時に複数回呼んでも _fetch_and_update_vision_models は 1 回しか実行されない。"""
+    call_count = 0
+    fetch_started = threading.Event()  # t1 の fetch が開始したら set する
+
+    def counting_fetch() -> None:
+        nonlocal call_count
+        call_count += 1
+        fetch_started.set()  # t1 がロックを保持したまま fetch 中であることを通知
+        time.sleep(0.1)
+
+    with patch(
+        "image_annotator_lib.core.api_model_discovery._fetch_and_update_vision_models",
+        side_effect=counting_fetch,
+    ):
+        t1 = trigger_background_refresh()
+        # t1 が _refresh_lock を保持して counting_fetch に入るまで待つ
+        fetch_started.wait(timeout=2)
+        t2 = trigger_background_refresh()
+        t1.join(timeout=2)
+        t2.join(timeout=2)
+
+    assert call_count == 1, f"fetch が複数回実行されました: {call_count} 回"

--- a/tests/unit/core/test_ttl_refresh.py
+++ b/tests/unit/core/test_ttl_refresh.py
@@ -85,6 +85,22 @@ def test_load_last_refresh_returns_timezone_aware_datetime(toml_path: Path, now_
     assert result.tzinfo is not None
 
 
+@pytest.mark.unit
+def test_load_last_refresh_normalizes_naive_datetime_to_utc(toml_path: Path) -> None:
+    """タイムゾーンなし文字列（手編集等）は UTC として扱い、aware datetime を返す。"""
+    import toml
+
+    toml_path.write_text(
+        '[meta]\nlast_refresh = "2026-04-20T10:00:00"\n[available_vision_models]\n',
+        encoding="utf-8",
+    )
+    load_available_api_models.cache_clear()
+    result = load_last_refresh()
+    assert result is not None
+    assert result.tzinfo is not None
+    assert result.tzinfo == timezone.utc
+
+
 # --- save_available_api_models + [meta] テスト ---
 
 
@@ -109,6 +125,19 @@ def test_save_preserves_meta_when_last_refresh_none(toml_path: Path, now_utc: da
     assert first_refresh is not None
     assert second_refresh is not None
     assert abs((first_refresh - second_refresh).total_seconds()) < 1
+
+
+@pytest.mark.unit
+def test_save_ignores_non_dict_meta_section(toml_path: Path, now_utc: datetime) -> None:
+    """TOML の [meta] が非 dict（破損）の場合でも save が正常完了し meta を上書きする。"""
+    toml_path.write_text(
+        'meta = "broken"\n[available_vision_models]\n',
+        encoding="utf-8",
+    )
+    load_available_api_models.cache_clear()
+    save_available_api_models({}, last_refresh=now_utc)
+    meta = load_api_models_meta()
+    assert "last_refresh" in meta
 
 
 @pytest.mark.unit

--- a/tests/unit/standard/core/test_registry.py
+++ b/tests/unit/standard/core/test_registry.py
@@ -454,3 +454,34 @@ def test_try_register_model_overwrite_warning():
     result = registry._try_register_model(reg, "test-model", new_cls, BaseAnnotator)
     assert result is True
     assert reg["test-model"] is new_cls
+
+
+# ==============================================================================
+# Test _discover_and_update_api_models: background refresh ordering
+# ==============================================================================
+
+
+@pytest.mark.unit
+@patch("image_annotator_lib.core.registry.os.getenv", return_value="false")
+@patch("image_annotator_lib.core.api_model_discovery.trigger_background_refresh")
+@patch("image_annotator_lib.core.api_model_discovery.should_refresh", return_value=True)
+@patch("image_annotator_lib.core.registry._update_config_with_api_models")
+@patch("image_annotator_lib.core.registry.AVAILABLE_API_MODELS_CONFIG_PATH")
+def test_background_refresh_starts_after_update_config(
+    mock_config_path,
+    mock_update_config,
+    _mock_should_refresh,
+    mock_trigger,
+    _mock_getenv,
+) -> None:
+    """TTL 超過時、trigger_background_refresh は _update_config_with_api_models の後に呼ばれる。"""
+    call_order: list[str] = []
+    mock_config_path.exists.return_value = True
+    mock_update_config.side_effect = lambda: call_order.append("update_config")
+    mock_trigger.side_effect = lambda: call_order.append("trigger_refresh")
+
+    registry._discover_and_update_api_models(skip_api_discovery=False)
+
+    assert call_order == ["update_config", "trigger_refresh"], (
+        f"呼び出し順が期待と異なります: {call_order}"
+    )

--- a/tests/unit/standard/core/test_registry.py
+++ b/tests/unit/standard/core/test_registry.py
@@ -96,6 +96,8 @@ def test_initialize_registry_api_models_file_not_exists_calls_fetch_and_update(
 
 
 @pytest.mark.unit
+@patch("image_annotator_lib.core.registry.os.getenv", return_value="false")
+@patch("image_annotator_lib.core.api_model_discovery.should_refresh", return_value=False)
 @patch("image_annotator_lib.core.registry.register_annotators")
 @patch("image_annotator_lib.core.registry._update_config_with_api_models")
 @patch("image_annotator_lib.core.api_model_discovery._fetch_and_update_vision_models")
@@ -107,6 +109,8 @@ def test_initialize_registry_api_models_file_exists_skips_fetch(
     mock_fetch_api_models,
     mock_update_config,
     mock_register,
+    _mock_should_refresh,
+    _mock_getenv,
 ):
     """Test initialize_registry skips API fetch but calls config update when file exists."""
     # Reset singleton state before test
@@ -117,7 +121,7 @@ def test_initialize_registry_api_models_file_exists_skips_fetch(
     registry.initialize_registry()
 
     mock_init_logger.assert_called_once()
-    # exists() is called twice: once in the first check, once before update
+    # exists() is called twice: once in the elif check, once before update
     assert mock_config_path.exists.call_count == 2
     mock_fetch_api_models.assert_not_called()
     mock_update_config.assert_called_once()
@@ -259,6 +263,8 @@ def test_update_config_with_api_models_no_classes(
 
 
 @pytest.mark.unit
+@patch("image_annotator_lib.core.registry.os.getenv", return_value="false")
+@patch("image_annotator_lib.core.api_model_discovery.should_refresh", return_value=False)
 @patch("image_annotator_lib.core.registry.register_annotators")
 @patch("image_annotator_lib.core.registry._update_config_with_api_models")
 @patch("image_annotator_lib.core.api_model_discovery._fetch_and_update_vision_models")
@@ -270,6 +276,8 @@ def test_initialize_registry_singleton_pattern(
     mock_fetch_api_models,
     mock_update_config,
     mock_register,
+    _mock_should_refresh,
+    _mock_getenv,
 ):
     """Test initialize_registry uses singleton pattern and only initializes once."""
     # Reset singleton state before test
@@ -282,9 +290,9 @@ def test_initialize_registry_singleton_pattern(
 
     # Verify first call executed all steps
     assert mock_init_logger.call_count == 1
-    # exists() called twice: first check and before update
+    # exists() called twice: once in elif check, once before update
     assert mock_config_path.exists.call_count == 2
-    assert mock_fetch_api_models.call_count == 0  # Should skip when file exists
+    assert mock_fetch_api_models.call_count == 0  # Should skip when file exists and within TTL
     assert mock_update_config.call_count == 1
     assert mock_register.call_count == 1
 


### PR DESCRIPTION
## Summary

- `available_api_models.toml` にファイルレベルの `[meta] last_refresh` セクションを追加
- 起動時に TTL（既定 7 日 / 環境変数 `IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS` で上書き可能）超過を判定し、超過時は **daemon thread でバックグラウンド refresh** をキック
- 起動をブロックしない（初回起動のみファイル未存在時に同期 fetch を維持）
- ネットワーク失敗時は既存キャッシュをそのまま使用、ログ警告のみ

## 変更ファイル

| ファイル | 変更概要 |
|---|---|
| `core/constants.py` | `DEFAULT_API_MODELS_TTL_DAYS=7`、`ENV_API_MODELS_TTL_DAYS` 追加 |
| `core/config.py` | `load_api_models_meta()`、`load_last_refresh()` 追加。`save_available_api_models()` に `last_refresh` パラメータ追加 |
| `core/api_model_discovery.py` | `should_refresh()`、`trigger_background_refresh()`、`_refresh_worker()` 追加 |
| `core/registry.py` | `_discover_and_update_api_models()` を 4 分岐に整理 |
| `tests/unit/core/test_ttl_refresh.py` | TTL 判定・background refresh 17 テスト新規追加 |
| `tests/unit/standard/core/test_registry.py` | 既存テストを新ロジックに対応（`should_refresh` mock 追加） |

## 受け入れ条件

- [x] 起動時に TTL 超過なら background refresh が走る
- [x] 期限内なら refresh されず即起動完了
- [x] ネットワーク失敗時も起動が成功する
- [x] `available_api_models.toml` の `[meta] last_refresh` が更新される

## Test plan

- [x] `uv run pytest tests/ -m "unit or fast"` — 414 tests passed
- [x] `test_ttl_refresh.py` — 17 tests passed

親 ADR: [LoRAIro ADR 0021](https://github.com/NEXTAltair/LoRAIro/blob/main/docs/decisions/0021-litellm-driven-model-registry.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)