### PR TITLE
feat(#8): CI 週次 refresh ワークフロー + ドキュメント整備

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/model_refresh.md
+++ b/.github/PULL_REQUEST_TEMPLATE/model_refresh.md
@@ -1,0 +1,15 @@
+## モデルレジストリ更新 PR
+
+### 変更内容
+<!-- 追加・削除・変更されたモデルを記載してください -->
+
+- 新規モデル:
+- 廃止モデル:
+- LiteLLM バージョン変更: (例: 1.x.y → 1.x.z)
+
+### 確認手順
+
+- [ ] `config/available_api_models.toml` の `[meta] last_refresh` が更新されている
+- [ ] 新規モデルの `provider` / `display_name` が正しい
+- [ ] 廃止モデルに `deprecated_on` タイムスタンプが設定されている
+- [ ] CI (lint / typecheck / unit tests) が通過している

--- a/.github/workflows/refresh-models.yml
+++ b/.github/workflows/refresh-models.yml
@@ -1,0 +1,79 @@
+name: Refresh Model Registry
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # 毎週月曜 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  PYTHONDONTWRITEBYTECODE: "1"
+
+jobs:
+  refresh:
+    name: Refresh API Model Registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Update LiteLLM to latest
+        run: |
+          uv lock --upgrade-package litellm
+          uv sync
+
+      - name: Set date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Refresh model registry
+        run: uv run python tools/check_api_model_discovery.py
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        id: cpr
+        with:
+          commit-message: "chore(deps): refresh model registry ${{ steps.date.outputs.date }}"
+          branch: chore/refresh-model-registry
+          delete-branch: false
+          title: "chore(deps): refresh model registry (${{ steps.date.outputs.date }})"
+          labels: |
+            dependencies
+            model-registry
+          body: |
+            ## 自動生成 PR: モデルレジストリ週次更新
+
+            このPRは週次CI (`refresh-models.yml`) によって自動生成されました。
+
+            ### 変更内容
+            - LiteLLM を最新版に更新（新規モデル・廃止モデルを反映）
+            - `config/available_api_models.toml` を再生成
+            - `[meta] last_refresh` を現在時刻に更新
+
+            ### 確認手順
+            - [ ] 新規モデルが適切に追加されている
+            - [ ] `deprecated_on` が設定された廃止モデルが正しい
+            - [ ] CI (lint / typecheck / unit tests) が通過している
+          add-paths: |
+            config/available_api_models.toml
+            uv.lock
+
+      - name: PR 作成結果を出力
+        if: steps.cpr.outputs.pull-request-number != ''
+        run: |
+          echo "PR #${{ steps.cpr.outputs.pull-request-number }} を作成しました"
+          echo "URL: ${{ steps.cpr.outputs.pull-request-url }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased] — ADR 0021: LiteLLM-Driven WebAPI Model Registry
+
+この変更セットは [ADR 0021](https://github.com/NEXTAltair/LoRAIro/blob/main/docs/decisions/0021-litellm-driven-model-registry.md) に基づく WebAPI モデルレジストリの刷新です。
+
+### Added
+
+- **LiteLLM 統合** (ISSUE B): `core/api_model_discovery.py` に LiteLLM ローカル DB を使用した Vision モデル自動検出機能を追加
+- **`deprecated_on` フィルタ** (ISSUE C): `simplified_agent_factory.py` に `get_available_models()` / `list_all_models()` / `is_model_deprecated()` を追加
+- **TTL ベース自動 refresh** (ISSUE E): `core/api_model_discovery.py` に `should_refresh()` / `trigger_background_refresh()` を追加
+- **`[meta] last_refresh`**: `config/available_api_models.toml` に refresh タイムスタンプのメタデータセクションを導入
+- **アトミック書き込み**: `save_available_api_models()` を `tempfile + os.replace()` によるアトミック書き込みに変更
+- **CI 週次 refresh** (ISSUE G): `.github/workflows/refresh-models.yml` による週次自動更新と PR 自動作成
+- **環境変数サポート**: `IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS` / `IMAGE_ANNOTATOR_SKIP_API_DISCOVERY` で動作を制御可能
+
+### Changed
+
+- **`annotator_config.toml` の WebAPI セクション削除** (ISSUE D): WebAPI モデルの手動定義を廃止。モデルリストは LiteLLM により動的に管理される
+  - **破壊的変更**: 詳細は [`docs/migration/0021-litellm-migration.md`](docs/migration/0021-litellm-migration.md) を参照
+- **`core/registry.py` の起動シーケンス**: TTL 判定に基づいて同期 fetch / バックグラウンド refresh / スキップを自動切り替え
+- **`discover_available_vision_models()` の戻り値**: `{"models": list[str], "toml_data": dict}` 形式に統一
+
+### Deprecated
+
+- `annotator_config.toml` への WebAPI モデルの手動定義（既存設定は無視される）
+
+### Fixed
+
+- OpenRouter API フォールバックが LiteLLM 未収録モデルを補完するよう改善
+- 起動時の同期 API fetch が UI/CLI 起動をブロックしていた問題を修正（バックグラウンド化）

--- a/README.md
+++ b/README.md
@@ -7,8 +7,47 @@
 - 複数の画像タギングモデルと画像スコアリングモデルをサポート
 - 統一された API (`annotate`) による複数モデル･複数画像の一括処理
 - pHash に基づく画像と結果の紐付け
-- 設定ファイル (`annotator_config.toml`) によるモデル選択と設定
+- 設定ファイル (`annotator_config.toml`) によるモデル選択と設定（ローカル ML モデル専用）
 - メモリ使用量に基づく効率的なモデルキャッシュ管理 (LRU, CPU 退避/CUDA 復元)
+- **LiteLLM による WebAPI モデル自動検出**（追加設定不要）
+
+## WebAPI モデル自動検出
+
+本ライブラリは [LiteLLM](https://github.com/BerriAI/litellm) のローカル DB を使用して、OpenAI / Anthropic / Google などの WebAPI モデルを自動的に検出します。
+
+### 動作フロー
+
+1. **初回起動時**: LiteLLM のローカル DB から Vision 対応モデルを検出し、`config/available_api_models.toml` に保存
+2. **以降の起動時**: `[meta] last_refresh` の TTL（デフォルト 7 日）を確認し、超過時はバックグラウンドで再取得
+3. **週次 CI**: `refresh-models.yml` が最新 LiteLLM で `available_api_models.toml` を更新し PR を自動作成
+
+### 環境変数
+
+| 変数名 | 既定値 | 説明 |
+|---|---|---|
+| `IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS` | `7` | モデルリストの有効期間（日数） |
+| `IMAGE_ANNOTATOR_SKIP_API_DISCOVERY` | `false` | `true` に設定すると起動時の API discovery を完全スキップ |
+
+### プログラムからの利用
+
+```python
+from image_annotator_lib import discover_available_vision_models
+from image_annotator_lib.core.api_model_discovery import should_refresh, trigger_background_refresh
+
+# キャッシュから読み込み（TTL 内なら再取得しない）
+result = discover_available_vision_models()
+if "models" in result:
+    print(f"{len(result['models'])} 件の Vision モデルが利用可能")
+
+# TTL 超過確認と手動 refresh
+if should_refresh():
+    trigger_background_refresh()  # 非同期・起動をブロックしない
+
+# 強制再取得
+result = discover_available_vision_models(force_refresh=True)
+```
+
+詳細は [`docs/integrations.md`](docs/integrations.md) を参照してください。
 
 ## インストール
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,159 @@
+# LiteLLM 統合ガイド
+
+本ライブラリは [LiteLLM](https://github.com/BerriAI/litellm) を使用して WebAPI モデルを自動的に検出・管理します。
+
+## 概要
+
+LiteLLM は OpenAI / Anthropic / Google など 100 以上のプロバイダーの 2600 以上のモデルを pip パッケージに同梱しています。`litellm.supports_vision(model_id)` を呼ぶだけでローカル DB を参照して Vision 対応を即時判定できるため、起動時のネットワーク I/O が不要です。
+
+## インストール
+
+`litellm` は本ライブラリの依存関係として自動的にインストールされます。
+
+```bash
+uv sync
+```
+
+## 公開 API
+
+### `discover_available_vision_models(force_refresh: bool = False) -> dict[str, Any]`
+
+利用可能な Vision 対応 WebAPI モデルの一覧を返します。
+
+```python
+from image_annotator_lib import discover_available_vision_models
+
+# キャッシュから読み込み（available_api_models.toml が存在すれば再取得しない）
+result = discover_available_vision_models()
+
+if "models" in result:
+    print(f"{len(result['models'])} 件のモデルが利用可能")
+    for model_id in result["models"][:5]:
+        print(f"  {model_id}")
+elif "error" in result:
+    print(f"取得失敗: {result['error']}")
+
+# 強制再取得（LiteLLM DB を再スキャン）
+result = discover_available_vision_models(force_refresh=True)
+```
+
+**戻り値:**
+
+| キー | 型 | 説明 |
+|---|---|---|
+| `models` | `list[str]` | 全モデル ID（廃止モデルを含む） |
+| `toml_data` | `dict[str, Any]` | 全モデルのメタデータ辞書 |
+| `error` | `str` | エラー時のみ存在。`models` / `toml_data` は存在しない |
+
+---
+
+### `should_refresh(ttl_days: int | None = None) -> bool`
+
+`config/available_api_models.toml` の `[meta] last_refresh` を確認して TTL 超過を判定します。
+
+```python
+from image_annotator_lib.core.api_model_discovery import should_refresh
+
+if should_refresh():
+    print("モデルリストの更新が必要です")
+
+# TTL を明示的に指定（日数）
+if should_refresh(ttl_days=1):
+    print("1日以上経過しています")
+```
+
+`last_refresh` が記録されていない場合は常に `True` を返します。
+
+---
+
+### `trigger_background_refresh() -> threading.Thread`
+
+バックグラウンドスレッドで `available_api_models.toml` を非同期更新します。呼び出し元をブロックしません。
+
+```python
+from image_annotator_lib.core.api_model_discovery import (
+    should_refresh,
+    trigger_background_refresh,
+)
+
+if should_refresh():
+    thread = trigger_background_refresh()
+    # thread は daemon スレッド。プロセス終了時に自動的に停止します。
+    # 完了を待つ場合: thread.join(timeout=30)
+```
+
+同時に複数回呼ばれても 1 回だけ実行されます（内部でロックを使用）。
+
+---
+
+## `available_api_models.toml` のスキーマ
+
+```toml
+# === メタデータセクション ===
+[meta]
+last_refresh = "2026-04-28T09:30:00+00:00"  # ISO 8601 with UTC offset
+schema_version = 1
+
+# === モデルエントリ ===
+[available_vision_models."google/gemini-2.5-pro"]
+provider = "Google"
+model_name_short = "Gemini 2.5 Pro"
+display_name = "Google: Gemini 2.5 Pro"
+created = "2025-01-01T00:00:00Z"
+modality = "text+image->text"
+input_modalities = ["text", "image"]
+last_seen = "2026-04-28T09:30:00+00:00Z"
+deprecated_on = None  # 廃止された場合は ISO 8601 タイムスタンプ
+```
+
+### フィールド説明
+
+| フィールド | 説明 |
+|---|---|
+| `provider` | プロバイダー名（OpenAI / Anthropic / Google など） |
+| `display_name` | UI 表示用の名前 |
+| `last_seen` | 最後に API レスポンスに現れた時刻 |
+| `deprecated_on` | 廃止が確認された時刻（`None` = アクティブ） |
+
+---
+
+## 環境変数
+
+| 変数名 | 既定値 | 説明 |
+|---|---|---|
+| `IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS` | `7` | モデルリストの有効期間（日数）。この期間を超えると起動時にバックグラウンド refresh が実行される |
+| `IMAGE_ANNOTATOR_SKIP_API_DISCOVERY` | `false` | `true` に設定すると起動時の API discovery を完全スキップ。CI / オフライン環境で有用 |
+
+```bash
+# TTL を 14 日に変更
+IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS=14 uv run lorairo
+
+# Discovery を無効化してオフラインで起動
+IMAGE_ANNOTATOR_SKIP_API_DISCOVERY=true uv run lorairo
+```
+
+---
+
+## CI 週次更新
+
+`.github/workflows/refresh-models.yml` が毎週月曜 09:00 UTC に以下を実行します:
+
+1. LiteLLM を最新版にアップデート（`uv lock --upgrade-package litellm`）
+2. `tools/check_api_model_discovery.py` を実行して `config/available_api_models.toml` を再生成
+3. 変更がある場合は `chore/refresh-model-registry` ブランチに PR を自動作成
+
+手動実行:
+
+```bash
+# GitHub Actions 手動トリガー
+gh workflow run refresh-models.yml --repo NEXTAltair/image-annotator-lib
+
+# ローカルで実行（プロジェクトルートから）
+uv run python tools/check_api_model_discovery.py
+```
+
+---
+
+## OpenRouter フォールバック
+
+LiteLLM のローカル DB に未収録のモデル（OpenRouter 限定の free tier モデルなど）は、OpenRouter API から補完取得します。OpenRouter API が利用できない場合でも、LiteLLM のみでモデルリストが生成されます（degraded mode）。

--- a/docs/migration/0021-litellm-migration.md
+++ b/docs/migration/0021-litellm-migration.md
@@ -1,0 +1,124 @@
+# 移行ガイド: ADR 0021 LiteLLM-Driven WebAPI Model Registry
+
+## 概要
+
+ADR 0021 により、WebAPI モデル（OpenAI / Anthropic / Google など）の管理方法が変更されました。
+`annotator_config.toml` に手動定義していた WebAPI モデルエントリは不要になり、LiteLLM が自動的に検出・管理します。
+
+## 影響を受けるユーザー
+
+以下のような設定を `config/annotator_config.toml` に記述していた場合に影響があります:
+
+```toml
+# 旧設定（削除対象）
+["GPT-4o"]
+class = "OpenAIApiAnnotator"
+api_model_id = "gpt-4o"
+
+["Claude 3.5 Sonnet"]
+class = "AnthropicApiAnnotator"
+api_model_id = "claude-3-5-sonnet-20241022"
+
+["Gemini 2.0 Flash"]
+class = "GoogleApiAnnotator"
+api_model_id = "gemini-2.0-flash-exp"
+```
+
+## 移行手順
+
+### 1. `annotator_config.toml` から WebAPI エントリを削除
+
+WebAPI モデル（`class` が `*ApiAnnotator` 系のエントリ）を削除してください。ローカル ML モデル（ONNX / Transformers / CLIP など）のエントリは**そのまま維持**します。
+
+**削除するエントリの判断基準:**
+
+- `class = "OpenAIApiAnnotator"` / `"AnthropicApiAnnotator"` / `"GoogleApiAnnotator"` / `"OpenRouterAnnotator"` → **削除**
+- `class = "ONNXBaseAnnotator"` / `"TransformersBaseAnnotator"` / `"TensorflowBaseAnnotator"` / `"ClipBaseAnnotator"` → **維持**
+
+### 2. 自動検出の動作確認
+
+ライブラリ（またはそれを組み込んだアプリケーション）を起動すると、初回起動時に LiteLLM DB から Vision 対応モデルが自動的に検出され、`config/available_api_models.toml` に保存されます。
+
+```bash
+# 手動で動作確認（プロジェクトルートから）
+uv run python tools/check_api_model_discovery.py
+```
+
+### 3. モデルリストの確認
+
+```python
+from image_annotator_lib.core.simplified_agent_factory import (
+    get_available_models,
+    list_all_models,
+)
+
+# アクティブなモデルのみ（廃止モデルを除く）
+active_models = get_available_models()
+print("利用可能なモデル:", active_models)
+
+# 全モデル（廃止モデルを含む）
+all_models = list_all_models()
+print("全モデル:", all_models)
+```
+
+## 変更点の詳細
+
+### `annotator_config.toml`
+
+| 変更前 | 変更後 |
+|---|---|
+| WebAPI モデルを手動定義 | WebAPI モデルは LiteLLM が自動管理 |
+| OpenAI / Anthropic / Google のモデルを個別に列挙 | 不要（`config/available_api_models.toml` に自動生成） |
+| 廃止モデルは手動削除が必要 | `deprecated_on` フィールドで自動的にフィルタ |
+
+### `available_api_models.toml`
+
+LiteLLM が自動生成・更新するキャッシュファイルです。手動編集は原則不要です。
+
+```toml
+# 自動生成される [meta] セクション
+[meta]
+last_refresh = "2026-04-28T09:30:00+00:00"
+schema_version = 1
+
+# モデルエントリも自動生成
+[available_vision_models."openai/gpt-4o"]
+provider = "OpenAI"
+display_name = "OpenAI: gpt-4o"
+...
+```
+
+## オフライン環境での動作
+
+ネットワーク接続なしで起動する場合は、環境変数で discovery をスキップできます:
+
+```bash
+IMAGE_ANNOTATOR_SKIP_API_DISCOVERY=true uv run lorairo
+```
+
+この場合、既存の `config/available_api_models.toml` がそのまま使用されます。ファイルが存在しない場合は WebAPI モデルなしで起動します。
+
+## TTL の調整
+
+デフォルトでは 7 日間隔でバックグラウンド refresh が実行されます。間隔を変更するには:
+
+```bash
+# TTL を 14 日に変更
+IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS=14 uv run lorairo
+
+# CI / 自動化環境で即時 refresh したい場合（TTL を 0 に近い値に設定）
+IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS=0 uv run python tools/check_api_model_discovery.py
+```
+
+## トラブルシューティング
+
+### モデルが検出されない
+
+1. LiteLLM のインストールを確認: `uv run python -c "import litellm; print(litellm.__version__)"`
+2. キャッシュをリセット: `available_api_models.toml` を削除して再起動
+3. 強制再取得: `uv run python tools/check_api_model_discovery.py`
+
+### 廃止モデルが表示される
+
+`get_available_models()` ではなく `list_all_models()` を使用している可能性があります。
+`get_available_models()` は `deprecated_on` が設定されたモデルを自動的に除外します。

--- a/tools/check_api_model_discovery.py
+++ b/tools/check_api_model_discovery.py
@@ -62,4 +62,8 @@ if __name__ == "__main__":
     elapsed = time.monotonic() - start
     print_result(f"キャッシュ利用 ({elapsed:.2f}秒)", result2)
 
+    if "error" in result2:
+        print(f"\nキャッシュ読み込みエラーが発生しました: {result2['error']}", file=sys.stderr)
+        sys.exit(1)
+
     print(f"\n完了。結果は {AVAILABLE_API_MODELS_CONFIG_PATH} に保存されています。")

--- a/tools/check_api_model_discovery.py
+++ b/tools/check_api_model_discovery.py
@@ -5,6 +5,7 @@ available_api_models.toml を更新して結果を検証する。
 """
 
 import pprint
+import sys
 import time
 
 import litellm
@@ -50,6 +51,10 @@ if __name__ == "__main__":
     result1 = discover_available_vision_models(force_refresh=True)
     elapsed = time.monotonic() - start
     print_result(f"強制リフレッシュ ({elapsed:.2f}秒)", result1)
+
+    if "error" in result1:
+        print(f"\nエラーが発生したため終了します: {result1['error']}", file=sys.stderr)
+        sys.exit(1)
 
     print("\n=== 2回目実行 (キャッシュ利用) ===")
     start = time.monotonic()


### PR DESCRIPTION
## Summary

ADR 0021「LiteLLM-Driven WebAPI Model Registry」の第三トリガー（CI 週次更新）を実装します。

- **週次 CI ワークフロー** (`.github/workflows/refresh-models.yml`): 毎週月曜 09:00 UTC に LiteLLM を最新版に更新し `config/available_api_models.toml` を再生成、差分がある場合は PR を自動作成
- **ドキュメント整備**: README / CHANGELOG / integrations.md / 移行ガイドを追加

## 変更ファイル

| ファイル | 種別 | 概要 |
|---|---|---|
| `.github/workflows/refresh-models.yml` | 新規 | 週次 + 手動トリガーの refresh ワークフロー |
| `.github/PULL_REQUEST_TEMPLATE/model_refresh.md` | 新規 | モデル更新 PR 用テンプレート |
| `tools/check_api_model_discovery.py` | 修正 | エラー時の `sys.exit(1)` 追加（CI 互換） |
| `README.md` | 修正 | WebAPI モデル自動検出セクション追加 |
| `CHANGELOG.md` | 新規 | ADR 0021 (ISSUE B-G) 変更集約 |
| `docs/integrations.md` | 新規 | LiteLLM 統合 API リファレンス |
| `docs/migration/0021-litellm-migration.md` | 新規 | 既存ユーザー向け移行ガイド |

## Closes

Closes #8

## Test plan

- [ ] `refresh-models.yml` の YAML 構文確認（`python -c "import yaml; yaml.safe_load(...)"` 済み）
- [ ] 手動トリガー: `gh workflow run refresh-models.yml --repo NEXTAltair/image-annotator-lib` で PR 生成を確認
- [ ] `tools/check_api_model_discovery.py` でエラー時に exit code 1 が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)