### PR TITLE
feat(#19/P2): AnnotatorInfo に詳細メタデータフィールドを追加

### DIFF
--- a/src/image_annotator_lib/api.py
+++ b/src/image_annotator_lib/api.py
@@ -85,7 +85,12 @@ def list_annotator_info() -> list[AnnotatorInfo]:
         all_config = {}
 
     for model_name, model_class in _MODEL_CLASS_OBJ_REGISTRY.items():
-        model_config = all_config.get(model_name) or _WEBAPI_MODEL_METADATA.get(model_name, {})
+        # discovery メタデータ (`_WEBAPI_MODEL_METADATA`) と config_registry の値を
+        # マージする (どちらか片方では provider / max_output_tokens 等が dropped される)。
+        # 優先順位: ユーザー/システム設定 (all_config) > discovery メタデータ。
+        discovery_meta = _WEBAPI_MODEL_METADATA.get(model_name) or {}
+        user_config = all_config.get(model_name) or {}
+        model_config = {**discovery_meta, **user_config}
         try:
             infos.append(_build_annotator_info_for_registry_model(model_name, model_class, model_config))
             seen_names.add(model_name)

--- a/src/image_annotator_lib/api.py
+++ b/src/image_annotator_lib/api.py
@@ -85,13 +85,27 @@ def list_annotator_info() -> list[AnnotatorInfo]:
         all_config = {}
 
     for model_name, model_class in _MODEL_CLASS_OBJ_REGISTRY.items():
-        # discovery メタデータ (`_WEBAPI_MODEL_METADATA`) と config_registry の値を
-        # マージする (どちらか片方では provider / max_output_tokens 等が dropped される)。
-        # 優先順位: ユーザー/システム設定 (all_config) > discovery メタデータ。
-        discovery_meta = _WEBAPI_MODEL_METADATA.get(model_name) or {}
-        user_config = all_config.get(model_name) or {}
-        model_config = {**discovery_meta, **user_config}
         try:
+            # discovery メタデータ (`_WEBAPI_MODEL_METADATA`) と config_registry の値を
+            # マージする (どちらか片方では provider / max_output_tokens 等が dropped される)。
+            # 優先順位: ユーザー/システム設定 (all_config) > discovery メタデータ。
+            # malformed config (scalar/list 等の非マッピング値) は warning + 空 dict 扱いとし、
+            # 該当モデルだけが失敗するようにして他モデルの listing を継続させる。
+            discovery_meta = _WEBAPI_MODEL_METADATA.get(model_name) or {}
+            if not isinstance(discovery_meta, dict):
+                logger.warning(
+                    f"モデル '{model_name}' の discovery メタデータが非マッピング "
+                    f"({type(discovery_meta).__name__}): {discovery_meta!r}"
+                )
+                discovery_meta = {}
+            user_config = all_config.get(model_name) or {}
+            if not isinstance(user_config, dict):
+                logger.warning(
+                    f"モデル '{model_name}' の config_registry 値が非マッピング "
+                    f"({type(user_config).__name__}): {user_config!r}"
+                )
+                user_config = {}
+            model_config = {**discovery_meta, **user_config}
             infos.append(_build_annotator_info_for_registry_model(model_name, model_class, model_config))
             seen_names.add(model_name)
         except Exception as e:

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -490,6 +490,33 @@ def _resolve_registry_capabilities(model_name: str, is_api: bool) -> frozenset[T
     return frozenset()
 
 
+def _infer_provider_from_model_id(model_id: str) -> str | None:
+    """PydanticAI 直接モデルの ``provider`` を model_id から推論する。
+
+    "provider/model_name" 形式 (例: "google/gemini-2.5-pro") は slash 前を返す。
+    slash のない model_id は PydanticAI の infer_provider_class でフォールバック。
+
+    Args:
+        model_id: PydanticAI 直接モデルの ID。
+
+    Returns:
+        推論された provider 名。判定できない場合は None。
+    """
+    if "/" in model_id:
+        return model_id.split("/", 1)[0]
+    try:
+        from pydantic_ai.providers import infer_provider_class
+
+        cls = infer_provider_class(model_id)
+        cls_name = (type(cls).__name__ if not isinstance(cls, type) else cls.__name__).lower()
+        for known in ("openai", "anthropic", "google"):
+            if known in cls_name:
+                return known
+    except Exception:
+        pass
+    return None
+
+
 def _build_annotator_info_for_registry_model(
     model_name: str, model_class: ModelClass, model_config: dict[str, Any]
 ) -> AnnotatorInfo:
@@ -507,6 +534,15 @@ def _build_annotator_info_for_registry_model(
     is_local = not is_api
     device = model_config.get("device") if is_local else None
 
+    # provider: config 優先、ローカルモデルは "local" にフォールバック
+    _raw_provider = model_config.get("provider")
+    provider: str | None = (
+        str(_raw_provider) if _raw_provider is not None else ("local" if is_local else None)
+    )
+
+    _raw_size = model_config.get("estimated_size_gb")
+    _raw_tokens = model_config.get("max_output_tokens")
+
     return AnnotatorInfo(
         name=model_name,
         model_type=_determine_model_type(model_name, model_class, model_config),
@@ -514,6 +550,13 @@ def _build_annotator_info_for_registry_model(
         is_local=is_local,
         is_api=is_api,
         device=device if isinstance(device, str) else None,
+        provider=provider,
+        api_model_id=str(model_config["api_model_id"])
+        if model_config.get("api_model_id") is not None
+        else None,
+        estimated_size_gb=float(_raw_size) if _raw_size is not None else None,
+        discontinued_at=model_config.get("discontinued_at"),
+        max_output_tokens=int(_raw_tokens) if _raw_tokens is not None else None,
     )
 
 
@@ -541,6 +584,8 @@ def _build_annotator_info_for_direct_model(model_id: str) -> AnnotatorInfo:
         is_local=False,
         is_api=True,
         device=None,
+        provider=_infer_provider_from_model_id(model_id),
+        api_model_id=model_id,  # 直接モデルは model_id 自体が上流 API の識別子
     )
 
 

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -1,3 +1,4 @@
+import datetime
 import importlib
 import inspect
 import os
@@ -517,6 +518,54 @@ def _infer_provider_from_model_id(model_id: str) -> str | None:
     return None
 
 
+def _safe_float(value: Any, model_name: str, field: str) -> float | None:
+    """optional な数値メタデータを float に安全に変換する。
+
+    変換できない値は **モデル登録を失敗させず**、warning ログ + None フォールバック
+    する (ADR 0005: optional metadata の不正値で listing 全体が壊れない設計)。
+    """
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        logger.warning(f"モデル '{model_name}' の {field} を float に変換できません: {value!r}")
+        return None
+
+
+def _safe_int(value: Any, model_name: str, field: str) -> int | None:
+    """optional な整数メタデータを int に安全に変換する (`_safe_float` と同じ方針)。"""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning(f"モデル '{model_name}' の {field} を int に変換できません: {value!r}")
+        return None
+
+
+def _parse_discontinued_at(value: Any, model_name: str) -> datetime.datetime | None:
+    """``discontinued_at`` を ``datetime.datetime | None`` に正規化する。
+
+    TOML の datetime ネイティブ型はそのまま、quoted string ("2025-12-31" 等) は
+    ISO 8601 として parse する。"Z" suffix も UTC として扱う。
+    """
+    if value is None or isinstance(value, datetime.datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            logger.warning(
+                f"モデル '{model_name}' の discontinued_at を datetime にパース失敗: {value!r}"
+            )
+            return None
+    logger.warning(
+        f"モデル '{model_name}' の discontinued_at が予期しない型 ({type(value).__name__}): {value!r}"
+    )
+    return None
+
+
 def _build_annotator_info_for_registry_model(
     model_name: str, model_class: ModelClass, model_config: dict[str, Any]
 ) -> AnnotatorInfo:
@@ -540,9 +589,6 @@ def _build_annotator_info_for_registry_model(
         str(_raw_provider) if _raw_provider is not None else ("local" if is_local else None)
     )
 
-    _raw_size = model_config.get("estimated_size_gb")
-    _raw_tokens = model_config.get("max_output_tokens")
-
     return AnnotatorInfo(
         name=model_name,
         model_type=_determine_model_type(model_name, model_class, model_config),
@@ -554,9 +600,13 @@ def _build_annotator_info_for_registry_model(
         api_model_id=str(model_config["api_model_id"])
         if model_config.get("api_model_id") is not None
         else None,
-        estimated_size_gb=float(_raw_size) if _raw_size is not None else None,
-        discontinued_at=model_config.get("discontinued_at"),
-        max_output_tokens=int(_raw_tokens) if _raw_tokens is not None else None,
+        estimated_size_gb=_safe_float(
+            model_config.get("estimated_size_gb"), model_name, "estimated_size_gb"
+        ),
+        discontinued_at=_parse_discontinued_at(model_config.get("discontinued_at"), model_name),
+        max_output_tokens=_safe_int(
+            model_config.get("max_output_tokens"), model_name, "max_output_tokens"
+        ),
     )
 
 

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -547,11 +547,22 @@ def _safe_int(value: Any, model_name: str, field: str) -> int | None:
 def _parse_discontinued_at(value: Any, model_name: str) -> datetime.datetime | None:
     """``discontinued_at`` を ``datetime.datetime | None`` に正規化する。
 
-    TOML の datetime ネイティブ型はそのまま、quoted string ("2025-12-31" 等) は
-    ISO 8601 として parse する。"Z" suffix も UTC として扱う。
+    受け付ける型:
+        - ``datetime.datetime``: そのまま返す
+        - ``datetime.date`` (TOML local-date ``2025-12-31`` 等): UTC 00:00:00 の datetime に変換
+        - ``str``: ISO 8601 として parse (``"Z"`` suffix は UTC として扱う)
+
+    Note:
+        `datetime.datetime` は `datetime.date` のサブクラスなので、isinstance チェックは
+        必ず datetime → date の順に行う必要がある。
     """
-    if value is None or isinstance(value, datetime.datetime):
+    if value is None:
+        return None
+    if isinstance(value, datetime.datetime):
         return value
+    if isinstance(value, datetime.date):
+        # TOML local-date (時刻なし) は datetime.date として渡される。UTC 00:00:00 で datetime 化。
+        return datetime.datetime.combine(value, datetime.time.min, tzinfo=datetime.UTC)
     if isinstance(value, str):
         try:
             return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/src/image_annotator_lib/core/types.py
+++ b/src/image_annotator_lib/core/types.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import datetime
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict, Union
@@ -408,3 +409,15 @@ class AnnotatorInfo:
     is_local: bool
     is_api: bool
     device: str | None = None
+    # --- Phase 2: 詳細メタデータ (ADR 0005 責務境界: lib 側で統一提供) ---
+    provider: str | None = None
+    """プロバイダー名。ローカルモデルは "local"、API モデルは "openai"/"anthropic"/"google" 等。
+    config_registry に未登録の PydanticAI 直接モデルは model_id の slash 前から推論。"""
+    api_model_id: str | None = None
+    """上流 API のモデル識別子 (例: "gpt-4o-2024-11-20")。ローカルモデルは None。"""
+    estimated_size_gb: float | None = None
+    """ローカル ML モデルのダウンロードサイズ推定値 (GB)。API モデルは None。"""
+    discontinued_at: datetime.datetime | None = None
+    """廃止日時。現役モデルは None (ADR 0021: LiteLLM 統合後は LiteLLM 由来に切替予定)。"""
+    max_output_tokens: int | None = None
+    """WebAPI 呼び出し時のトークン上限。API モデルのみ設定。ローカルモデルは None。"""

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -126,6 +126,10 @@ def test_local_ml_model_classification(patched_registry):
     assert info.is_api is False
     assert info.device == "cuda"
     assert TaskCapability.TAGS in info.capabilities
+    # Phase 2: ローカルモデルは provider="local"、API 関連は None
+    assert info.provider == "local"
+    assert info.api_model_id is None
+    assert info.max_output_tokens is None
 
 
 @pytest.mark.unit
@@ -150,6 +154,9 @@ def test_webapi_model_classification(patched_registry):
     assert info.is_api is True
     assert info.is_local is False
     assert info.device is None
+    # Phase 2: config に provider がない WebAPI モデルは provider=None
+    assert info.provider is None
+    assert info.api_model_id == "claude-3-opus-20240229"
 
 
 @pytest.mark.unit
@@ -205,6 +212,9 @@ def test_pydanticai_direct_model_inclusion(patched_registry):
     assert TaskCapability.TAGS in info.capabilities
     assert TaskCapability.CAPTIONS in info.capabilities
     assert TaskCapability.SCORES in info.capabilities
+    # Phase 2: provider は "google/..." の slash 前から推論
+    assert info.provider == "google"
+    assert info.api_model_id == direct_id
 
 
 @pytest.mark.unit
@@ -254,3 +264,90 @@ def test_invariants_is_local_xor_is_api(patched_registry):
 
     # frozenset により hashable であることを確認 (frozen=True dataclass の必須条件)
     assert hash(result[0]) is not None
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: 詳細メタデータフィールドのテスト
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_local_model_has_estimated_size_gb(patched_registry):
+    """ローカルモデルは estimated_size_gb が config から取れる。"""
+    with patched_registry(
+        model_dict={"aesthetic-scorer": _DummyScorer},
+        config_dict={
+            "aesthetic-scorer": {"type": "scorer", "estimated_size_gb": 4.065, "capabilities": ["scores"]}
+        },
+    ):
+        result = list_annotator_info()
+
+    assert len(result) == 1
+    info = result[0]
+    assert info.estimated_size_gb == pytest.approx(4.065)
+    assert info.provider == "local"
+    assert info.api_model_id is None
+    assert info.max_output_tokens is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_webapi_model_with_provider_and_max_tokens(patched_registry):
+    """config に provider / api_model_id / max_output_tokens がある WebAPI モデルは正しく取れる。"""
+    with patched_registry(
+        model_dict={"GPT-4o": PydanticAIWebAPIAnnotator},
+        config_dict={
+            "GPT-4o": {
+                "provider": "openai",
+                "api_model_id": "gpt-4o-2024-11-20",
+                "max_output_tokens": 1800,
+                "type": "vision",
+                "capabilities": ["tags", "captions", "scores"],
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    assert len(result) == 1
+    info = result[0]
+    assert info.provider == "openai"
+    assert info.api_model_id == "gpt-4o-2024-11-20"
+    assert info.max_output_tokens == 1800
+    assert info.is_api is True
+    assert info.estimated_size_gb is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "model_id,expected_provider",
+    [
+        ("google/gemini-2.5-pro", "google"),
+        ("anthropic/claude-3-7-sonnet", "anthropic"),
+        ("openai/gpt-4o", "openai"),
+        ("openrouter/google/gemini-flash", "openrouter"),
+    ],
+)
+def test_pydanticai_direct_model_provider_inferred(patched_registry, model_id: str, expected_provider: str):
+    """PydanticAI 直接モデルは model_id の slash 前から provider を推論する。"""
+    with patched_registry(model_dict={}, config_dict={}, direct_models=[model_id]):
+        result = list_annotator_info()
+
+    assert len(result) == 1
+    info = result[0]
+    assert info.provider == expected_provider
+    assert info.api_model_id == model_id
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_discontinued_at_none_for_active_model(patched_registry):
+    """現役モデルの discontinued_at は None。"""
+    with patched_registry(
+        model_dict={"active-tagger": _DummyTagger},
+        config_dict={"active-tagger": {"type": "tagger", "capabilities": ["tags"]}},
+    ):
+        result = list_annotator_info()
+
+    assert result[0].discontinued_at is None

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -407,6 +407,16 @@ def test_parse_discontinued_at_normalizes_quoted_string():
     native = _dt.datetime(2025, 12, 31, tzinfo=_dt.UTC)
     assert _parse_discontinued_at(native, "m") is native
 
+    # TOML local-date (datetime.date) は datetime.datetime に変換される (Codex P2 #22 第 5 指摘)
+    local_date = _dt.date(2025, 12, 31)
+    converted = _parse_discontinued_at(local_date, "m")
+    assert isinstance(converted, _dt.datetime)
+    assert converted.year == 2025
+    assert converted.month == 12
+    assert converted.day == 31
+    assert converted.hour == 0
+    assert converted.tzinfo is not None  # UTC で aware
+
     # 普通の ISO 文字列
     parsed = _parse_discontinued_at("2025-12-31T00:00:00", "m")
     assert isinstance(parsed, _dt.datetime)
@@ -425,6 +435,38 @@ def test_parse_discontinued_at_normalizes_quoted_string():
 
     # 予期しない型 → None
     assert _parse_discontinued_at(123, "m") is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_list_annotator_info_accepts_toml_local_date_for_discontinued_at(patched_registry):
+    """TOML local-date (`discontinued_at = 2025-12-31`) は datetime.date で来るが、
+    AnnotatorInfo.discontinued_at の datetime.datetime に正規化される (Codex P2 #22 第 5 指摘)。
+
+    silently None になると廃止モデルが list_annotator_info() で active と誤報される。
+    """
+    import datetime as _dt
+
+    with patched_registry(
+        model_dict={"deprecated-tagger": _DummyTagger},
+        config_dict={
+            "deprecated-tagger": {
+                "type": "tagger",
+                "capabilities": ["tags"],
+                # tomllib は `discontinued_at = 2025-12-31` を datetime.date として返す
+                "discontinued_at": _dt.date(2024, 6, 30),
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    assert len(result) == 1
+    info = result[0]
+    assert info.discontinued_at is not None  # 廃止モデルが active と誤報されない
+    assert isinstance(info.discontinued_at, _dt.datetime)
+    assert info.discontinued_at.year == 2024
+    assert info.discontinued_at.month == 6
+    assert info.discontinued_at.day == 30
 
 
 @pytest.mark.unit

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -513,6 +513,37 @@ def test_user_config_overrides_discovery_metadata(patched_registry):
 
 @pytest.mark.unit
 @pytest.mark.fast
+def test_list_annotator_info_skips_only_malformed_model_section(patched_registry):
+    """1 モデルの config セクションが非マッピング (scalar/list) でも、
+    他モデルの listing は継続される (Codex P2 #22 第 4 指摘)。
+
+    malformed: TOML で `[model.section]` の代わりに `model.section = "scalar"` のように
+    書かれた場合、`{**user_config}` のスプレッドが TypeError を投げて関数全体が abort
+    する問題があった。merge を try ブロックに含めて per-model 失敗にする。
+    """
+    # 2 モデル: "good" は dict、"malformed" は scalar (TOML の typo を想定)
+    user_config = {
+        "good-tagger": {"type": "tagger", "capabilities": ["tags"]},
+        "malformed-tagger": "this-should-be-a-dict",  # 不正な型
+    }
+    with patched_registry(
+        model_dict={"good-tagger": _DummyTagger, "malformed-tagger": _DummyTagger},
+        config_dict=user_config,
+    ):
+        result = list_annotator_info()
+
+    # malformed-tagger は build 失敗で skip されるが、good-tagger は listing に残る
+    names = [info.name for info in result]
+    assert "good-tagger" in names
+    # malformed の挙動: 非マッピングは warning + 空 dict 扱いされ、build には進む
+    # ただし最低限の config (capabilities/type) がないため capabilities フォールバックで
+    # 構築されるか、もしくは build 失敗で skip。どちらでも他モデルが残ることが要件。
+    # ここでは少なくとも 1 件以上残ることを保証。
+    assert len(result) >= 1
+
+
+@pytest.mark.unit
+@pytest.mark.fast
 def test_list_annotator_info_keeps_model_with_invalid_metadata(patched_registry):
     """estimated_size_gb / max_output_tokens / discontinued_at が malformed でも
     モデル自体は listing に残り、該当フィールドのみ None になる (Codex P2 #22)。"""

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -51,13 +51,24 @@ def patched_registry():
     """`_MODEL_CLASS_OBJ_REGISTRY` を直接書き換えるためのフィクスチャ。
     呼び出し側が辞書と config を渡す。"""
 
-    def _setup(model_dict: dict, config_dict: dict | None = None, direct_models: list[str] | None = None):
-        """戻り値: () のコンテキストマネージャ。withで使う。"""
+    def _setup(
+        model_dict: dict,
+        config_dict: dict | None = None,
+        direct_models: list[str] | None = None,
+        webapi_metadata: dict | None = None,
+    ):
+        """戻り値: () のコンテキストマネージャ。withで使う。
+
+        Args:
+            webapi_metadata: ``_WEBAPI_MODEL_METADATA`` を上書きする辞書。
+                discovery 経由で登録された WebAPI モデルのメタデータ検証で使う。
+        """
         config_dict = config_dict or {}
         direct_models = direct_models or []
+        webapi_metadata = webapi_metadata or {}
 
         # _config が dict の場合はそれを書き換え、なければ get_all_config を patch
-        return _PatchedRegistryCtx(model_dict, config_dict, direct_models)
+        return _PatchedRegistryCtx(model_dict, config_dict, direct_models, webapi_metadata)
 
     return _setup
 
@@ -65,10 +76,11 @@ def patched_registry():
 class _PatchedRegistryCtx:
     """_MODEL_CLASS_OBJ_REGISTRY と get_all_config と agent_factory を一括 patch するコンテキスト。"""
 
-    def __init__(self, model_dict: dict, config_dict: dict, direct_models: list[str]):
+    def __init__(self, model_dict: dict, config_dict: dict, direct_models: list[str], webapi_metadata: dict):
         self.model_dict = model_dict
         self.config_dict = config_dict
         self.direct_models = direct_models
+        self.webapi_metadata = webapi_metadata
         self._patches: list = []
 
     def __enter__(self):
@@ -77,7 +89,7 @@ class _PatchedRegistryCtx:
 
         self._patches.append(patch.object(registry, "_MODEL_CLASS_OBJ_REGISTRY", self.model_dict))
         self._patches.append(patch.object(registry, "_REGISTRY_INITIALIZED", True))
-        self._patches.append(patch.object(registry, "_WEBAPI_MODEL_METADATA", {}))
+        self._patches.append(patch.object(registry, "_WEBAPI_MODEL_METADATA", self.webapi_metadata))
         # config_registry の get / get_all_config は _merged_config_data を読むので、
         # 内部データを差し替えれば両方一貫した値を返せる。proxy の delattr 問題も回避できる。
         real_registry = get_config_registry()
@@ -413,6 +425,90 @@ def test_parse_discontinued_at_normalizes_quoted_string():
 
     # 予期しない型 → None
     assert _parse_discontinued_at(123, "m") is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_webapi_model_merges_discovery_metadata(patched_registry):
+    """discovery 経由 (`_WEBAPI_MODEL_METADATA`) と config_registry の値を merge した上で
+    AnnotatorInfo を構築する (Codex P2 #22 第 3 指摘)。
+
+    `_register_webapi_models_from_discovery()` は provider/max_output_tokens を
+    `_WEBAPI_MODEL_METADATA` に保存するが、`set_system_value()` は class/api_model_id
+    のみを config_registry に永続化する。両方を merge しないと Phase 2 メタデータが
+    silently dropped される。
+    """
+    # config_registry は class/api_model_id のみ
+    user_config = {
+        "openai/gpt-4o": {
+            "class": "PydanticAIWebAPIAnnotator",
+            "api_model_id": "gpt-4o",
+            "type": "vision",
+            "capabilities": ["tags", "captions"],
+        }
+    }
+    # discovery は provider/max_output_tokens を含む
+    discovery_meta = {
+        "openai/gpt-4o": {
+            "class": "PydanticAIWebAPIAnnotator",
+            "api_model_id": "gpt-4o",
+            "provider": "openai",
+            "max_output_tokens": 1800,
+            "type": "vision",
+            "capabilities": ["tags", "captions"],
+        }
+    }
+    with patched_registry(
+        model_dict={"openai/gpt-4o": PydanticAIWebAPIAnnotator},
+        config_dict=user_config,
+        webapi_metadata=discovery_meta,
+    ):
+        result = list_annotator_info()
+
+    assert len(result) == 1
+    info = result[0]
+    # discovery のメタデータが反映されている (両方を merge した結果)
+    assert info.provider == "openai"
+    assert info.max_output_tokens == 1800
+    assert info.api_model_id == "gpt-4o"
+    assert info.is_api is True
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_user_config_overrides_discovery_metadata(patched_registry):
+    """config_registry の値は discovery メタデータより優先される (merge 優先順位)。"""
+    user_config = {
+        "openai/gpt-4o": {
+            "class": "PydanticAIWebAPIAnnotator",
+            "api_model_id": "gpt-4o",
+            "provider": "user-override",  # ユーザー側で provider を上書き
+            "type": "vision",
+            "capabilities": ["tags"],
+        }
+    }
+    discovery_meta = {
+        "openai/gpt-4o": {
+            "class": "PydanticAIWebAPIAnnotator",
+            "api_model_id": "gpt-4o",
+            "provider": "openai",  # discovery 側はデフォルト
+            "max_output_tokens": 2048,
+            "type": "vision",
+            "capabilities": ["tags"],
+        }
+    }
+    with patched_registry(
+        model_dict={"openai/gpt-4o": PydanticAIWebAPIAnnotator},
+        config_dict=user_config,
+        webapi_metadata=discovery_meta,
+    ):
+        result = list_annotator_info()
+
+    info = result[0]
+    # ユーザー設定の provider が discovery を上書き
+    assert info.provider == "user-override"
+    # ユーザー設定にない max_output_tokens は discovery から取得
+    assert info.max_output_tokens == 2048
 
 
 @pytest.mark.unit

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -351,3 +351,94 @@ def test_discontinued_at_none_for_active_model(patched_registry):
         result = list_annotator_info()
 
     assert result[0].discontinued_at is None
+
+
+# --- safe 型変換ヘルパー (Codex P2 review for #22) ---
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_safe_float_returns_none_for_invalid_value():
+    """malformed な estimated_size_gb は None フォールバック (モデル消失防止)。"""
+    from image_annotator_lib.core.registry import _safe_float
+
+    assert _safe_float(None, "m", "estimated_size_gb") is None
+    assert _safe_float("1.5", "m", "estimated_size_gb") == 1.5
+    assert _safe_float(2.0, "m", "estimated_size_gb") == 2.0
+    assert _safe_float("not-a-number", "m", "estimated_size_gb") is None
+    assert _safe_float([1, 2], "m", "estimated_size_gb") is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_safe_int_returns_none_for_invalid_value():
+    """quoted '1800.0' のような int で parse 不能な値は None フォールバック。"""
+    from image_annotator_lib.core.registry import _safe_int
+
+    assert _safe_int(None, "m", "max_output_tokens") is None
+    assert _safe_int("1800", "m", "max_output_tokens") == 1800
+    assert _safe_int(2048, "m", "max_output_tokens") == 2048
+    # int("1800.0") は ValueError → None フォールバック
+    assert _safe_int("1800.0", "m", "max_output_tokens") is None
+    assert _safe_int("abc", "m", "max_output_tokens") is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_parse_discontinued_at_normalizes_quoted_string():
+    """quoted TOML 文字列 (ISO 8601) は datetime に正規化。"""
+    import datetime as _dt
+
+    from image_annotator_lib.core.registry import _parse_discontinued_at
+
+    # ネイティブ datetime はそのまま
+    native = _dt.datetime(2025, 12, 31, tzinfo=_dt.UTC)
+    assert _parse_discontinued_at(native, "m") is native
+
+    # 普通の ISO 文字列
+    parsed = _parse_discontinued_at("2025-12-31T00:00:00", "m")
+    assert isinstance(parsed, _dt.datetime)
+    assert parsed.year == 2025
+
+    # "Z" suffix → UTC として扱う
+    parsed_utc = _parse_discontinued_at("2025-12-31T00:00:00Z", "m")
+    assert isinstance(parsed_utc, _dt.datetime)
+    assert parsed_utc.tzinfo is not None
+
+    # None はそのまま
+    assert _parse_discontinued_at(None, "m") is None
+
+    # malformed 文字列 → None
+    assert _parse_discontinued_at("not-a-date", "m") is None
+
+    # 予期しない型 → None
+    assert _parse_discontinued_at(123, "m") is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_list_annotator_info_keeps_model_with_invalid_metadata(patched_registry):
+    """estimated_size_gb / max_output_tokens / discontinued_at が malformed でも
+    モデル自体は listing に残り、該当フィールドのみ None になる (Codex P2 #22)。"""
+    with patched_registry(
+        model_dict={"local-tagger": _DummyTagger},
+        config_dict={
+            "local-tagger": {
+                "type": "tagger",
+                "capabilities": ["tags"],
+                "estimated_size_gb": "not-a-number",
+                "max_output_tokens": "1800.0",  # int() では ValueError
+                "discontinued_at": "not-a-date",
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    # モデルは listing から消えていない
+    assert len(result) == 1
+    info = result[0]
+    assert info.name == "local-tagger"
+    # 不正値はすべて None フォールバック
+    assert info.estimated_size_gb is None
+    assert info.max_output_tokens is None
+    assert info.discontinued_at is None


### PR DESCRIPTION
## Summary

Issue #19 Phase 2: `AnnotatorInfo` dataclass に optional フィールド 5 個を追加し、ライブラリ側で完結するメタデータ提供を実現する。

- `provider: str | None` — プロバイダー名 (ローカルは "local"、API モデルは "openai"/"anthropic"/"google" 等)
- `api_model_id: str | None` — 上流 API のモデル識別子
- `estimated_size_gb: float | None` — ローカル ML モデルのダウンロードサイズ推定値
- `discontinued_at: datetime.datetime | None` — 廃止日時 (ADR 0021 LiteLLM 統合互換)
- `max_output_tokens: int | None` — WebAPI のトークン上限

PydanticAI 直接モデル (`provider/model_id` 形式) は config_registry 未登録でも `model_id.split("/", 1)[0]` から provider を自動推論する。

Closes: #19

## Issue #9 取り込み済み

main で先に merge された PR #21 (Issue #9: AnnotationRunner 切り出し) を本ブランチへ merge 済み (`4991d31`)。これにより Phase 2 と Issue #9 の競合解消も完了している。

### 解消した競合

`src/image_annotator_lib/core/types.py` で `AnnotatorInfo` 直下の Phase 2 拡張フィールド追加と、その後ろに新設された `PHashAnnotationResults` (Issue #9) が同領域で衝突。両方を残す形で解消。

## LoRAIro 側との関係

LoRAIro main は **すでに本ブランチの旧 HEAD (`9edadfa`)** を submodule pointer として固定している (PR #227 で先行 merge)。本 PR が main に merge されると、LoRAIro 側で submodule pointer を本 PR の merge commit に更新する別 PR が必要になる。

## Test plan

- [x] `uv run pytest local_packages/image-annotator-lib/tests/unit/fast/` — **70/70 PASS** (Phase 2 fields ロジックを検証する `test_list_annotator_info.py` 14 件含む)
- [ ] integration tests は CI で実行
- [ ] LoRAIro 側 `model_sync_service.py` `MockAnnotatorLibrary` の `AnnotatorInfo(provider=..., api_model_id=..., ...)` が動作することを別 PR で確認

## 関連 ADR

- ADR 0005: lib と app の型境界をアダプタで局所化 → メタデータは lib が責務を持つ
- ADR 0021: LiteLLM 駆動 registry → `discontinued_at` フィールド先行追加で移行パス確保

🤖 Generated with [Claude Code](https://claude.com/claude-code)