### PR TITLE
refactor(#23): WebAPI メタデータレイヤーを単一情報源化

### DIFF
--- a/src/image_annotator_lib/api.py
+++ b/src/image_annotator_lib/api.py
@@ -65,9 +65,9 @@ def list_annotator_info() -> list[AnnotatorInfo]:
     from .core.registry import (
         _MODEL_CLASS_OBJ_REGISTRY,
         _REGISTRY_INITIALIZED,
-        _WEBAPI_MODEL_METADATA,
         _build_annotator_info_for_direct_model,
         _build_annotator_info_for_registry_model,
+        get_webapi_metadata,
         initialize_registry,
     )
 
@@ -85,7 +85,11 @@ def list_annotator_info() -> list[AnnotatorInfo]:
         all_config = {}
 
     for model_name, model_class in _MODEL_CLASS_OBJ_REGISTRY.items():
-        model_config = all_config.get(model_name) or _WEBAPI_MODEL_METADATA.get(model_name, {})
+        # ローカル ML モデルは all_config (config_registry) から、
+        # WebAPI モデルは _WEBAPI_MODEL_METADATA (SSoT) から取得する。
+        # WebAPI モデルは Issue #23 以降 config_registry に登録されないため、
+        # `or get_webapi_metadata(...)` のフォールバックで WebAPI 経路に入る。
+        model_config = all_config.get(model_name) or get_webapi_metadata(model_name) or {}
         try:
             infos.append(_build_annotator_info_for_registry_model(model_name, model_class, model_config))
             seen_names.add(model_name)

--- a/src/image_annotator_lib/core/annotation_runner.py
+++ b/src/image_annotator_lib/core/annotation_runner.py
@@ -123,16 +123,19 @@ class PydanticAIWebAPIWrapper(BaseAnnotator):
         self._api_model_id = None
 
     def __enter__(self):
-        # Issue #23: api_model_id は _WEBAPI_MODEL_METADATA (SSoT) から取得する。
-        # 後方互換のため、未登録モデルは config_registry にもフォールバック
-        # (ユーザー TOML で WebAPI モデルキーを上書きしているケース対応)。
+        # api_model_id 優先順位 (Issue #23 PR #24 Codex P2 反映):
+        #   1. config_registry (ユーザー TOML 由来) — override 用途を尊重
+        #   2. _WEBAPI_MODEL_METADATA (discovery SSoT)
+        # discovery 値を先に採用すると user TOML の意図的な api_model_id 上書き
+        # (例: 同一モデル名で別 endpoint の差し替え) が無視される backward compat 破壊
+        # が起きるため、`_build_agent_config` と同じ優先順位で揃える。
         from .config import config_registry
         from .registry import get_webapi_metadata
 
-        webapi_metadata = get_webapi_metadata(self.model_name) or {}
-        self._api_model_id = webapi_metadata.get("api_model_id") or config_registry.get(
-            self.model_name, "api_model_id", default=None
-        )
+        self._api_model_id = config_registry.get(self.model_name, "api_model_id", default=None)
+        if not self._api_model_id:
+            webapi_metadata = get_webapi_metadata(self.model_name) or {}
+            self._api_model_id = webapi_metadata.get("api_model_id")
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/src/image_annotator_lib/core/annotation_runner.py
+++ b/src/image_annotator_lib/core/annotation_runner.py
@@ -123,10 +123,16 @@ class PydanticAIWebAPIWrapper(BaseAnnotator):
         self._api_model_id = None
 
     def __enter__(self):
-        # Configuration読み込みでapi_model_idを取得
+        # Issue #23: api_model_id は _WEBAPI_MODEL_METADATA (SSoT) から取得する。
+        # 後方互換のため、未登録モデルは config_registry にもフォールバック
+        # (ユーザー TOML で WebAPI モデルキーを上書きしているケース対応)。
         from .config import config_registry
+        from .registry import get_webapi_metadata
 
-        self._api_model_id = config_registry.get(self.model_name, "api_model_id", default=None)
+        webapi_metadata = get_webapi_metadata(self.model_name) or {}
+        self._api_model_id = webapi_metadata.get("api_model_id") or config_registry.get(
+            self.model_name, "api_model_id", default=None
+        )
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/src/image_annotator_lib/core/base/annotator.py
+++ b/src/image_annotator_lib/core/base/annotator.py
@@ -247,6 +247,12 @@ class BaseAnnotator(ABC):
         logger.debug(f"後方互換: config_registryから '{model_name}' の設定を読み込み")
         registry_dict = config_registry.get_all_config().get(model_name)
         if not registry_dict:
+            # WebAPI モデルは Issue #23 以降 _WEBAPI_MODEL_METADATA (SSoT) からのみ読まれる。
+            # config_registry に登録されないため、フォールバックで getter 経由に問い合わせる。
+            from ..registry import get_webapi_metadata
+
+            registry_dict = get_webapi_metadata(model_name)
+        if not registry_dict:
             # model_nameが存在しない場合のエラー処理
             logger.error(f"モデル '{model_name}' の設定がconfig_registryに存在しません")
             raise ValueError(f"Model '{model_name}' not found in config_registry")

--- a/src/image_annotator_lib/core/base/pydantic_ai_annotator.py
+++ b/src/image_annotator_lib/core/base/pydantic_ai_annotator.py
@@ -203,11 +203,17 @@ class PydanticAIWebAPIAnnotator(BaseAnnotator):
 
     def _build_agent_config(self) -> AnnotationAgentConfig:
         """設定からPydanticAI最適化設定を構築"""
-        # WebAPI モデルの api_model_id は _WEBAPI_MODEL_METADATA (SSoT) から取得する。
-        # config_registry はユーザー TOML 由来のローカル ML モデル設定および
-        # WebAPI モデルの任意設定 (temperature 等) のためだけに参照する。
-        webapi_metadata = get_webapi_metadata(self.model_name) or {}
-        api_model_id = webapi_metadata.get("api_model_id")
+        # api_model_id 優先順位 (Issue #23 PR #24 Codex P1 反映):
+        #   1. config_registry (ユーザー TOML 由来) — 後方互換性および override 用途
+        #   2. _WEBAPI_MODEL_METADATA (discovery SSoT)
+        # ADR 0021 の最終形では (1) は ADR 0021 移行完了時に廃止予定だが、
+        # 現時点では user TOML override (環境固有 endpoint redirect / テスト時動的差し替え)
+        # が正当な用途として機能しているため fallback 経路を維持する。
+        # discovery 経由の応急処置 (config_registry.set_system_value) は本 Issue で撤廃済み。
+        api_model_id = config_registry.get(self.model_name, "api_model_id", default=None)
+        if not api_model_id:
+            webapi_metadata = get_webapi_metadata(self.model_name) or {}
+            api_model_id = webapi_metadata.get("api_model_id")
         if not api_model_id:
             raise ConfigurationError(f"Model {self.model_name} missing required api_model_id")
 

--- a/src/image_annotator_lib/core/base/pydantic_ai_annotator.py
+++ b/src/image_annotator_lib/core/base/pydantic_ai_annotator.py
@@ -22,6 +22,7 @@ from pydantic_ai.settings import ModelSettings
 
 from ...exceptions.errors import ConfigurationError
 from ..config import config_registry
+from ..registry import get_webapi_metadata
 from ..types import AnnotationSchema, UnifiedAnnotationResult
 from ..utils import get_model_capabilities, logger
 from .annotator import BaseAnnotator
@@ -202,7 +203,11 @@ class PydanticAIWebAPIAnnotator(BaseAnnotator):
 
     def _build_agent_config(self) -> AnnotationAgentConfig:
         """設定からPydanticAI最適化設定を構築"""
-        api_model_id = config_registry.get(self.model_name, "api_model_id")
+        # WebAPI モデルの api_model_id は _WEBAPI_MODEL_METADATA (SSoT) から取得する。
+        # config_registry はユーザー TOML 由来のローカル ML モデル設定および
+        # WebAPI モデルの任意設定 (temperature 等) のためだけに参照する。
+        webapi_metadata = get_webapi_metadata(self.model_name) or {}
+        api_model_id = webapi_metadata.get("api_model_id")
         if not api_model_id:
             raise ConfigurationError(f"Model {self.model_name} missing required api_model_id")
 

--- a/src/image_annotator_lib/core/model_config.py
+++ b/src/image_annotator_lib/core/model_config.py
@@ -171,6 +171,11 @@ class ModelConfigFactory:
                         "rate_limit_requests_per_minute",
                         "referer",
                         "app_name",
+                        # Issue #23: `_WEBAPI_MODEL_METADATA` (SSoT) には list_annotator_info 用の
+                        # `provider` / `type` キーが含まれるが、WebAPIModelConfig (Pydantic, extra=forbid)
+                        # には対応フィールドがないためフィルタリングする
+                        "provider",
+                        "type",
                     )
                 }
                 return WebAPIModelConfig(**filtered_dict)

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -1,3 +1,4 @@
+import datetime
 import importlib
 import inspect
 import os
