### PR TITLE
fix: 同一クラスの二重登録 WARNING をDEBUGに格下げ

### DIFF
--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -210,6 +210,9 @@ def _try_register_model(
         return False
 
     if model_name in registry:
+        if registry[model_name] is model_cls:
+            logger.debug(f"モデル名 '{model_name}' は既に登録されています（同一クラス）。スキップします。")
+            return True
         logger.warning(f"モデル名 '{model_name}' は既に登録されています。クラス '{model_cls.__name__}' で上書きします。")
     registry[model_name] = model_cls
     logger.debug(f"モデル '{model_name}' をクラス '{model_cls.__name__}' でレジストリに登録しました。")


### PR DESCRIPTION
## 問題

`initialize_registry()` 実行時に 95 件の WARNING が出力されていた。

```
WARNING: モデル名 'Claude Sonnet 4' は既に登録されています。クラス 'PydanticAIWebAPIAnnotator' で上書きします。
```

## 原因

1. `_register_webapi_models_from_discovery()` が `_MODEL_CLASS_OBJ_REGISTRY` に WebAPI モデルを登録
2. 同関数が `config_registry.set_system_value()` でモデル情報を merged config にも書き込む
3. その後 `register_annotators()` が `config_registry.get_all_config()` を読み込むと同じ 95 件が見える
4. 再登録しようとして全件 WARNING

## 修正

`_try_register_model()` 内で、再登録時に既存クラスと新クラスが **同一** であれば WARNING ではなく DEBUG に格下げ。  
別クラスへの上書き（本来の警告対象）は引き続き WARNING を維持。

## テスト

- `tests/unit/standard/core/test_registry.py` 19 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)