### PR TITLE
feat(#2): UnifiedAnnotationResult 統一と後方互換パス撤去

### DIFF
--- a/config/annotator_config.toml
+++ b/config/annotator_config.toml
@@ -180,7 +180,7 @@ model_path = "Minthy/ToriiGate-v0.3"
 class = "ToriiGateTagger"
 device = "cpu"
 estimated_size_gb = 37.828
-type = "tagger"
+type = "captioner"
 
 [deepdanbooru-v3-20211112-sgd-e28]
 model_path = "https://github.com/KichangKim/DeepDanbooru/releases/download/v3-20211112-sgd-e28/deepdanbooru-v3-20211112-sgd-e28.zip"

--- a/src/image_annotator_lib/core/base/annotator.py
+++ b/src/image_annotator_lib/core/base/annotator.py
@@ -11,7 +11,7 @@ from PIL import Image
 from ...exceptions.errors import OutOfMemoryError
 from ..config import config_registry
 from ..model_config import BaseModelConfig, ModelConfigFactory
-from ..types import AnnotationResult, LoaderComponents, UnifiedAnnotationResult
+from ..types import LoaderComponents, UnifiedAnnotationResult
 from ..utils import logger
 
 
@@ -112,18 +112,6 @@ class BaseAnnotator(ABC):
         """
         raise NotImplementedError("サブクラスは _format_predictions を実装する必要があります。")
 
-    @abstractmethod
-    def _generate_tags(self, formatted_output: Any) -> list[str]:
-        """整形済み出力からタグリストを生成します。
-
-        Args:
-            formatted_output: _format_predictions の出力。
-
-        Returns:
-            タグの文字列リスト。
-        """
-        raise NotImplementedError("サブクラスは _generate_tags を実装する必要があります。")
-
     def predict(
         self, images: list[Image.Image], phash_list: list[str] | None = None
     ) -> list[UnifiedAnnotationResult]:
@@ -182,8 +170,8 @@ class BaseAnnotator(ABC):
     ) -> list[UnifiedAnnotationResult]:
         """各画像の推論出力からアノテーション結果を構築する。
 
-        _format_predictionsがUnifiedAnnotationResultを返す場合はそのまま使用。
-        それ以外の場合はget_model_capabilitiesを使って変換する（後方互換）。
+        全アノテーターは `_format_predictions` で `UnifiedAnnotationResult` を返すことが必須。
+        旧形式 (dict / list[str] 等) を返した場合は TypeError を送出する。
 
         Args:
             images: 元画像リスト。
@@ -191,31 +179,18 @@ class BaseAnnotator(ABC):
 
         Returns:
             UnifiedAnnotationResult結果のリスト。
-        """
-        from ..utils import get_model_capabilities
 
+        Raises:
+            TypeError: `formatted_output` が UnifiedAnnotationResult でない場合。
+        """
         results: list[UnifiedAnnotationResult] = []
-        for i, (image, formatted_output) in enumerate(zip(images, formatted_outputs, strict=True)):
-            try:
-                if isinstance(formatted_output, UnifiedAnnotationResult):
-                    # _format_predictionsが既にUnifiedAnnotationResultを返す場合
-                    results.append(formatted_output)
-                else:
-                    # 後方互換: 旧形式の出力をUnifiedAnnotationResultに変換
-                    capabilities = get_model_capabilities(self.model_name)
-                    tags = self._generate_tags(formatted_output)
-                    result = UnifiedAnnotationResult(
-                        model_name=self.model_name,
-                        capabilities=capabilities,
-                        tags=tags or None,
-                        raw_output={"formatted_output": formatted_output}
-                        if formatted_output is not None
-                        else None,
-                    )
-                    results.append(result)
-            except Exception as e:
-                logger.exception(f"画像 {i} の処理中にエラー: {e}")
-                results.append(self._create_error_result(f"タグ生成エラー: {e}"))
+        for i, (_image, formatted_output) in enumerate(zip(images, formatted_outputs, strict=True)):
+            if not isinstance(formatted_output, UnifiedAnnotationResult):
+                raise TypeError(
+                    f"画像 {i}: _format_predictions は UnifiedAnnotationResult を返す必要があります "
+                    f"(モデル: {self.model_name}, 取得型: {type(formatted_output).__name__})"
+                )
+            results.append(formatted_output)
         return results
 
     def _create_error_result(self, error_message: str) -> UnifiedAnnotationResult:

--- a/src/image_annotator_lib/core/base/transformers.py
+++ b/src/image_annotator_lib/core/base/transformers.py
@@ -156,9 +156,10 @@ class TransformersBaseAnnotator(BaseAnnotator):
     def _format_predictions(self, token_ids_list: list[torch.Tensor]) -> list[UnifiedAnnotationResult]:
         """生出力バッチをフォーマットします (Transformers用、テキストデコード)。
 
-        capabilities に応じて captions / tags のどちらか一方にデコード文字列を格納する。
-        両方を設定すると capability バリデーションで弾かれるため、CAPTIONS が含まれれば
-        captions を優先し、そうでなければ tags にフォールバックする。
+        capabilities に応じて captions / tags の両方または片方にデコード文字列を格納する。
+        TAGS と CAPTIONS の両方が capabilities に含まれるマルチタスクモデルでは
+        両フィールドに同じ payload を入れて情報損失を防ぐ
+        (UnifiedAnnotationResult は両フィールド同時設定を許可している)。
 
         Returns:
             list[UnifiedAnnotationResult]: 統一フォーマットのアノテーション結果リスト
@@ -184,8 +185,6 @@ class TransformersBaseAnnotator(BaseAnnotator):
             logger.error(f"モデル '{self.model_name}' のcapabilities取得に失敗: {e}")
             capabilities = set()
 
-        use_captions = TaskCapability.CAPTIONS in capabilities
-
         try:
             for token_ids in token_ids_list:
                 # batch_decode属性の有無を安全に判定
@@ -207,11 +206,15 @@ class TransformersBaseAnnotator(BaseAnnotator):
                     raise TypeError(f"Unsupported processor type: {type(processor_obj)}")
 
                 payload = [decoded_text] if decoded_text else None
+                captions_value = (
+                    payload if (TaskCapability.CAPTIONS in capabilities and payload) else None
+                )
+                tags_value = payload if (TaskCapability.TAGS in capabilities and payload) else None
                 result = UnifiedAnnotationResult(
                     model_name=self.model_name,
                     capabilities=capabilities,
-                    captions=payload if use_captions else None,
-                    tags=payload if not use_captions else None,
+                    captions=captions_value,
+                    tags=tags_value,
                     framework="transformers",
                 )
                 all_formatted.append(result)

--- a/src/image_annotator_lib/core/base/transformers.py
+++ b/src/image_annotator_lib/core/base/transformers.py
@@ -10,7 +10,7 @@ from transformers.models.clip import CLIPProcessor
 from ...exceptions.errors import ConfigurationError, ModelLoadError, OutOfMemoryError
 from ..config import config_registry
 from ..model_factory import ModelLoad
-from ..types import TransformersComponents
+from ..types import TransformersComponents, UnifiedAnnotationResult
 from ..utils import logger
 from .annotator import BaseAnnotator
 
@@ -153,14 +153,18 @@ class TransformersBaseAnnotator(BaseAnnotator):
                 outputs.append(model_out)
         return outputs
 
-    def _format_predictions(self, token_ids_list: list[torch.Tensor]) -> list[Any]:
+    def _format_predictions(self, token_ids_list: list[torch.Tensor]) -> list[UnifiedAnnotationResult]:
         """生出力バッチをフォーマットします (Transformers用、テキストデコード)。
+
+        capabilities に応じて captions / tags のどちらか一方にデコード文字列を格納する。
+        両方を設定すると capability バリデーションで弾かれるため、CAPTIONS が含まれれば
+        captions を優先し、そうでなければ tags にフォールバックする。
 
         Returns:
             list[UnifiedAnnotationResult]: 統一フォーマットのアノテーション結果リスト
         """
         # 関数レベルでインポート（循環インポート回避）
-        from ..types import UnifiedAnnotationResult
+        from ..types import TaskCapability, UnifiedAnnotationResult
         from ..utils import get_model_capabilities
 
         if (
@@ -171,7 +175,7 @@ class TransformersBaseAnnotator(BaseAnnotator):
             raise RuntimeError("Transformer プロセッサがロードされていません。")
 
         processor_obj = self.components["processor"]
-        all_formatted: list[Any] = []
+        all_formatted: list[UnifiedAnnotationResult] = []
 
         # get_model_capabilities を一度だけ呼び出す
         try:
@@ -179,6 +183,8 @@ class TransformersBaseAnnotator(BaseAnnotator):
         except Exception as e:
             logger.error(f"モデル '{self.model_name}' のcapabilities取得に失敗: {e}")
             capabilities = set()
+
+        use_captions = TaskCapability.CAPTIONS in capabilities
 
         try:
             for token_ids in token_ids_list:
@@ -200,12 +206,12 @@ class TransformersBaseAnnotator(BaseAnnotator):
                 else:
                     raise TypeError(f"Unsupported processor type: {type(processor_obj)}")
 
-                # UnifiedAnnotationResult に変換
+                payload = [decoded_text] if decoded_text else None
                 result = UnifiedAnnotationResult(
                     model_name=self.model_name,
                     capabilities=capabilities,
-                    captions=[decoded_text] if decoded_text else None,
-                    tags=[decoded_text] if decoded_text else None,
+                    captions=payload if use_captions else None,
+                    tags=payload if not use_captions else None,
                     framework="transformers",
                 )
                 all_formatted.append(result)
@@ -221,22 +227,3 @@ class TransformersBaseAnnotator(BaseAnnotator):
                 framework="transformers",
             )
             return [error_result]
-
-    def _generate_tags(self, formatted_output: str | list[str]) -> list[str]:
-        """キャプション文字列を単一要素のリストに変換します。
-
-        formatted_outputは文字列型であるため、単純にそれを含む
-        リストを返します。文字列以外の型の場合は、エラーログを出力して
-        空のリストを返します。
-        """
-        try:
-            if isinstance(formatted_output, str):
-                return [formatted_output]
-            else:
-                logger.warning(
-                    f"_generate_tags: 期待される文字列型ではありません: {type(formatted_output)}"
-                )
-                return []
-        except Exception as e:
-            logger.exception(f"タグ生成中にエラー発生: {e}")
-            return []

--- a/src/image_annotator_lib/core/simplified_agent_wrapper.py
+++ b/src/image_annotator_lib/core/simplified_agent_wrapper.py
@@ -10,8 +10,8 @@ from pydantic_ai.messages import BinaryContent
 
 from .base.annotator import BaseAnnotator
 from .simplified_agent_factory import get_agent_factory
-from .types import AnnotationResult
-from .utils import logger
+from .types import TaskCapability, UnifiedAnnotationResult
+from .utils import get_model_capabilities, logger
 
 
 class SimplifiedAgentWrapper(BaseAnnotator):
@@ -82,48 +82,35 @@ class SimplifiedAgentWrapper(BaseAnnotator):
             results.append(result)
         return results
 
-    def _format_predictions(self, raw_outputs: list[Any]) -> list[dict[str, Any]]:
+    def _format_predictions(self, raw_outputs: list[Any]) -> list[UnifiedAnnotationResult]:
         """
-        Format raw inference results.
+        Format raw inference results into UnifiedAnnotationResult.
 
         Args:
             raw_outputs: List of raw results from _run_inference
 
         Returns:
-            List of formatted prediction dictionaries
+            List of UnifiedAnnotationResult instances
         """
-        formatted = []
+        capabilities = get_model_capabilities(self.model_name)
+        if not capabilities:
+            # PydanticAI Agents は config に type が無いことがあるため TAGS をデフォルトとする
+            capabilities = {TaskCapability.TAGS}
+
+        formatted: list[UnifiedAnnotationResult] = []
         for output in raw_outputs:
-            # Extract tags from AnnotationSchema result
-            if hasattr(output, "tags") and output.tags:
-                tags = output.tags
-            else:
-                tags = []
+            tags = list(output.tags) if hasattr(output, "tags") and output.tags else []
 
             formatted.append(
-                {
-                    "model_id": self.model_id,
-                    "tags": tags,
-                    "tag_count": len(tags),
-                    "method": "simplified_pydantic_ai",
-                }
+                UnifiedAnnotationResult(
+                    model_name=self.model_id,
+                    capabilities=capabilities,
+                    tags=tags if (TaskCapability.TAGS in capabilities and tags) else None,
+                    framework="pydantic_ai",
+                    raw_output={"method": "simplified_pydantic_ai", "tag_count": len(tags)},
+                )
             )
         return formatted
-
-    def _generate_tags(self, formatted_output: Any) -> list[str]:
-        """
-        Extract tags from formatted output.
-
-        Args:
-            formatted_output: Formatted prediction dictionary from _format_predictions
-
-        Returns:
-            List of extracted tags
-        """
-        if isinstance(formatted_output, dict) and "tags" in formatted_output:
-            tags = formatted_output["tags"]
-            return tags if isinstance(tags, list) else []
-        return []
 
     def _pil_to_binary_content(self, image: Image.Image) -> BinaryContent:
         """Convert PIL Image to PydanticAI BinaryContent."""
@@ -174,57 +161,3 @@ class SimplifiedAgentWrapper(BaseAnnotator):
             future = executor.submit(run_with_new_loop)
             return future.result()
 
-    def _format_output(self, image: Image.Image, tags: list[str]) -> dict[str, Any]:
-        """
-        Format output for compatibility with existing API.
-
-        Args:
-            image: Original PIL Image
-            tags: Generated tags
-
-        Returns:
-            Formatted output dictionary
-        """
-        return {
-            "model_id": self.model_id,
-            "tags": tags,
-            "tag_count": len(tags),
-            "method": "simplified_pydantic_ai",
-        }
-
-    def run_inference(self, image: Image.Image) -> AnnotationResult:
-        """
-        Run inference on an image following the complete BaseAnnotator pipeline.
-
-        Args:
-            image: PIL Image to annotate
-
-        Returns:
-            AnnotationResult with tags and formatted output
-
-        Note:
-            Implements the full pipeline:
-            1. Preprocess: PIL Image → BinaryContent
-            2. Inference: BinaryContent → Agent result
-            3. Format: Agent result → structured dict
-            4. Extract: dict → tags list
-        """
-        try:
-            # Step 1: Preprocess image to BinaryContent
-            processed = self._preprocess_images([image])
-
-            # Step 2: Run inference with agent
-            raw_outputs = self._run_inference(processed)
-
-            # Step 3: Format agent results
-            formatted_outputs = self._format_predictions(raw_outputs)
-
-            # Step 4: Extract tags from formatted output
-            formatted_output = formatted_outputs[0] if formatted_outputs else {}
-            tags = self._generate_tags(formatted_output)
-
-            return AnnotationResult(tags=tags, formatted_output=formatted_output, error=None)
-        except Exception as e:
-            error_msg = f"Inference failed for {self.model_id}: {e}"
-            logger.error(error_msg)
-            return AnnotationResult(tags=[], formatted_output={"error": error_msg}, error=error_msg)

--- a/src/image_annotator_lib/model_class/tagger_transformers.py
+++ b/src/image_annotator_lib/model_class/tagger_transformers.py
@@ -4,7 +4,8 @@ import torch
 from PIL import Image
 
 from ..core.base import TransformersBaseAnnotator
-from ..core.utils import logger
+from ..core.types import UnifiedAnnotationResult
+from ..core.utils import get_model_capabilities, logger
 from ..exceptions.errors import OutOfMemoryError
 
 
@@ -83,26 +84,30 @@ class ToriiGateTagger(TransformersBaseAnnotator):
             logger.error(error_message)
             raise OutOfMemoryError(error_message) from e
 
-    def _format_predictions(self, token_ids_list: list[torch.Tensor]) -> list[str]:
-        """モデルの出力をデコードしてテキストにします。Assistant部分のみを抽出します。"""
-        all_results = []
+    def _format_predictions(self, token_ids_list: list[torch.Tensor]) -> list[UnifiedAnnotationResult]:
+        """モデルの出力をデコードして UnifiedAnnotationResult に詰める。
+
+        ToriiGate はキャプション生成モデルなので captions に格納する。
+        Assistant: 以降を抽出する後処理は基底クラスの汎用デコードでは行えないため、
+        本クラスでオーバーライドしている。
+        """
+        capabilities = get_model_capabilities(self.model_name)
+        results: list[UnifiedAnnotationResult] = []
         for token_ids in token_ids_list:
-            # デコード
-            generated_text = self.components["processor"].batch_decode(token_ids, skip_special_tokens=True)[
-                0
-            ]
-            # 'Assistant: ' 以降の部分を取得
+            generated_text = self.components["processor"].batch_decode(
+                token_ids, skip_special_tokens=True
+            )[0]
             if "Assistant: " in generated_text:
                 caption = generated_text.split("Assistant: ")[1]
             else:
                 caption = generated_text
-            all_results.append(caption)
-        return all_results
 
-    def _generate_tags(self, formatted_output: str) -> list[str]:
-        """単一のキャプション文字列を単一要素のリストに変換します。
-        各キャプションを単一要素のリストとして返します。
-        ToriiGateの場合、キャプション全体を1つのタグとして扱います。
-        """
-        # formatted_output は単一の文字列と想定
-        return [formatted_output]
+            results.append(
+                UnifiedAnnotationResult(
+                    model_name=self.model_name,
+                    capabilities=capabilities,
+                    captions=[caption] if caption else None,
+                    framework="transformers",
+                )
+            )
+        return results

--- a/src/image_annotator_lib/resources/system/annotator_config.toml
+++ b/src/image_annotator_lib/resources/system/annotator_config.toml
@@ -180,7 +180,7 @@ model_path = "Minthy/ToriiGate-v0.3"
 class = "ToriiGateTagger"
 device = "cpu"
 estimated_size_gb = 37.828
-type = "tagger"
+type = "captioner"
 
 [deepdanbooru-v3-20211112-sgd-e28]
 model_path = "https://github.com/KichangKim/DeepDanbooru/releases/download/v3-20211112-sgd-e28/deepdanbooru-v3-20211112-sgd-e28.zip"

--- a/tests/features/step_definitions/simplified_agent_wrapper_steps.py
+++ b/tests/features/step_definitions/simplified_agent_wrapper_steps.py
@@ -199,29 +199,22 @@ def call_run_inference(wrapper: SimplifiedAgentWrapper, load_image_files):
 
 @when("run_inference メソッドを呼び出す", target_fixture="run_inference_result")
 def call_run_inference_method(wrapper_with_error: SimplifiedAgentWrapper, load_image_files):
-    """run_inferenceメソッドを呼び出す"""
+    """predict() を経由して BaseAnnotator のパイプラインを呼び出す。
+
+    旧 run_inference (テスト専用 API) は撤去済みのため predict() 経由でテストする。
+    """
     pil_image = load_image_files(1)[0]
-    result = wrapper_with_error.run_inference([pil_image])
-    return result
+    return wrapper_with_error.predict([pil_image])
 
 
 @when("run_syncがRuntimeError (Event loop関連) を発生させる", target_fixture="async_fallback_result")
 def trigger_event_loop_error(wrapper: SimplifiedAgentWrapper, load_image_files):
-    """Event loop エラーを発生させてasync fallback をトリガー"""
+    """Event loop エラーを発生させて async fallback をトリガー (predict 経由)."""
     images = load_image_files(1)
-    # This should trigger the async fallback path
     with patch.object(
         wrapper._agent, "run_sync", side_effect=RuntimeError("Event loop is already running")
     ):
-        result = wrapper.run_inference(images)
-    return result
-
-
-@when("_generate_tags メソッドを呼び出す", target_fixture="tags_result")
-def call_generate_tags(wrapper: SimplifiedAgentWrapper, formatted_output_without_tags: dict):
-    """_generate_tagsメソッドを呼び出す"""
-    result = wrapper._generate_tags(formatted_output_without_tags)
-    return result
+        return wrapper.predict(images)
 
 
 # ============================================================================
@@ -351,19 +344,20 @@ def error_logged(log_message: str, caplog):
 
 @then("tagsは空リストである")
 def tags_are_empty(run_inference_result):
-    """tagsが空リストである"""
-    # run_inference returns a list of results
+    """tagsが空(None または []) である。
+
+    UnifiedAnnotationResult はエラー時に tags=None を取る (capability validation の都合)。
+    """
     if isinstance(run_inference_result, list):
         result = run_inference_result[0]
         if isinstance(result, dict):
-            assert result.get("tags", []) == [], f"Expected empty tags: {result}"
+            assert result.get("tags", []) in ([], None), f"Expected empty tags: {result}"
         else:
-            assert result.tags == [], f"Expected empty tags: {result}"
+            assert result.tags in ([], None), f"Expected empty tags: {result}"
+    elif isinstance(run_inference_result, dict):
+        assert run_inference_result.get("tags", []) in ([], None)
     else:
-        if isinstance(run_inference_result, dict):
-            assert run_inference_result.get("tags", []) == []
-        else:
-            assert run_inference_result.tags == []
+        assert run_inference_result.tags in ([], None)
 
 
 @then("空のtagsリストが返される")

--- a/tests/unit/core/test_base_annotator_di.py
+++ b/tests/unit/core/test_base_annotator_di.py
@@ -13,6 +13,7 @@ import pytest
 
 from image_annotator_lib.core.base.annotator import BaseAnnotator
 from image_annotator_lib.core.model_config import LocalMLModelConfig
+from image_annotator_lib.core.types import TaskCapability, UnifiedAnnotationResult
 from image_annotator_lib.exceptions.errors import ConfigurationError
 
 
@@ -37,12 +38,15 @@ class ConcreteTestAnnotator(BaseAnnotator):
         return processed
 
     def _format_predictions(self, raw_outputs):
-        """結果整形(テスト用スタブ)"""
-        return [{"score": 0.9}] * len(raw_outputs)
-
-    def _generate_tags(self, formatted_output):
-        """タグ生成(テスト用スタブ)"""
-        return ["test_tag"]
+        """結果整形(テスト用スタブ)。UnifiedAnnotationResult を返す。"""
+        return [
+            UnifiedAnnotationResult(
+                model_name=self.model_name,
+                capabilities={TaskCapability.TAGS},
+                tags=["test_tag"],
+            )
+            for _ in raw_outputs
+        ]
 
 
 @pytest.fixture

--- a/tests/unit/core/test_build_results_strict_typing.py
+++ b/tests/unit/core/test_build_results_strict_typing.py
@@ -1,0 +1,88 @@
+"""`_build_results` が UnifiedAnnotationResult 以外を受け取った場合に TypeError を出すことを検証する。
+
+Issue #2 で後方互換パス (raw_output={"formatted_output": ...} へのラップ) を削除したため、
+全アノテーターは `_format_predictions` で UnifiedAnnotationResult を返すことが必須となった。
+旧形式 (dict / list[str] 等) を返した場合は TypeError で早期失敗する。
+"""
+
+import pytest
+from PIL import Image
+
+from image_annotator_lib.core.base.annotator import BaseAnnotator
+from image_annotator_lib.core.model_config import LocalMLModelConfig
+from image_annotator_lib.core.types import TaskCapability, UnifiedAnnotationResult
+
+
+class _StubAnnotator(BaseAnnotator):
+    """テスト用スタブアノテーター。_format_predictions の戻り値を差し替えるため。"""
+
+    def __init__(self, model_name: str, formatted_output: object):
+        config = LocalMLModelConfig(
+            model_name=model_name,
+            model_path="dummy",
+            class_name="StubAnnotator",
+            device="cpu",
+            estimated_size_gb=0.01,
+        )
+        super().__init__(model_name, config=config)
+        self._formatted_output = formatted_output
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+    def _preprocess_images(self, images):
+        return images
+
+    def _run_inference(self, processed):
+        return processed
+
+    def _format_predictions(self, raw_outputs):
+        return [self._formatted_output for _ in raw_outputs]
+
+
+@pytest.fixture
+def dummy_image() -> Image.Image:
+    return Image.new("RGB", (32, 32), color="red")
+
+
+@pytest.mark.unit
+def test_build_results_accepts_unified_annotation_result(dummy_image: Image.Image) -> None:
+    """正常系: _format_predictions が UnifiedAnnotationResult を返せばそのまま返却される。"""
+    expected = UnifiedAnnotationResult(
+        model_name="stub",
+        capabilities={TaskCapability.TAGS},
+        tags=["dog"],
+    )
+    annotator = _StubAnnotator(model_name="stub", formatted_output=expected)
+
+    results = annotator.predict([dummy_image])
+
+    assert len(results) == 1
+    assert results[0] is expected
+
+
+@pytest.mark.unit
+def test_build_results_rejects_dict(dummy_image: Image.Image) -> None:
+    """旧形式 (dict) を返すと TypeError が発生する (predict は内部で例外をエラー結果に変換)。"""
+    annotator = _StubAnnotator(model_name="stub", formatted_output={"score": 0.9})
+
+    results = annotator.predict([dummy_image])
+
+    assert len(results) == 1
+    assert results[0].error is not None
+    assert "UnifiedAnnotationResult" in (results[0].error or "")
+
+
+@pytest.mark.unit
+def test_build_results_rejects_str(dummy_image: Image.Image) -> None:
+    """旧形式 (str) を返すと TypeError が発生する。"""
+    annotator = _StubAnnotator(model_name="stub", formatted_output="caption text")
+
+    results = annotator.predict([dummy_image])
+
+    assert len(results) == 1
+    assert results[0].error is not None
+    assert "UnifiedAnnotationResult" in (results[0].error or "")

--- a/tests/unit/core/test_simplified_agent_wrapper.py
+++ b/tests/unit/core/test_simplified_agent_wrapper.py
@@ -403,30 +403,7 @@ class TestSimplifiedWrapperFormatting:
     def test_simplified_wrapper_format_output_and_tags(
         self, mock_pydantic_ai_agent, mock_agent_result_with_tags, managed_config_registry
     ):
-        """Test tag extraction and output formatting.
-
-        Coverage: Lines 85-111, 113-126, 177-193 (_format_predictions, _generate_tags, _format_output)
-
-        REAL components:
-        - Real tag extraction logic
-        - Real dict formatting
-
-        MOCKED:
-        - Agent result with tags attribute
-
-        Scenario:
-        1. Initialize wrapper
-        2. Call _format_predictions with mock agent results
-        3. Verify tags extracted
-        4. Verify dict formatted correctly
-
-        Assertions:
-        - Tags list extracted from result.tags
-        - method field set to "simplified_pydantic_ai"
-        - tag_count matches tags length
-        - model_id included in output
-        """
-        # Setup: Register minimal config for test model
+        """Test tag extraction in _format_predictions returning UnifiedAnnotationResult."""
         managed_config_registry.set(
             "test/model-formatting",
             {
@@ -444,54 +421,23 @@ class TestSimplifiedWrapperFormatting:
 
             wrapper = SimplifiedAgentWrapper(model_id="test/model-formatting")
 
-            # Act: Format predictions
             formatted = wrapper._format_predictions([mock_agent_result_with_tags])
 
-            # Assert: Formatted output structure
             assert len(formatted) == 1, "1つのフォーマット済み結果"
-            output = formatted[0]
+            unified = formatted[0]
 
-            # Assert: Tags extracted
-            assert output["tags"] == ["mock_tag_1", "mock_tag_2", "mock_tag_3"], "タグ正しく抽出"
-            assert output["tag_count"] == 3, "tag_count正しい"
-
-            # Assert: Method field set
-            assert output["method"] == "simplified_pydantic_ai", "method: simplified_pydantic_ai"
-
-            # Assert: model_id included
-            assert output["model_id"] == "test/model-formatting", "model_id含まれる"
-
-            # Act: Generate tags from formatted output
-            tags = wrapper._generate_tags(output)
-
-            # Assert: Tags list returned
-            assert tags == ["mock_tag_1", "mock_tag_2", "mock_tag_3"], "_generate_tagsでタグ抽出"
+            assert unified.model_name == "test/model-formatting", "model_name 正しく設定"
+            assert unified.tags == ["mock_tag_1", "mock_tag_2", "mock_tag_3"], "タグ正しく抽出"
+            assert unified.framework == "pydantic_ai", "framework 識別子"
+            assert unified.raw_output is not None
+            assert unified.raw_output["tag_count"] == 3, "raw_output に tag_count"
+            assert unified.raw_output["method"] == "simplified_pydantic_ai"
 
     @pytest.mark.unit
     def test_simplified_wrapper_format_output_no_tags(
         self, mock_pydantic_ai_agent, managed_config_registry
     ):
-        """Test formatting when result has no tags.
-
-        Coverage: Lines 98-111 (_format_predictions edge case)
-
-        REAL components:
-        - Real empty tags handling
-
-        MOCKED:
-        - Agent result without tags attribute
-
-        Scenario:
-        1. Initialize wrapper
-        2. Pass result without tags attribute
-        3. Verify empty tags list used
-
-        Assertions:
-        - tags field is empty list
-        - tag_count is 0
-        - No exception raised
-        """
-        # Register config BEFORE wrapper initialization
+        """Test _format_predictions when result has no tags."""
         managed_config_registry.set(
             "test/model-no-tags",
             {
@@ -509,49 +455,24 @@ class TestSimplifiedWrapperFormatting:
 
             wrapper = SimplifiedAgentWrapper(model_id="test/model-no-tags")
 
-            # Mock result without tags
             mock_result_no_tags = MagicMock()
-            del mock_result_no_tags.tags  # Remove tags attribute
+            del mock_result_no_tags.tags
 
-            # Act: Format predictions
             formatted = wrapper._format_predictions([mock_result_no_tags])
 
-            # Assert: Empty tags list
-            assert formatted[0]["tags"] == [], "タグなし時は空リスト"
-            assert formatted[0]["tag_count"] == 0, "tag_count: 0"
+            assert formatted[0].tags is None, "タグなし時は None (capability validation 通過)"
+            assert formatted[0].raw_output is not None
+            assert formatted[0].raw_output["tag_count"] == 0, "raw_output の tag_count: 0"
 
 
-class TestSimplifiedWrapperRunInference:
-    """run_inference public method tests."""
+class TestSimplifiedWrapperPredict:
+    """predict() public pipeline tests for SimplifiedAgentWrapper."""
 
     @pytest.mark.unit
-    def test_simplified_wrapper_run_inference_success(
+    def test_simplified_wrapper_predict_success(
         self, mock_pydantic_ai_agent, mock_agent_result_with_tags, managed_config_registry
     ):
-        """Test run_inference public method with successful inference.
-
-        Coverage: Lines 195-238 (run_inference method - UPDATED for complete pipeline)
-
-        REAL components:
-        - Real AnnotationResult creation
-        - Real error handling
-        - Real complete 4-step pipeline (preprocess → inference → format → extract)
-
-        MOCKED:
-        - Agent operations
-
-        Scenario:
-        1. Initialize wrapper with config
-        2. Mock successful inference
-        3. Call run_inference (tests REAL pipeline)
-        4. Verify AnnotationResult returned
-
-        Assertions:
-        - AnnotationResult with tags from mock agent
-        - formatted_output contains expected fields
-        - error is None
-        """
-        # Register config BEFORE wrapper initialization
+        """Test predict() returns UnifiedAnnotationResult through complete pipeline."""
         managed_config_registry.set(
             "test/model-public",
             {
@@ -567,29 +488,17 @@ class TestSimplifiedWrapperRunInference:
             mock_factory_instance.get_cached_agent.return_value = mock_pydantic_ai_agent
             mock_factory.return_value = mock_factory_instance
 
-            # Mock successful run_sync
             mock_pydantic_ai_agent.run_sync.return_value = mock_agent_result_with_tags
 
             wrapper = SimplifiedAgentWrapper(model_id="test/model-public")
 
-            # Create test image
             test_image = Image.new("RGB", (64, 64), "blue")
 
-            # Act: Run inference (tests REAL complete pipeline)
-            result = wrapper.run_inference(test_image)
+            results = wrapper.predict([test_image])
 
-            # Assert: AnnotationResult structure (TypedDict doesn't support isinstance)
-            assert isinstance(result, dict), "AnnotationResult型はdict"
-            assert "tags" in result, "tagsキー存在"
-            assert "formatted_output" in result, "formatted_outputキー存在"
-            assert "error" in result, "errorキー存在"
-            assert result["error"] is None, "エラーなし"
-
-            # Assert: Real tags from mock_agent_result_with_tags
-            assert result["tags"] == ["mock_tag_1", "mock_tag_2", "mock_tag_3"], "タグ正しく抽出"
-
-            # Assert: formatted_output structure
-            assert "tags" in result["formatted_output"], "formatted_outputにtags存在"
-            assert "model_id" in result["formatted_output"], "formatted_outputにmodel_id存在"
-            assert "method" in result["formatted_output"], "formatted_outputにmethod存在"
-            assert result["formatted_output"]["method"] == "simplified_pydantic_ai"
+            assert len(results) == 1, "predict は画像数と同じ結果数を返す"
+            unified = results[0]
+            assert unified.model_name == "test/model-public", "model_name 設定"
+            assert unified.tags == ["mock_tag_1", "mock_tag_2", "mock_tag_3"], "タグ正しく抽出"
+            assert unified.error is None, "エラーなし"
+            assert unified.framework == "pydantic_ai", "framework 識別子"

--- a/uv.lock
+++ b/uv.lock
@@ -57,7 +57,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.1"
+version = "3.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -68,25 +68,25 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/fa/3ae643cd525cf6844d3dc810481e5748107368eb49563c15a5fb9f680750/aiohttp-3.13.1.tar.gz", hash = "sha256:4b7ee9c355015813a6aa085170b96ec22315dabc3d866fd77d147927000e9464", size = 7835344, upload-time = "2025-10-17T14:03:29.337Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/4a/064321452809dae953c1ed6e017504e72551a26b6f5708a5a80e4bf556ff/aiohttp-3.13.4.tar.gz", hash = "sha256:d97a6d09c66087890c2ab5d49069e1e570583f7ac0314ecf98294c1b6aaebd38", size = 7859748, upload-time = "2026-03-28T17:19:40.6Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/72/d463a10bf29871f6e3f63bcf3c91362dc4d72ed5917a8271f96672c415ad/aiohttp-3.13.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0760bd9a28efe188d77b7c3fe666e6ef74320d0f5b105f2e931c7a7e884c8230", size = 736218, upload-time = "2025-10-17T14:00:03.51Z" },
-    { url = "https://files.pythonhosted.org/packages/26/13/f7bccedbe52ea5a6eef1e4ebb686a8d7765319dfd0a5939f4238cb6e79e6/aiohttp-3.13.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7129a424b441c3fe018a414401bf1b9e1d49492445f5676a3aecf4f74f67fcdb", size = 491251, upload-time = "2025-10-17T14:00:05.756Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/7c/7ea51b5aed6cc69c873f62548da8345032aa3416336f2d26869d4d37b4a2/aiohttp-3.13.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e1cb04ae64a594f6ddf5cbb024aba6b4773895ab6ecbc579d60414f8115e9e26", size = 490394, upload-time = "2025-10-17T14:00:07.504Z" },
-    { url = "https://files.pythonhosted.org/packages/31/05/1172cc4af4557f6522efdee6eb2b9f900e1e320a97e25dffd3c5a6af651b/aiohttp-3.13.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:782d656a641e755decd6bd98d61d2a8ea062fd45fd3ff8d4173605dd0d2b56a1", size = 1737455, upload-time = "2025-10-17T14:00:09.403Z" },
-    { url = "https://files.pythonhosted.org/packages/24/3d/ce6e4eca42f797d6b1cd3053cf3b0a22032eef3e4d1e71b9e93c92a3f201/aiohttp-3.13.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f92ad8169767429a6d2237331726c03ccc5f245222f9373aa045510976af2b35", size = 1699176, upload-time = "2025-10-17T14:00:11.314Z" },
-    { url = "https://files.pythonhosted.org/packages/25/04/7127ba55653e04da51477372566b16ae786ef854e06222a1c96b4ba6c8ef/aiohttp-3.13.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0e778f634ca50ec005eefa2253856921c429581422d887be050f2c1c92e5ce12", size = 1767216, upload-time = "2025-10-17T14:00:13.668Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/3b/43bca1e75847e600f40df829a6b2f0f4e1d4c70fb6c4818fdc09a462afd5/aiohttp-3.13.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9bc36b41cf4aab5d3b34d22934a696ab83516603d1bc1f3e4ff9930fe7d245e5", size = 1865870, upload-time = "2025-10-17T14:00:15.852Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/69/b204e5d43384197a614c88c1717c324319f5b4e7d0a1b5118da583028d40/aiohttp-3.13.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3fd4570ea696aee27204dd524f287127ed0966d14d309dc8cc440f474e3e7dbd", size = 1751021, upload-time = "2025-10-17T14:00:18.297Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/af/845dc6b6fdf378791d720364bf5150f80d22c990f7e3a42331d93b337cc7/aiohttp-3.13.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7bda795f08b8a620836ebfb0926f7973972a4bf8c74fdf9145e489f88c416811", size = 1561448, upload-time = "2025-10-17T14:00:20.152Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/91/d2ab08cd77ed76a49e4106b1cfb60bce2768242dd0c4f9ec0cb01e2cbf94/aiohttp-3.13.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:055a51d90e351aae53dcf324d0eafb2abe5b576d3ea1ec03827d920cf81a1c15", size = 1698196, upload-time = "2025-10-17T14:00:22.131Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/d1/082f0620dc428ecb8f21c08a191a4694915cd50f14791c74a24d9161cc50/aiohttp-3.13.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:d4131df864cbcc09bb16d3612a682af0db52f10736e71312574d90f16406a867", size = 1719252, upload-time = "2025-10-17T14:00:24.453Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/78/2af2f44491be7b08e43945b72d2b4fd76f0a14ba850ba9e41d28a7ce716a/aiohttp-3.13.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:163d3226e043f79bf47c87f8dfc89c496cc7bc9128cb7055ce026e435d551720", size = 1736529, upload-time = "2025-10-17T14:00:26.567Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/34/3e919ecdc93edaea8d140138049a0d9126141072e519535e2efa38eb7a02/aiohttp-3.13.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:a2370986a3b75c1a5f3d6f6d763fc6be4b430226577b0ed16a7c13a75bf43d8f", size = 1553723, upload-time = "2025-10-17T14:00:28.592Z" },
-    { url = "https://files.pythonhosted.org/packages/21/4b/d8003aeda2f67f359b37e70a5a4b53fee336d8e89511ac307ff62aeefcdb/aiohttp-3.13.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:d7c14de0c7c9f1e6e785ce6cbe0ed817282c2af0012e674f45b4e58c6d4ea030", size = 1763394, upload-time = "2025-10-17T14:00:31.051Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/7b/1dbe6a39e33af9baaafc3fc016a280663684af47ba9f0e5d44249c1f72ec/aiohttp-3.13.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb611489cf0db10b99beeb7280bd39e0ef72bc3eb6d8c0f0a16d8a56075d1eb7", size = 1718104, upload-time = "2025-10-17T14:00:33.407Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/88/bd1b38687257cce67681b9b0fa0b16437be03383fa1be4d1a45b168bef25/aiohttp-3.13.1-cp312-cp312-win32.whl", hash = "sha256:f90fe0ee75590f7428f7c8b5479389d985d83c949ea10f662ab928a5ed5cf5e6", size = 425303, upload-time = "2025-10-17T14:00:35.829Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/e3/4481f50dd6f27e9e58c19a60cff44029641640237e35d32b04aaee8cf95f/aiohttp-3.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:3461919a9dca272c183055f2aab8e6af0adc810a1b386cce28da11eb00c859d9", size = 452071, upload-time = "2025-10-17T14:00:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/bd/ede278648914cabbabfdf95e436679b5d4156e417896a9b9f4587169e376/aiohttp-3.13.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ee62d4471ce86b108b19c3364db4b91180d13fe3510144872d6bad5401957360", size = 752158, upload-time = "2026-03-28T17:16:06.901Z" },
+    { url = "https://files.pythonhosted.org/packages/90/de/581c053253c07b480b03785196ca5335e3c606a37dc73e95f6527f1591fe/aiohttp-3.13.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c0fd8f41b54b58636402eb493afd512c23580456f022c1ba2db0f810c959ed0d", size = 501037, upload-time = "2026-03-28T17:16:08.82Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/a5ede193c08f13cc42c0a5b50d1e246ecee9115e4cf6e900d8dbd8fd6acb/aiohttp-3.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4baa48ce49efd82d6b1a0be12d6a36b35e5594d1dd42f8bfba96ea9f8678b88c", size = 501556, upload-time = "2026-03-28T17:16:10.63Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/10/88ff67cd48a6ec36335b63a640abe86135791544863e0cfe1f065d6cef7a/aiohttp-3.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d738ebab9f71ee652d9dbd0211057690022201b11197f9a7324fd4dba128aa97", size = 1757314, upload-time = "2026-03-28T17:16:12.498Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/15/fdb90a5cf5a1f52845c276e76298c75fbbcc0ac2b4a86551906d54529965/aiohttp-3.13.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0ce692c3468fa831af7dceed52edf51ac348cebfc8d3feb935927b63bd3e8576", size = 1731819, upload-time = "2026-03-28T17:16:14.558Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/df/28146785a007f7820416be05d4f28cc207493efd1e8c6c1068e9bdc29198/aiohttp-3.13.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e08abcfe752a454d2cb89ff0c08f2d1ecd057ae3e8cc6d84638de853530ebab", size = 1793279, upload-time = "2026-03-28T17:16:16.594Z" },
+    { url = "https://files.pythonhosted.org/packages/10/47/689c743abf62ea7a77774d5722f220e2c912a77d65d368b884d9779ef41b/aiohttp-3.13.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5977f701b3fff36367a11087f30ea73c212e686d41cd363c50c022d48b011d8d", size = 1891082, upload-time = "2026-03-28T17:16:18.71Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b6/f7f4f318c7e58c23b761c9b13b9a3c9b394e0f9d5d76fbc6622fa98509f6/aiohttp-3.13.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54203e10405c06f8b6020bd1e076ae0fe6c194adcee12a5a78af3ffa3c57025e", size = 1773938, upload-time = "2026-03-28T17:16:21.125Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/06/f207cb3121852c989586a6fc16ff854c4fcc8651b86c5d3bd1fc83057650/aiohttp-3.13.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:358a6af0145bc4dda037f13167bef3cce54b132087acc4c295c739d05d16b1c3", size = 1579548, upload-time = "2026-03-28T17:16:23.588Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/e1289661a32161e24c1fe479711d783067210d266842523752869cc1d9c2/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:898ea1850656d7d61832ef06aa9846ab3ddb1621b74f46de78fbc5e1a586ba83", size = 1714669, upload-time = "2026-03-28T17:16:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/96/0a/3e86d039438a74a86e6a948a9119b22540bae037d6ba317a042ae3c22711/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7bc30cceb710cf6a44e9617e43eebb6e3e43ad855a34da7b4b6a73537d8a6763", size = 1754175, upload-time = "2026-03-28T17:16:28.18Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/30/e717fc5df83133ba467a560b6d8ef20197037b4bb5d7075b90037de1018e/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4a31c0c587a8a038f19a4c7e60654a6c899c9de9174593a13e7cc6e15ff271f9", size = 1762049, upload-time = "2026-03-28T17:16:30.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/28/8f7a2d4492e336e40005151bdd94baf344880a4707573378579f833a64c1/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2062f675f3fe6e06d6113eb74a157fb9df58953ffed0cdb4182554b116545758", size = 1570861, upload-time = "2026-03-28T17:16:32.953Z" },
+    { url = "https://files.pythonhosted.org/packages/78/45/12e1a3d0645968b1c38de4b23fdf270b8637735ea057d4f84482ff918ad9/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d1ba8afb847ff80626d5e408c1fdc99f942acc877d0702fe137015903a220a9", size = 1790003, upload-time = "2026-03-28T17:16:35.468Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/60374e18d590de16dcb39d6ff62f39c096c1b958e6f37727b5870026ea30/aiohttp-3.13.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b08149419994cdd4d5eecf7fd4bc5986b5a9380285bcd01ab4c0d6bfca47b79d", size = 1737289, upload-time = "2026-03-28T17:16:38.187Z" },
+    { url = "https://files.pythonhosted.org/packages/02/bf/535e58d886cfbc40a8b0013c974afad24ef7632d645bca0b678b70033a60/aiohttp-3.13.4-cp312-cp312-win32.whl", hash = "sha256:fc432f6a2c4f720180959bc19aa37259651c1a4ed8af8afc84dd41c60f15f791", size = 434185, upload-time = "2026-03-28T17:16:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/1a/d92e3325134ebfff6f4069f270d3aac770d63320bd1fcd0eca023e74d9a8/aiohttp-3.13.4-cp312-cp312-win_amd64.whl", hash = "sha256:6148c9ae97a3e8bff9a1fc9c757fa164116f86c100468339730e717590a3fb77", size = 461285, upload-time = "2026-03-28T17:16:42.713Z" },
 ]
 
 [[package]]
@@ -292,14 +292,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.0"
+version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
@@ -587,6 +587,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f2/bd/ad8a0cc9ea3e8bfe8fb63a00be985d4c887c3c0a454d26c712c160af489f/fastmcp-2.13.0.1.tar.gz", hash = "sha256:d6dbd52a6b06fc1797db9fe0b487db966b4a4d34d9c7dd87b9918d5ec775dcb7", size = 7768846, upload-time = "2025-10-26T15:43:00.567Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/0c/7e966e01240f7a9347d22d09e9d60cb46eaad68ca2ba24830755dab2c55c/fastmcp-2.13.0.1-py3-none-any.whl", hash = "sha256:60a8313b48803a2ddfad2d0fe8b9dd1f231aba7564c0551cad8447527ffe46e2", size = 367504, upload-time = "2025-10-26T15:42:58.98Z" },
+]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
 ]
 
 [[package]]
@@ -916,6 +935,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "huggingface-hub" },
     { name = "imagehash" },
+    { name = "litellm" },
     { name = "loguru" },
     { name = "numpy" },
     { name = "onnxruntime" },
@@ -966,6 +986,7 @@ requires-dist = [
     { name = "google-genai" },
     { name = "huggingface-hub", specifier = ">=0.19.0" },
     { name = "imagehash" },
+    { name = "litellm", specifier = ">=1.0.0" },
     { name = "loguru" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "onnxruntime", specifier = ">=1.16.0" },
@@ -1024,14 +1045,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "8.7.0"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304, upload-time = "2024-09-11T14:56:08.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b", size = 26514, upload-time = "2024-09-11T14:56:07.019Z" },
 ]
 
 [[package]]
@@ -1151,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "jsonschema"
-version = "4.25.1"
+version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1159,9 +1180,9 @@ dependencies = [
     { name = "referencing" },
     { name = "rpds-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/2e/03362ee4034a4c917f697890ccd4aec0800ccf9ded7f511971c75451deec/jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4", size = 325778, upload-time = "2024-07-08T18:40:05.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/69/4a/4f9dbeb84e8850557c02365a0eee0649abe5eb1d84af92a25731c6c0f922/jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566", size = 88462, upload-time = "2024-07-08T18:40:00.165Z" },
 ]
 
 [[package]]
@@ -1256,6 +1277,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/c2/de1db8c6d413597076a4259cea409b83459b2db997c003578affdd32bf66/libclang-18.1.1-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:69f8eb8f65c279e765ffd28aaa7e9e364c776c17618af8bff22a8df58677ff4f", size = 24921494, upload-time = "2024-03-17T16:14:20.132Z" },
     { url = "https://files.pythonhosted.org/packages/0b/2d/3f480b1e1d31eb3d6de5e3ef641954e5c67430d5ac93b7fa7e07589576c7/libclang-18.1.1-py2.py3-none-win_amd64.whl", hash = "sha256:4dd2d3b82fab35e2bf9ca717d7b63ac990a3519c7e312f19fa8e86dcc712f7fb", size = 26415083, upload-time = "2024-03-17T16:42:21.703Z" },
     { url = "https://files.pythonhosted.org/packages/71/cf/e01dc4cc79779cd82d77888a88ae2fa424d93b445ad4f6c02bfc18335b70/libclang-18.1.1-py2.py3-none-win_arm64.whl", hash = "sha256:3f0e1f49f04d3cd198985fea0511576b0aee16f9ff0e0f0cad7f9c57ec3c20e8", size = 22361112, upload-time = "2024-03-17T16:42:59.565Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.83.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
 ]
 
 [[package]]
@@ -1702,12 +1746,12 @@ name = "onnxruntime-gpu"
 version = "1.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "coloredlogs", marker = "sys_platform != 'darwin'" },
+    { name = "flatbuffers", marker = "sys_platform != 'darwin'" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "packaging", marker = "sys_platform != 'darwin'" },
+    { name = "protobuf", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/d9/b7140a4f1615195938c7e358c0804bb84271f0d6886b5cbf105c6cb58aae/onnxruntime_gpu-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f2d1f720685d729b5258ec1b36dee1de381b8898189908c98cbeecdb2f2b5c2", size = 300509596, upload-time = "2025-10-22T16:56:31.728Z" },
@@ -1716,7 +1760,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.6.1"
+version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1728,9 +1772,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/44/303deb97be7c1c9b53118b52825cbd1557aeeff510f3a52566b1fa66f6a2/openai-2.6.1.tar.gz", hash = "sha256:27ae704d190615fca0c0fc2b796a38f8b5879645a3a52c9c453b23f97141bb49", size = 593043, upload-time = "2025-10-24T13:29:52.79Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/0e/331df43df633e6105ff9cf45e0ce57762bd126a45ac16b25a43f6738d8a2/openai-2.6.1-py3-none-any.whl", hash = "sha256:904e4b5254a8416746a2f05649594fa41b19d799843cd134dac86167e094edef", size = 1005551, upload-time = "2025-10-24T13:29:50.973Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
 ]
 
 [[package]]
@@ -2249,7 +2293,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.12.3"
+version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -2257,9 +2301,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/1e/4f0a3233767010308f2fd6bd0814597e3f63f1dc98304a9112b8759df4ff/pydantic-2.12.3.tar.gz", hash = "sha256:1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74", size = 819383, upload-time = "2025-10-17T15:04:21.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/6b/83661fa77dcefa195ad5f8cd9af3d1a7450fd57cc883ad04d65446ac2029/pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf", size = 462431, upload-time = "2025-10-17T15:04:19.346Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
 ]
 
 [package.optional-dependencies]
@@ -2357,31 +2401,31 @@ vertexai = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.41.4"
+version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/18/d0944e8eaaa3efd0a91b0f1fc537d3be55ad35091b6a87638211ba691964/pydantic_core-2.41.4.tar.gz", hash = "sha256:70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5", size = 457557, upload-time = "2025-10-14T10:23:47.909Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/81/d3b3e95929c4369d30b2a66a91db63c8ed0a98381ae55a45da2cd1cc1288/pydantic_core-2.41.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ab06d77e053d660a6faaf04894446df7b0a7e7aba70c2797465a0a1af00fc887", size = 2099043, upload-time = "2025-10-14T10:20:28.561Z" },
-    { url = "https://files.pythonhosted.org/packages/58/da/46fdac49e6717e3a94fc9201403e08d9d61aa7a770fab6190b8740749047/pydantic_core-2.41.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c53ff33e603a9c1179a9364b0a24694f183717b2e0da2b5ad43c316c956901b2", size = 1910699, upload-time = "2025-10-14T10:20:30.217Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/63/4d948f1b9dd8e991a5a98b77dd66c74641f5f2e5225fee37994b2e07d391/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:304c54176af2c143bd181d82e77c15c41cbacea8872a2225dd37e6544dce9999", size = 1952121, upload-time = "2025-10-14T10:20:32.246Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a7/e5fc60a6f781fc634ecaa9ecc3c20171d238794cef69ae0af79ac11b89d7/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:025ba34a4cf4fb32f917d5d188ab5e702223d3ba603be4d8aca2f82bede432a4", size = 2041590, upload-time = "2025-10-14T10:20:34.332Z" },
-    { url = "https://files.pythonhosted.org/packages/70/69/dce747b1d21d59e85af433428978a1893c6f8a7068fa2bb4a927fba7a5ff/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9f5f30c402ed58f90c70e12eff65547d3ab74685ffe8283c719e6bead8ef53f", size = 2219869, upload-time = "2025-10-14T10:20:35.965Z" },
-    { url = "https://files.pythonhosted.org/packages/83/6a/c070e30e295403bf29c4df1cb781317b6a9bac7cd07b8d3acc94d501a63c/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd96e5d15385d301733113bcaa324c8bcf111275b7675a9c6e88bfb19fc05e3b", size = 2345169, upload-time = "2025-10-14T10:20:37.627Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/83/06d001f8043c336baea7fd202a9ac7ad71f87e1c55d8112c50b745c40324/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98f348cbb44fae6e9653c1055db7e29de67ea6a9ca03a5fa2c2e11a47cff0e47", size = 2070165, upload-time = "2025-10-14T10:20:39.246Z" },
-    { url = "https://files.pythonhosted.org/packages/14/0a/e567c2883588dd12bcbc110232d892cf385356f7c8a9910311ac997ab715/pydantic_core-2.41.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ec22626a2d14620a83ca583c6f5a4080fa3155282718b6055c2ea48d3ef35970", size = 2189067, upload-time = "2025-10-14T10:20:41.015Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/1d/3d9fca34273ba03c9b1c5289f7618bc4bd09c3ad2289b5420481aa051a99/pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3a95d4590b1f1a43bf33ca6d647b990a88f4a3824a8c4572c708f0b45a5290ed", size = 2132997, upload-time = "2025-10-14T10:20:43.106Z" },
-    { url = "https://files.pythonhosted.org/packages/52/70/d702ef7a6cd41a8afc61f3554922b3ed8d19dd54c3bd4bdbfe332e610827/pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:f9672ab4d398e1b602feadcffcdd3af44d5f5e6ddc15bc7d15d376d47e8e19f8", size = 2307187, upload-time = "2025-10-14T10:20:44.849Z" },
-    { url = "https://files.pythonhosted.org/packages/68/4c/c06be6e27545d08b802127914156f38d10ca287a9e8489342793de8aae3c/pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:84d8854db5f55fead3b579f04bda9a36461dab0730c5d570e1526483e7bb8431", size = 2305204, upload-time = "2025-10-14T10:20:46.781Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/e5/35ae4919bcd9f18603419e23c5eaf32750224a89d41a8df1a3704b69f77e/pydantic_core-2.41.4-cp312-cp312-win32.whl", hash = "sha256:9be1c01adb2ecc4e464392c36d17f97e9110fbbc906bcbe1c943b5b87a74aabd", size = 1972536, upload-time = "2025-10-14T10:20:48.39Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c2/49c5bb6d2a49eb2ee3647a93e3dae7080c6409a8a7558b075027644e879c/pydantic_core-2.41.4-cp312-cp312-win_amd64.whl", hash = "sha256:d682cf1d22bab22a5be08539dca3d1593488a99998f9f412137bc323179067ff", size = 2031132, upload-time = "2025-10-14T10:20:50.421Z" },
-    { url = "https://files.pythonhosted.org/packages/06/23/936343dbcba6eec93f73e95eb346810fc732f71ba27967b287b66f7b7097/pydantic_core-2.41.4-cp312-cp312-win_arm64.whl", hash = "sha256:833eebfd75a26d17470b58768c1834dfc90141b7afc6eb0429c21fc5a21dcfb8", size = 1969483, upload-time = "2025-10-14T10:20:52.35Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/48/ae937e5a831b7c0dc646b2ef788c27cd003894882415300ed21927c21efa/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:4f5d640aeebb438517150fdeec097739614421900e4a08db4a3ef38898798537", size = 2112087, upload-time = "2025-10-14T10:22:56.818Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/db/6db8073e3d32dae017da7e0d16a9ecb897d0a4d92e00634916e486097961/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:4a9ab037b71927babc6d9e7fc01aea9e66dc2a4a34dff06ef0724a4049629f94", size = 1920387, upload-time = "2025-10-14T10:22:59.342Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c1/dd3542d072fcc336030d66834872f0328727e3b8de289c662faa04aa270e/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4dab9484ec605c3016df9ad4fd4f9a390bc5d816a3b10c6550f8424bb80b18c", size = 1951495, upload-time = "2025-10-14T10:23:02.089Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c6/db8d13a1f8ab3f1eb08c88bd00fd62d44311e3456d1e85c0e59e0a0376e7/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8a5028425820731d8c6c098ab642d7b8b999758e24acae03ed38a66eca8335", size = 2139008, upload-time = "2025-10-14T10:23:04.539Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
 ]
 
 [[package]]
@@ -2555,11 +2599,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -3032,6 +3076,25 @@ wheels = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/85/be65d39d6b647c79800fd9d29241d081d4eeb06271f383bb87200d74cf76/tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8", size = 1050728, upload-time = "2025-10-06T20:21:52.756Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c5/ed88504d2f4a5fd6856990b230b56d85a777feab84e6129af0822f5d0f70/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37", size = 1129008, upload-time = "2025-10-06T20:21:54.832Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
+]
+
+[[package]]
 name = "timm"
 version = "1.0.21"
 source = { registry = "https://pypi.org/simple" }
@@ -3049,27 +3112,28 @@ wheels = [
 
 [[package]]
 name = "tokenizers"
-version = "0.22.1"
+version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/46/fb6854cec3278fbfa4a75b50232c77622bc517ac886156e6afbfa4d8fc6e/tokenizers-0.22.1.tar.gz", hash = "sha256:61de6522785310a309b3407bac22d99c4db5dba349935e99e4d15ea2226af2d9", size = 363123, upload-time = "2025-09-19T09:49:23.424Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/33/f4b2d94ada7ab297328fc671fed209368ddb82f965ec2224eb1892674c3a/tokenizers-0.22.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:59fdb013df17455e5f950b4b834a7b3ee2e0271e6378ccb33aa74d178b513c73", size = 3069318, upload-time = "2025-09-19T09:49:11.848Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/58/2aa8c874d02b974990e89ff95826a4852a8b2a273c7d1b4411cdd45a4565/tokenizers-0.22.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8d4e484f7b0827021ac5f9f71d4794aaef62b979ab7608593da22b1d2e3c4edc", size = 2926478, upload-time = "2025-09-19T09:49:09.759Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/3b/55e64befa1e7bfea963cf4b787b2cea1011362c4193f5477047532ce127e/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19d2962dd28bc67c1f205ab180578a78eef89ac60ca7ef7cbe9635a46a56422a", size = 3256994, upload-time = "2025-09-19T09:48:56.701Z" },
-    { url = "https://files.pythonhosted.org/packages/71/0b/fbfecf42f67d9b7b80fde4aabb2b3110a97fac6585c9470b5bff103a80cb/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:38201f15cdb1f8a6843e6563e6e79f4abd053394992b9bbdf5213ea3469b4ae7", size = 3153141, upload-time = "2025-09-19T09:48:59.749Z" },
-    { url = "https://files.pythonhosted.org/packages/17/a9/b38f4e74e0817af8f8ef925507c63c6ae8171e3c4cb2d5d4624bf58fca69/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d1cbe5454c9a15df1b3443c726063d930c16f047a3cc724b9e6e1a91140e5a21", size = 3508049, upload-time = "2025-09-19T09:49:05.868Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/48/dd2b3dac46bb9134a88e35d72e1aa4869579eacc1a27238f1577270773ff/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e7d094ae6312d69cc2a872b54b91b309f4f6fbce871ef28eb27b52a98e4d0214", size = 3710730, upload-time = "2025-09-19T09:49:01.832Z" },
-    { url = "https://files.pythonhosted.org/packages/93/0e/ccabc8d16ae4ba84a55d41345207c1e2ea88784651a5a487547d80851398/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afd7594a56656ace95cdd6df4cca2e4059d294c5cfb1679c57824b605556cb2f", size = 3412560, upload-time = "2025-09-19T09:49:03.867Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c6/dc3a0db5a6766416c32c034286d7c2d406da1f498e4de04ab1b8959edd00/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2ef6063d7a84994129732b47e7915e8710f27f99f3a3260b8a38fc7ccd083f4", size = 3250221, upload-time = "2025-09-19T09:49:07.664Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/a6/2c8486eef79671601ff57b093889a345dd3d576713ef047776015dc66de7/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ba0a64f450b9ef412c98f6bcd2a50c6df6e2443b560024a09fa6a03189726879", size = 9345569, upload-time = "2025-09-19T09:49:14.214Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/16/32ce667f14c35537f5f605fe9bea3e415ea1b0a646389d2295ec348d5657/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:331d6d149fa9c7d632cde4490fb8bbb12337fa3a0232e77892be656464f4b446", size = 9271599, upload-time = "2025-09-19T09:49:16.639Z" },
-    { url = "https://files.pythonhosted.org/packages/51/7c/a5f7898a3f6baa3fc2685c705e04c98c1094c523051c805cdd9306b8f87e/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:607989f2ea68a46cb1dfbaf3e3aabdf3f21d8748312dbeb6263d1b3b66c5010a", size = 9533862, upload-time = "2025-09-19T09:49:19.146Z" },
-    { url = "https://files.pythonhosted.org/packages/36/65/7e75caea90bc73c1dd8d40438adf1a7bc26af3b8d0a6705ea190462506e1/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a0f307d490295717726598ef6fa4f24af9d484809223bbc253b201c740a06390", size = 9681250, upload-time = "2025-09-19T09:49:21.501Z" },
-    { url = "https://files.pythonhosted.org/packages/30/2c/959dddef581b46e6209da82df3b78471e96260e2bc463f89d23b1bf0e52a/tokenizers-0.22.1-cp39-abi3-win32.whl", hash = "sha256:b5120eed1442765cd90b903bb6cfef781fd8fe64e34ccaecbae4c619b7b12a82", size = 2472003, upload-time = "2025-09-19T09:49:27.089Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/46/e33a8c93907b631a99377ef4c5f817ab453d0b34f93529421f42ff559671/tokenizers-0.22.1-cp39-abi3-win_amd64.whl", hash = "sha256:65fd6e3fb11ca1e78a6a93602490f134d1fdeb13bcef99389d5102ea318ed138", size = 2674684, upload-time = "2025-09-19T09:49:24.953Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #2

- transformers 基底の `tags`/`captions` 重複バグを修正し capabilities ベースで分岐
- ToriiGate を `UnifiedAnnotationResult(captions=...)` 化、config も `type=captioner` に
- `_build_results` の後方互換パス削除 (`UnifiedAnnotationResult` 以外は `TypeError`)
- `_generate_tags` 抽象メソッド要件を削除
- LoRAIro 側 `_extract_scores_from_formatted_output()` の FIXME を解消可能に

## Context

実コード調査の結果、Issue 本文の「ONNX/Transformers/TensorFlow が後方互換パスを通る」という記述は誤認で、実際は **ToriiGate 系のみ** が `_format_predictions` で `list[str]` を返して互換パスを通っていた。Transformers 基底自体は既に `UnifiedAnnotationResult` を返していたが、`tags` と `captions` の両方に同じデコード文字列を入れる capability 違反バグがあった。

外部ユーザーなしの内部 submodule であり、ADR 0021 (LoRAIro) でも破壊的変更を許容済みのため Big Bang 方式で互換レイヤーを撤去。

## Scope decisions

- ONNX/TensorFlow タガーの `scores` は **`None` のまま維持**（ADR 案A 採用）。タガーは tags のみで `scores` はスコアラー専用とする
- ToriiGate の `type` を `tagger` → `captioner` に修正（実態と整合）
- 既存 DB 移行はスコープ外（新規実行から `captions` テーブルに保存される）

## Test plan

- [x] `tests/unit/core/test_build_results_strict_typing.py` 新規追加 (TypeError 動作検証 3 件)
- [x] 既存 `test_base_annotator_di.py` のスタブを `UnifiedAnnotationResult` 返却に更新
- [x] `tests/unit/test_capability_validation.py` および `test_unified_validation_schema.py` の既存 41 テスト全 pass
- [x] LoRAIro 側 `tests/unit/services/test_annotation_save_service.py` および `tests/integration/services/test_annotation_save_three_paths.py` 全 pass
- [ ] 実機 ML モデル (BLIP/DeepDanbooru/WDTagger/ToriiGate) E2E 検証（マージ後手動）

## Related

- LoRAIro 側対応 PR: NEXTAltair/LoRAIro feat/annotator-lib-issue-2-unified-scores
- 設計 ADR: LoRAIro/docs/plans/wobbly-percolating-pebble.md (実装計画)

🤖 Generated with [Claude Code](https://claude.com/claude-code)