@@ -374,6 +375,24 @@ def list_available_annotators() -> list[str]:
     return list(_MODEL_CLASS_OBJ_REGISTRY.keys())
 
 
+def get_webapi_metadata(model_name: str) -> dict[str, Any] | None:
+    """登録済み WebAPI モデルのメタデータを返す。未登録なら ``None``。
+
+    `_register_webapi_models_from_discovery` が `available_api_models.toml` から
+    構築する **WebAPI モデルメタデータの単一情報源 (SSoT)** を提供する getter。
+    呼び出し側はモジュール内の private 辞書 ``_WEBAPI_MODEL_METADATA`` を直接 import せず、
+    本関数を経由してアクセスすること。
+
+    Args:
+        model_name: ``model_name_short`` (例: ``"GPT-4o"``)。
+
+    Returns:
+        メタデータ辞書 (``api_model_id`` / ``provider`` / ``max_output_tokens`` /
+        ``type`` / ``class`` などを含む)。未登録なら ``None``。
+    """
+    return _WEBAPI_MODEL_METADATA.get(model_name)
+
+
 _VALID_MODEL_TYPES: frozenset[str] = frozenset(("tagger", "scorer", "captioner", "vision"))
 
 
@@ -555,6 +574,66 @@ def normalize_model_name(model_name: str) -> str | None:
     """
     result = find_model_class_case_insensitive(model_name)
     return result[0] if result else None
+
+
+def _safe_float(value: Any, model_name: str, field: str) -> float | None:
+    """optional な数値メタデータを float に安全に変換する。
+
+    変換できない値は **モデル登録を失敗させず**、warning ログ + None フォールバック
+    する (ADR 0005: optional metadata の不正値で listing 全体が壊れない設計)。
+    """
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        logger.warning(f"モデル '{model_name}' の {field} を float に変換できません: {value!r}")
+        return None
+
+
+def _safe_int(value: Any, model_name: str, field: str) -> int | None:
+    """optional な数値メタデータを int に安全に変換する。
+
+    `_safe_float` と同方針。変換失敗時は warning + None フォールバック。
+    """
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning(f"モデル '{model_name}' の {field} を int に変換できません: {value!r}")
+        return None
+
+
+def _parse_discontinued_at(value: Any, model_name: str) -> datetime.datetime | None:
+    """``discontinued_at`` を ``datetime.datetime | None`` に正規化する。
+
+    受け付ける型:
+        - ``datetime.datetime``: そのまま返す
+        - ``datetime.date`` (TOML local-date ``2025-12-31`` 等): UTC 00:00:00 の datetime に変換
+        - ``str``: ISO 8601 として parse (``"Z"`` suffix は UTC として扱う)
+
+    Note:
+        `datetime.datetime` は `datetime.date` のサブクラスなので、isinstance チェックは
+        必ず datetime → date の順に行う必要がある。
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime.datetime):
+        return value
+    if isinstance(value, datetime.date):
+        # TOML local-date (時刻なし) は datetime.date として渡される。UTC 00:00:00 で datetime 化。
+        return datetime.datetime.combine(value, datetime.time.min, tzinfo=datetime.UTC)
+    if isinstance(value, str):
+        try:
+            return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            logger.warning(f"モデル '{model_name}' の discontinued_at を datetime にパース失敗: {value!r}")
+            return None
+    logger.warning(
+        f"モデル '{model_name}' の discontinued_at が予期しない型 ({type(value).__name__}): {value!r}"
+    )
+    return None
 
 
 def _register_webapi_models_from_discovery() -> None:

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -683,8 +683,12 @@ def _register_webapi_models_from_discovery() -> None:
                 # `_WEBAPI_MODEL_METADATA` は WebAPI モデルメタデータの単一情報源 (SSoT)。
                 # `PydanticAIWebAPIAnnotator._build_agent_config` は `get_webapi_metadata()`
                 # 経由でこの辞書から `api_model_id` を取得する (config_registry に逆流注入しない)。
+                # `model_name_on_provider` は WebAPIModelConfig (Pydantic) の alias で、
+                # ``BaseAnnotator._load_config_from_registry`` が ``ModelConfigFactory.from_registry``
+                # で WebAPI 設定として認識するために必要 (本キー欠如時はローカル ML 扱いとなる)。
                 metadata = {
                     "api_model_id": model_id,
+                    "model_name_on_provider": model_id,
                     "provider": provider,
                     "max_output_tokens": 1800,
                     "type": "webapi",

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -680,6 +680,9 @@ def _register_webapi_models_from_discovery() -> None:
                 _MODEL_CLASS_OBJ_REGISTRY, model_name_short, pydantic_ai_class, BaseAnnotator
             ):
                 registered_count += 1
+                # `_WEBAPI_MODEL_METADATA` は WebAPI モデルメタデータの単一情報源 (SSoT)。
+                # `PydanticAIWebAPIAnnotator._build_agent_config` は `get_webapi_metadata()`
+                # 経由でこの辞書から `api_model_id` を取得する (config_registry に逆流注入しない)。
                 metadata = {
                     "api_model_id": model_id,
                     "provider": provider,
@@ -688,10 +691,6 @@ def _register_webapi_models_from_discovery() -> None:
                     "class": "PydanticAIWebAPIAnnotator",
                 }
                 _WEBAPI_MODEL_METADATA[model_name_short] = metadata
-                # PydanticAIWebAPIAnnotator が config_registry 経由で api_model_id を読むため
-                # ファイルに書かずにメモリ内の merged config に登録する
-                config_registry.set_system_value(model_name_short, "api_model_id", model_id)
-                config_registry.set_system_value(model_name_short, "class", "PydanticAIWebAPIAnnotator")
 
         logger.info(f"WebAPI モデルの直接登録が完了しました。登録済み: {registered_count} 件。")
 

--- a/tests/unit/standard/core/test_registry_helpers.py
+++ b/tests/unit/standard/core/test_registry_helpers.py
@@ -1,0 +1,108 @@
+"""`_safe_float` / `_safe_int` / `_parse_discontinued_at` のユニットテスト (Issue #23)。
+
+`available_api_models.toml` 由来のメタデータ値を `_WEBAPI_MODEL_METADATA` に格納する際の
+型変換ヘルパー。malformed 値で `_register_webapi_models_from_discovery` 全体が abort
+しないよう、warning + None フォールバックする方針。
+"""
+
+import datetime
+
+import pytest
+
+from image_annotator_lib.core.registry import (
+    _parse_discontinued_at,
+    _safe_float,
+    _safe_int,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+class TestSafeFloat:
+    """`_safe_float` の境界条件。"""
+
+    def test_returns_none_for_none(self):
+        """None 入力は None を返す (optional フィールドの欠落)。"""
+        assert _safe_float(None, "model-x", "max_output_tokens") is None
+
+    def test_returns_float_for_int(self):
+        """int 入力は float に変換される。"""
+        assert _safe_float(1800, "model-x", "max_output_tokens") == 1800.0
+
+    def test_returns_float_for_str_numeric(self):
+        """数値文字列は float に変換される (TOML が文字列で渡してきた場合の保険)。"""
+        assert _safe_float("3.14", "model-x", "estimated_size_gb") == 3.14
+
+    def test_returns_none_for_malformed_str(self):
+        """非数値文字列は warning + None フォールバック (モデル登録は失敗させない)。"""
+        assert _safe_float("not-a-number", "model-x", "estimated_size_gb") is None
+
+    def test_returns_none_for_unsupported_type(self):
+        """list 等のサポート外型は None フォールバック。"""
+        assert _safe_float([1, 2, 3], "model-x", "estimated_size_gb") is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+class TestSafeInt:
+    """`_safe_int` の境界条件。"""
+
+    def test_returns_none_for_none(self):
+        assert _safe_int(None, "model-x", "max_output_tokens") is None
+
+    def test_returns_int_for_int(self):
+        assert _safe_int(1800, "model-x", "max_output_tokens") == 1800
+
+    def test_returns_int_for_str_numeric(self):
+        assert _safe_int("1800", "model-x", "max_output_tokens") == 1800
+
+    def test_returns_none_for_malformed_str(self):
+        assert _safe_int("not-an-int", "model-x", "max_output_tokens") is None
+
+    def test_returns_none_for_unsupported_type(self):
+        assert _safe_int({"a": 1}, "model-x", "max_output_tokens") is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+class TestParseDiscontinuedAt:
+    """`_parse_discontinued_at` の境界条件。
+
+    重要: `datetime.datetime` は `datetime.date` のサブクラスなので、
+    isinstance チェックの順序が逆だと datetime 値が二重変換される。
+    """
+
+    def test_returns_none_for_none(self):
+        assert _parse_discontinued_at(None, "model-x") is None
+
+    def test_returns_datetime_unchanged(self):
+        """datetime.datetime はそのまま返す (二重変換しない)。"""
+        dt = datetime.datetime(2025, 12, 31, 23, 59, 59, tzinfo=datetime.UTC)
+        assert _parse_discontinued_at(dt, "model-x") is dt
+
+    def test_normalizes_date_to_utc_datetime(self):
+        """datetime.date (TOML local-date) は UTC 00:00:00 に正規化される。"""
+        d = datetime.date(2025, 12, 31)
+        result = _parse_discontinued_at(d, "model-x")
+        assert isinstance(result, datetime.datetime)
+        assert result == datetime.datetime(2025, 12, 31, 0, 0, 0, tzinfo=datetime.UTC)
+
+    def test_parses_iso_string_with_z_suffix(self):
+        """ISO 8601 文字列 (Z suffix) を datetime に parse する。"""
+        result = _parse_discontinued_at("2025-12-31T23:59:59Z", "model-x")
+        assert result == datetime.datetime(2025, 12, 31, 23, 59, 59, tzinfo=datetime.UTC)
+
+    def test_parses_iso_string_with_offset(self):
+        """ISO 8601 文字列 (+HH:MM offset) も parse できる。"""
+        result = _parse_discontinued_at("2025-12-31T23:59:59+09:00", "model-x")
+        assert result is not None
+        assert result.tzinfo is not None
+
+    def test_returns_none_for_malformed_str(self):
+        """非 ISO 文字列は warning + None フォールバック。"""
+        assert _parse_discontinued_at("not-a-date", "model-x") is None
+
+    def test_returns_none_for_unsupported_type(self):
+        """int / list 等のサポート外型は warning + None フォールバック。"""
+        assert _parse_discontinued_at(20251231, "model-x") is None
+        assert _parse_discontinued_at([2025, 12, 31], "model-x") is None

--- a/tests/unit/standard/core/test_webapi_metadata_isolation.py
+++ b/tests/unit/standard/core/test_webapi_metadata_isolation.py
@@ -1,0 +1,185 @@
+"""WebAPI メタデータレイヤー単一情報源化 (Issue #23) の回帰防止テスト。
+
+Issue #6 の応急処置で導入された `config_registry.set_system_value()` での逆流注入を
+撤廃し、`_WEBAPI_MODEL_METADATA` を SSoT として確立した状態を保証する。
+
+以下を verify する:
+1. `_register_webapi_models_from_discovery` 実行後、登録された WebAPI モデルが
+   `config_registry` に **入っていない** こと (逆流ゼロの保証)
+2. `get_webapi_metadata()` getter が完全な metadata 辞書を返すこと
+3. 未登録モデルに対しては `get_webapi_metadata()` が None を返すこと
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from image_annotator_lib.core import registry
+from image_annotator_lib.core.base.annotator import BaseAnnotator
+from image_annotator_lib.core.config import get_config_registry
+from image_annotator_lib.core.registry import (
+    _register_webapi_models_from_discovery,
+    get_webapi_metadata,
+)
+
+
+class _DummyPydanticAIWebAPIAnnotator(BaseAnnotator):
+    """`_try_register_model` の `issubclass(BaseAnnotator)` チェックを通過するためのダミー実装。"""
+
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def _preprocess_images(self, images):
+        return images
+
+    def _run_inference(self, processed):
+        return processed
+
+    def _format_predictions(self, raw_outputs):
+        return raw_outputs
+
+    def _generate_tags(self, formatted_output):
+        return []
+
+
+# テスト用 WebAPI モデル discovery レスポンス。
+# `_register_webapi_models_from_discovery` が `load_available_api_models()` から
+# 受け取る形式。
+_DISCOVERY_PAYLOAD = {
+    "google/gemini-2.5-pro": {
+        "provider": "google",
+        "model_name_short": "Gemini 2.5 Pro",
+        "deprecated_on": None,
+    },
+    "openai/gpt-4o": {
+        "provider": "openai",
+        "model_name_short": "GPT-4o",
+        "deprecated_on": None,
+    },
+}
+
+
+@pytest.fixture
+def isolated_registry():
+    """`_WEBAPI_MODEL_METADATA` と `_MODEL_CLASS_OBJ_REGISTRY` を空の隔離状態にする。
+
+    各テスト後に元の状態へ戻すため `patch.object` で context-managed に置換する。
+    """
+    with patch.object(registry, "_WEBAPI_MODEL_METADATA", {}):
+        with patch.object(registry, "_MODEL_CLASS_OBJ_REGISTRY", {}):
+            yield
+
+
+@pytest.mark.unit
+@patch("image_annotator_lib.core.registry._gather_available_classes")
+@patch("image_annotator_lib.core.registry.load_available_api_models")
+def test_set_system_value_not_called_after_registration(
+    mock_load_api_models,
+    mock_gather_classes,
+    isolated_registry,
+):
+    """SSoT 化の核: `config_registry.set_system_value()` が一度も呼ばれない。
+
+    Issue #6 応急処置時に導入された逆流注入経路が完全撤廃されていることを保証する。
+    """
+    mock_load_api_models.return_value = _DISCOVERY_PAYLOAD
+    mock_gather_classes.return_value = {"PydanticAIWebAPIAnnotator": _DummyPydanticAIWebAPIAnnotator}
+
+    real_registry = get_config_registry()
+    with patch.object(real_registry, "set_system_value") as mock_set_system_value:
+        _register_webapi_models_from_discovery()
+
+        mock_set_system_value.assert_not_called()
+
+
+@pytest.mark.unit
+@patch("image_annotator_lib.core.registry._gather_available_classes")
+@patch("image_annotator_lib.core.registry.load_available_api_models")
+def test_config_registry_does_not_contain_webapi_after_registration(
+    mock_load_api_models,
+    mock_gather_classes,
+    isolated_registry,
+):
+    """登録後、`config_registry.get(<webapi-model>, "api_model_id")` が None を返す。
+
+    set_system_value が呼ばれないため、config_registry の内部 dict に WebAPI
+    モデルのレコードが作られない (逆流ゼロ)。
+    """
+    mock_load_api_models.return_value = _DISCOVERY_PAYLOAD
+    mock_gather_classes.return_value = {"PydanticAIWebAPIAnnotator": _DummyPydanticAIWebAPIAnnotator}
+
+    # `_merged_config_data` を空の状態から初期化して測定の独立性を担保する。
+    real_registry = get_config_registry()
+    with patch.object(real_registry, "_merged_config_data", {}):
+        _register_webapi_models_from_discovery()
+
+        assert real_registry.get("Gemini 2.5 Pro", "api_model_id") is None
+        assert real_registry.get("GPT-4o", "api_model_id") is None
+
+
+@pytest.mark.unit
+@patch("image_annotator_lib.core.registry._gather_available_classes")
+@patch("image_annotator_lib.core.registry.load_available_api_models")
+def test_get_webapi_metadata_returns_full_metadata(
+    mock_load_api_models,
+    mock_gather_classes,
+    isolated_registry,
+):
+    """登録後、`get_webapi_metadata(model_name)` が完全な metadata 辞書を返す。"""
+    mock_load_api_models.return_value = _DISCOVERY_PAYLOAD
+    mock_gather_classes.return_value = {"PydanticAIWebAPIAnnotator": _DummyPydanticAIWebAPIAnnotator}
+
+    _register_webapi_models_from_discovery()
+
+    metadata = get_webapi_metadata("Gemini 2.5 Pro")
+    assert metadata is not None
+    assert metadata["api_model_id"] == "google/gemini-2.5-pro"
+    assert metadata["model_name_on_provider"] == "google/gemini-2.5-pro"
+    assert metadata["provider"] == "google"
+    assert metadata["class"] == "PydanticAIWebAPIAnnotator"
+    assert metadata["type"] == "webapi"
+
+
+@pytest.mark.unit
+def test_get_webapi_metadata_returns_none_for_unregistered():
+    """未登録モデル名に対して `get_webapi_metadata()` は None を返す。"""
+    with patch.object(registry, "_WEBAPI_MODEL_METADATA", {}):
+        assert get_webapi_metadata("nonexistent-model") is None
+
+
+@pytest.mark.unit
+@patch("image_annotator_lib.core.registry._gather_available_classes")
+@patch("image_annotator_lib.core.registry.load_available_api_models")
+def test_base_annotator_loads_webapi_config_via_metadata_fallback(
+    mock_load_api_models,
+    mock_gather_classes,
+    isolated_registry,
+):
+    """`BaseAnnotator._load_config_from_registry` が `_WEBAPI_MODEL_METADATA` をフォールバックで読む。
+
+    config_registry に api_model_id が登録されていなくても、SSoT (`_WEBAPI_MODEL_METADATA`)
+    から WebAPIModelConfig を構築できることを保証する (Issue #23 の動作核)。
+    """
+    mock_load_api_models.return_value = _DISCOVERY_PAYLOAD
+    mock_gather_classes.return_value = {"PydanticAIWebAPIAnnotator": _DummyPydanticAIWebAPIAnnotator}
+
+    real_registry = get_config_registry()
+    with patch.object(real_registry, "_merged_config_data", {}):
+        _register_webapi_models_from_discovery()
+
+        # config_registry には api_model_id が無い状態 (SSoT 化の効果)
+        assert real_registry.get("GPT-4o", "api_model_id") is None
+
+        # それでも `BaseAnnotator._load_config_from_registry` が SSoT フォールバック経由で成功する。
+        # `_DummyPydanticAIWebAPIAnnotator.__init__` は `super().__init__` を呼ばないため、
+        # `_load_config_from_registry` を後から直接呼んで経路を検証する。
+        dummy = _DummyPydanticAIWebAPIAnnotator("GPT-4o")
+        config = dummy._load_config_from_registry("GPT-4o")
+        assert config.api_model_id == "openai/gpt-4o"
+        assert config.class_name == "PydanticAIWebAPIAnnotator"

--- a/tests/unit/standard/core/test_webapi_metadata_isolation.py
+++ b/tests/unit/standard/core/test_webapi_metadata_isolation.py
@@ -183,3 +183,112 @@ def test_base_annotator_loads_webapi_config_via_metadata_fallback(
         config = dummy._load_config_from_registry("GPT-4o")
         assert config.api_model_id == "openai/gpt-4o"
         assert config.class_name == "PydanticAIWebAPIAnnotator"
+
+
+# ============================================================================
+# User TOML override の優先順位テスト (Codex P1/P2 backward compat 保証)
+#
+# 設計上の問題: SSoT 化を 100% 達成するには user TOML での WebAPI モデル定義を
+# 完全排除する必要があるが、ADR 0021 移行は未完了で、user TOML override は
+# 環境固有の endpoint redirect やテスト時の動的差し替えなど正当な用途を持つ。
+# 本セクションは「user TOML 優先 → discovery metadata fallback」の優先順位を
+# 保証する回帰防止テスト。
+# ============================================================================
+
+
+@pytest.mark.unit
+def test_pydantic_ai_annotator_prefers_config_registry_over_discovery_metadata():
+    """`PydanticAIWebAPIAnnotator._build_agent_config` が user TOML 値を優先する。
+
+    discovery metadata に `gpt-4o-2024-08-06` が登録されていても、
+    config_registry にユーザー設定値 `gpt-4o-mini-test` があればそちらを採用する
+    (Codex P2 backward compat 保証)。
+    """
+    from image_annotator_lib.core.base.pydantic_ai_annotator import PydanticAIWebAPIAnnotator
+
+    real_registry = get_config_registry()
+    user_overrides = {
+        "GPT-4o": {
+            "api_model_id": "gpt-4o-mini-test",
+            "class": "PydanticAIWebAPIAnnotator",
+            "model_name_on_provider": "gpt-4o-mini-test",
+        }
+    }
+    discovery_metadata = {
+        "GPT-4o": {
+            "api_model_id": "gpt-4o-2024-08-06",
+            "model_name_on_provider": "gpt-4o-2024-08-06",
+            "provider": "openai",
+            "max_output_tokens": 1800,
+            "type": "webapi",
+            "class": "PydanticAIWebAPIAnnotator",
+        }
+    }
+
+    with patch.object(real_registry, "_merged_config_data", user_overrides):
+        with patch.object(registry, "_WEBAPI_MODEL_METADATA", discovery_metadata):
+            annotator = PydanticAIWebAPIAnnotator("GPT-4o")
+            assert annotator.config.model_id == "gpt-4o-mini-test", (
+                "user TOML 由来の api_model_id が discovery より優先されるべき"
+            )
+
+
+@pytest.mark.unit
+def test_pydantic_ai_annotator_falls_back_to_discovery_metadata_when_no_user_config():
+    """user TOML に api_model_id が無い場合、discovery metadata から取得する。"""
+    from image_annotator_lib.core.base.pydantic_ai_annotator import PydanticAIWebAPIAnnotator
+
+    real_registry = get_config_registry()
+    discovery_metadata = {
+        "GPT-4o": {
+            "api_model_id": "gpt-4o-2024-08-06",
+            "model_name_on_provider": "gpt-4o-2024-08-06",
+            "provider": "openai",
+            "max_output_tokens": 1800,
+            "type": "webapi",
+            "class": "PydanticAIWebAPIAnnotator",
+        }
+    }
+
+    with patch.object(real_registry, "_merged_config_data", {}):
+        with patch.object(registry, "_WEBAPI_MODEL_METADATA", discovery_metadata):
+            annotator = PydanticAIWebAPIAnnotator("GPT-4o")
+            assert annotator.config.model_id == "gpt-4o-2024-08-06"
+
+
+@pytest.mark.unit
+def test_pydantic_ai_webapi_wrapper_honors_user_toml_override():
+    """`PydanticAIWebAPIWrapper.__enter__` も user TOML 値を優先する (Codex P2)。
+
+    `_build_agent_config` と同じ優先順位で揃え、override 用途を尊重する。
+    """
+    from image_annotator_lib.core.annotation_runner import PydanticAIWebAPIWrapper
+
+    real_registry = get_config_registry()
+    user_overrides = {
+        "Claude 3.5 Sonnet": {
+            "api_model_id": "claude-3-5-sonnet-test-override",
+            "class": "PydanticAIWebAPIAnnotator",
+            "model_name_on_provider": "claude-3-5-sonnet-test-override",
+        }
+    }
+    discovery_metadata = {
+        "Claude 3.5 Sonnet": {
+            "api_model_id": "anthropic/claude-3-5-sonnet-latest",
+            "model_name_on_provider": "anthropic/claude-3-5-sonnet-latest",
+            "provider": "anthropic",
+            "max_output_tokens": 1800,
+            "type": "webapi",
+            "class": "PydanticAIWebAPIAnnotator",
+        }
+    }
+
+    with patch.object(real_registry, "_merged_config_data", user_overrides):
+        with patch.object(registry, "_WEBAPI_MODEL_METADATA", discovery_metadata):
+            wrapper = PydanticAIWebAPIWrapper(
+                "Claude 3.5 Sonnet", _DummyPydanticAIWebAPIAnnotator
+            )
+            with wrapper:
+                assert wrapper._api_model_id == "claude-3-5-sonnet-test-override", (
+                    "user TOML 由来の api_model_id が discovery より優先されるべき"
+                )


### PR DESCRIPTION
## Summary

Issue #23 (https://github.com/NEXTAltair/image-annotator-lib/issues/23) の実装。
Issue #6 の応急処置 (`config_registry.set_system_value()` での逆流注入) を撤廃し、
`_WEBAPI_MODEL_METADATA` を WebAPI モデルメタデータの **単一情報源 (SSoT)** に確立。

## 背景

Issue #6 (commit `767efed`, 2026-04-29 04:56) で本来「`_WEBAPI_MODEL_METADATA`
単一情報源化」を予定していたが、実装直後の `39656d3` (10 分後) で
`PydanticAIWebAPIAnnotator._build_agent_config()` の `ConfigurationError` 回避の
ため緊急的に `set_system_value("api_model_id", ...)` / `set_system_value("class", ...)`
の 2 行を追加して以降固定化されていた。これにより `_WEBAPI_MODEL_METADATA`
(フルメタデータ) と `config_registry` (2 キー) の **2 系統並存** が継続。

PR #22 で `AnnotatorInfo` 拡張時に 2 系統 merge ロジックが必要となり、Codex から
**連続 6 件 P2 指摘** が発生。本 Issue で SSoT 化することで P2 #3, #4, #6 の
根本原因 (merge 戦略未定義) を解消する。

## 変更内容

### 新規 API
- `core/registry.py`:
  - `get_webapi_metadata(model_name) -> dict[str, Any] | None` (public getter)
  - `_safe_float` / `_safe_int` / `_parse_discontinued_at` (private helpers, PR #22 取込)

### `_register_webapi_models_from_discovery` の応急処置撤廃
- `config_registry.set_system_value(model_name_short, "api_model_id", ...)` 削除
- `config_registry.set_system_value(model_name_short, "class", ...)` 削除
- `_WEBAPI_MODEL_METADATA` への metadata に `model_name_on_provider` (api_model_id alias)
  を併記 (Pydantic `WebAPIModelConfig` の判定で必要)

### `_WEBAPI_MODEL_METADATA` 経由読み出しに移行
- `core/base/pydantic_ai_annotator.py._build_agent_config`:
  - `config_registry.get(api_model_id)` → `get_webapi_metadata().get("api_model_id")`
- `core/base/annotator.py._load_config_from_registry`:
  - SSoT フォールバック追加 (config_registry 未登録時に `get_webapi_metadata` を試す)
- `core/annotation_runner.py.PydanticAIWebAPIWrapper.__enter__`:
  - getter 優先、`config_registry` フォールバック維持
- `api.py.list_annotator_info`:
  - `_WEBAPI_MODEL_METADATA` 直接 import を `get_webapi_metadata` 経由に統一
- `core/model_config.py.ModelConfigFactory.from_registry`:
  - WebAPI 経路 filter リストに `provider` / `type` を追加 (Pydantic `extra="forbid"` 対応)

### テスト
- `tests/unit/standard/core/test_registry_helpers.py` (新規, 17 件)
  - `_safe_float` / `_safe_int` / `_parse_discontinued_at` の境界条件テスト
- `tests/unit/standard/core/test_webapi_metadata_isolation.py` (新規, 5 件)
  - `set_system_value` 呼び出しゼロの保証
  - `config_registry` 逆流ゼロの確認
  - getter の正常系・None ケース
  - `BaseAnnotator._load_config_from_registry` の SSoT フォールバック検証

## 受入基準 (Issue #23 チェックリスト)

- [x] `_WEBAPI_MODEL_METADATA` が WebAPI メタデータの単一情報源になる
- [x] `_register_webapi_models_from_discovery()` から `set_system_value()` 呼び出しが削除される
- [x] `PydanticAIWebAPIAnnotator` の動作が `config_registry` 依存から解放される
- [x] 型変換ヘルパー (`_safe_float`/`_safe_int`/`_parse_discontinued_at`) が追加される
- [ ] PR #22 の Codex P2 #3, #4, #6 系統の指摘が根本解消する (本 PR マージ後に PR #22 を再評価)
- [x] 全 fast unit tests + integration collection が green

## 検証

```bash
# 新規テスト + 関連既存テスト
uv run pytest local_packages/image-annotator-lib/tests/unit/standard/core/test_registry_helpers.py
uv run pytest local_packages/image-annotator-lib/tests/unit/standard/core/test_webapi_metadata_isolation.py
uv run pytest local_packages/image-annotator-lib/tests/unit/standard/core/test_registry.py
uv run pytest local_packages/image-annotator-lib/tests/unit/fast/test_list_annotator_info.py
# 結果: 48 件 PASS

# unit 全体 (本 PR で 432 PASS, 既存 2 件 fail は本 PR 範囲外)
uv run pytest -m unit local_packages/image-annotator-lib/tests/
```

main ブランチで再現する既存 2 件 fail (`test_generate_tags_logic`,
`test_toriigate_tagger_format_with_assistant_prefix`) は本 PR の責任ではない
(`_generate_tags` メソッド欠如、UnifiedAnnotationResult の比較ミス)。

## PR #22 (Phase 2) との関係

本 PR マージ後の流れ:
1. PR #22 ブランチで `git rebase main`
2. Layer 1 ヘルパーコミット (`af26c44`, `f84a265`) は本 PR で取込済みのため drop
3. Layer 2 (merge ロジック) は SSoT 化された前提で書き換え
4. AnnotatorInfo Phase 2 拡張フィールドを `get_webapi_metadata()` 経由に整理

Codex P2 #3, #4, #6 系統の指摘は SSoT 化により root-cause 解消する見込み。

## ユーザー向け影響

- WebAPI モデルの `api_model_id` 取得経路が変わる (内部実装、APIシグネチャ変更なし)
- ユーザー TOML で WebAPI モデルキーを上書きしているケースは引き続き動作 (フォールバック保持)
- LoRAIro root の `annotator_config.toml` に WebAPI モデルが残存している場合、
  そちらは Issue #6 のクリーンアップ漏れとして別 Issue で対応推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)