### PR TITLE
feat(#19/#26): AnnotatorInfo Phase 2 詳細メタデータを SSoT 経由で取得 (PR #22 rebased)

### DIFF
--- a/src/image_annotator_lib/api.py
+++ b/src/image_annotator_lib/api.py
@@ -4,6 +4,8 @@
 本モジュールは公開 API のシグネチャ維持と委譲のみを担う薄い層として設計されている。
 """
 
+from typing import Any
+
 from PIL import Image
 
 from .core.annotation_runner import run_annotation
@@ -94,16 +96,30 @@ def list_annotator_info() -> list[AnnotatorInfo]:
         # 発生していたが、model_class ベースの排他分岐により混入経路が消滅する。
         # `_WEBAPI_MODEL_METADATA` 存在ベース判定にすると、ローカル ML と同名 entry が
         # 偶然 SSoT に居た場合に誤分類するため、model_class ベースの判定が安全。
-        is_webapi_class = model_class.__name__ == "PydanticAIWebAPIAnnotator"
-        user_overrides = all_config.get(model_name)
-        if is_webapi_class:
-            # WebAPI モデル: SSoT base + user TOML override (PR #24 backward compat)
-            webapi_metadata = get_webapi_metadata(model_name) or {}
-            model_config = {**webapi_metadata, **(user_overrides or {})}
-        else:
-            # ローカル ML モデル: user TOML のみ (WebAPI metadata は混入させない)
-            model_config = user_overrides or {}
+        # 注意 (PR #27 Codex P1): merge 処理 (`{**a, **b}`) は b が dict でない場合
+        # `TypeError` を投げるため try ブロック **内** で実施する。malformed user TOML
+        # entry (truthy で dict でない値) で listing 全体が abort することを防ぐ。
         try:
+            is_webapi_class = model_class.__name__ == "PydanticAIWebAPIAnnotator"
+            raw_user_overrides = all_config.get(model_name)
+            user_overrides: dict[str, Any] = (
+                raw_user_overrides if isinstance(raw_user_overrides, dict) else {}
+            )
+            if raw_user_overrides is not None and not isinstance(raw_user_overrides, dict):
+                logger.warning(
+                    f"モデル '{model_name}' の config_registry エントリが dict ではありません "
+                    f"(取得型: {type(raw_user_overrides).__name__})。空 dict として扱います。"
+                )
+            if is_webapi_class:
+                # WebAPI モデル: SSoT base + user TOML override (PR #24 backward compat)
+                raw_webapi_metadata = get_webapi_metadata(model_name)
+                webapi_metadata: dict[str, Any] = (
+                    raw_webapi_metadata if isinstance(raw_webapi_metadata, dict) else {}
+                )
+                model_config = {**webapi_metadata, **user_overrides}
+            else:
+                # ローカル ML モデル: user TOML のみ (WebAPI metadata は混入させない)
+                model_config = user_overrides
             infos.append(_build_annotator_info_for_registry_model(model_name, model_class, model_config))
             seen_names.add(model_name)
         except Exception as e:

--- a/src/image_annotator_lib/api.py
+++ b/src/image_annotator_lib/api.py
@@ -85,11 +85,24 @@ def list_annotator_info() -> list[AnnotatorInfo]:
         all_config = {}
 
     for model_name, model_class in _MODEL_CLASS_OBJ_REGISTRY.items():
-        # ローカル ML モデルは all_config (config_registry) から、
-        # WebAPI モデルは _WEBAPI_MODEL_METADATA (SSoT) から取得する。
-        # WebAPI モデルは Issue #23 以降 config_registry に登録されないため、
-        # `or get_webapi_metadata(...)` のフォールバックで WebAPI 経路に入る。
-        model_config = all_config.get(model_name) or get_webapi_metadata(model_name) or {}
+        # WebAPI モデル / ローカル ML モデルの排他分岐 (Issue #26 Codex P2 #6 根本対応):
+        #   - 判定基準: **model_class が PydanticAIWebAPIAnnotator か** (model_name 同名衝突に左右されない)
+        #   - WebAPI モデル: `_WEBAPI_MODEL_METADATA` (SSoT) を base、user TOML で上書き
+        #   - ローカル ML モデル: `config_registry` (user TOML) のみ参照
+        # 旧来の `or` フォールバック方式 (PR #22) では discovery 経由の `api_model_id`
+        # がローカル ML モデルに混入し `_requires_api_key` が誤分類する Codex P2 #6 が
+        # 発生していたが、model_class ベースの排他分岐により混入経路が消滅する。
+        # `_WEBAPI_MODEL_METADATA` 存在ベース判定にすると、ローカル ML と同名 entry が
+        # 偶然 SSoT に居た場合に誤分類するため、model_class ベースの判定が安全。
+        is_webapi_class = model_class.__name__ == "PydanticAIWebAPIAnnotator"
+        user_overrides = all_config.get(model_name)
+        if is_webapi_class:
+            # WebAPI モデル: SSoT base + user TOML override (PR #24 backward compat)
+            webapi_metadata = get_webapi_metadata(model_name) or {}
+            model_config = {**webapi_metadata, **(user_overrides or {})}
+        else:
+            # ローカル ML モデル: user TOML のみ (WebAPI metadata は混入させない)
+            model_config = user_overrides or {}
         try:
             infos.append(_build_annotator_info_for_registry_model(model_name, model_class, model_config))
             seen_names.add(model_name)

--- a/src/image_annotator_lib/core/model_config.py
+++ b/src/image_annotator_lib/core/model_config.py
@@ -176,6 +176,9 @@ class ModelConfigFactory:
                         # には対応フィールドがないためフィルタリングする
                         "provider",
                         "type",
+                        # Issue #26: Phase 2 詳細メタデータ。AnnotatorInfo 構築専用で
+                        # WebAPIModelConfig 自体のフィールドではない
+                        "discontinued_at",
                     )
                 }
                 return WebAPIModelConfig(**filtered_dict)

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -686,11 +686,22 @@ def _register_webapi_models_from_discovery() -> None:
                 # `model_name_on_provider` は WebAPIModelConfig (Pydantic) の alias で、
                 # ``BaseAnnotator._load_config_from_registry`` が ``ModelConfigFactory.from_registry``
                 # で WebAPI 設定として認識するために必要 (本キー欠如時はローカル ML 扱いとなる)。
+                # Phase 2 (Issue #19/#26): AnnotatorInfo の詳細メタデータフィールドを SSoT に集約。
+                # max_output_tokens は TOML 由来値があれば採用、なければ 1800 default。
+                # estimated_size_gb は WebAPI モデルでは原則 None (ローカル ML 専用フィールド)。
+                # discontinued_at は active のみ登録するため None で明示 (deprecated は line 668 で skip)。
                 metadata = {
                     "api_model_id": model_id,
                     "model_name_on_provider": model_id,
                     "provider": provider,
-                    "max_output_tokens": 1800,
+                    "max_output_tokens": _safe_int(
+                        model_info.get("max_output_tokens"), model_id, "max_output_tokens"
+                    )
+                    or 1800,
+                    "estimated_size_gb": _safe_float(
+                        model_info.get("estimated_size_gb"), model_id, "estimated_size_gb"
+                    ),
+                    "discontinued_at": None,
                     "type": "webapi",
                     "class": "PydanticAIWebAPIAnnotator",
                 }

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -566,8 +566,10 @@ def _build_annotator_info_for_registry_model(
     # provider は lowercase 正規化 (PR #27 Codex P2 反映): user TOML/discovery/直接モデルで
     # case が混在しても AnnotatorInfo.provider は常に小文字で一貫する。
     raw_provider = model_config.get("provider")
+    # ローカルMLモデルは provider を "local" に固定 (Codex P2 r3193126501):
+    # user TOML に誤って provider キーが含まれても is_local=True との矛盾を防ぐ。
     provider: str | None = (
-        str(raw_provider).lower() if raw_provider is not None else ("local" if is_local else None)
+        "local" if is_local else (str(raw_provider).lower() if raw_provider is not None else None)
     )
 
     raw_api_model_id = model_config.get("api_model_id")

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -509,6 +509,33 @@ def _resolve_registry_capabilities(model_name: str, is_api: bool) -> frozenset[T
     return frozenset()
 
 
+def _infer_provider_from_model_id(model_id: str) -> str | None:
+    """PydanticAI 直接モデルの ``provider`` を model_id から推論する。
+
+    "provider/model_name" 形式 (例: "google/gemini-2.5-pro") は slash 前を返す。
+    slash のない model_id は PydanticAI の infer_provider_class でフォールバック。
+
+    Args:
+        model_id: PydanticAI 直接モデルの ID。
+
+    Returns:
+        推論された provider 名。判定できない場合は None。
+    """
+    if "/" in model_id:
+        return model_id.split("/", 1)[0]
+    try:
+        from pydantic_ai.providers import infer_provider_class
+
+        cls = infer_provider_class(model_id)
+        cls_name = (type(cls).__name__ if not isinstance(cls, type) else cls.__name__).lower()
+        for known in ("openai", "anthropic", "google"):
+            if known in cls_name:
+                return known
+    except Exception:
+        pass
+    return None
+
+
 def _build_annotator_info_for_registry_model(
     model_name: str, model_class: ModelClass, model_config: dict[str, Any]
 ) -> AnnotatorInfo:
@@ -517,7 +544,9 @@ def _build_annotator_info_for_registry_model(
     Args:
         model_name: モデル名 (レジストリキー)
         model_class: モデルクラス
-        model_config: TOML 由来の設定辞書 (空辞書の場合もある)
+        model_config: model_config の出所 (排他分岐):
+            - WebAPI モデル: `_WEBAPI_MODEL_METADATA` (SSoT) + user TOML override
+            - ローカル ML モデル: `config_registry` (user TOML)
 
     Returns:
         AnnotatorInfo: 型安全なメタデータ
@@ -526,6 +555,18 @@ def _build_annotator_info_for_registry_model(
     is_local = not is_api
     device = model_config.get("device") if is_local else None
 
+    # Phase 2 (Issue #19/#26): 詳細メタデータを model_config から取得。
+    # `_safe_float` / `_safe_int` / `_parse_discontinued_at` は malformed 値で
+    # warning + None フォールバックする (Codex P2 #1, #2, #5 の根本対応)。
+    # `provider` はローカルモデルなら "local" にフォールバック (ADR 0005)。
+    raw_provider = model_config.get("provider")
+    provider: str | None = (
+        str(raw_provider) if raw_provider is not None else ("local" if is_local else None)
+    )
+
+    raw_api_model_id = model_config.get("api_model_id")
+    api_model_id: str | None = str(raw_api_model_id) if raw_api_model_id is not None else None
+
     return AnnotatorInfo(
         name=model_name,
         model_type=_determine_model_type(model_name, model_class, model_config),
@@ -533,6 +574,15 @@ def _build_annotator_info_for_registry_model(
         is_local=is_local,
         is_api=is_api,
         device=device if isinstance(device, str) else None,
+        provider=provider,
+        api_model_id=api_model_id,
+        estimated_size_gb=_safe_float(
+            model_config.get("estimated_size_gb"), model_name, "estimated_size_gb"
+        ),
+        discontinued_at=_parse_discontinued_at(model_config.get("discontinued_at"), model_name),
+        max_output_tokens=_safe_int(
+            model_config.get("max_output_tokens"), model_name, "max_output_tokens"
+        ),
     )
 
 
@@ -550,6 +600,7 @@ def _build_annotator_info_for_direct_model(model_id: str) -> AnnotatorInfo:
 
     Returns:
         AnnotatorInfo: 型安全なメタデータ。model_type は "vision" 固定 (汎用 VLM)。
+        Phase 2 拡張で `provider` は model_id から推論、`api_model_id` は model_id 自体。
     """
     from .simplified_agent_wrapper import SimplifiedAgentWrapper  # 循環 import 回避のため遅延
 
@@ -560,6 +611,8 @@ def _build_annotator_info_for_direct_model(model_id: str) -> AnnotatorInfo:
         is_local=False,
         is_api=True,
         device=None,
+        provider=_infer_provider_from_model_id(model_id),
+        api_model_id=model_id,  # 直接モデルは model_id 自体が上流 API の識別子
     )
 
 

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -515,14 +515,18 @@ def _infer_provider_from_model_id(model_id: str) -> str | None:
     "provider/model_name" 形式 (例: "google/gemini-2.5-pro") は slash 前を返す。
     slash のない model_id は PydanticAI の infer_provider_class でフォールバック。
 
+    戻り値は **常に lowercase** で正規化する (PR #27 Codex P2 反映): registry-backed
+    WebAPI モデル / direct モデル / user TOML override の各経路で provider 名が
+    case-sensitive に一貫することを保証する。
+
     Args:
         model_id: PydanticAI 直接モデルの ID。
 
     Returns:
-        推論された provider 名。判定できない場合は None。
+        推論された provider 名 (小文字)。判定できない場合は None。
     """
     if "/" in model_id:
-        return model_id.split("/", 1)[0]
+        return model_id.split("/", 1)[0].lower()
     try:
         from pydantic_ai.providers import infer_provider_class
 
@@ -559,9 +563,11 @@ def _build_annotator_info_for_registry_model(
     # `_safe_float` / `_safe_int` / `_parse_discontinued_at` は malformed 値で
     # warning + None フォールバックする (Codex P2 #1, #2, #5 の根本対応)。
     # `provider` はローカルモデルなら "local" にフォールバック (ADR 0005)。
+    # provider は lowercase 正規化 (PR #27 Codex P2 反映): user TOML/discovery/直接モデルで
+    # case が混在しても AnnotatorInfo.provider は常に小文字で一貫する。
     raw_provider = model_config.get("provider")
     provider: str | None = (
-        str(raw_provider) if raw_provider is not None else ("local" if is_local else None)
+        str(raw_provider).lower() if raw_provider is not None else ("local" if is_local else None)
     )
 
     raw_api_model_id = model_config.get("api_model_id")
@@ -743,10 +749,14 @@ def _register_webapi_models_from_discovery() -> None:
                 # max_output_tokens は TOML 由来値があれば採用、なければ 1800 default。
                 # estimated_size_gb は WebAPI モデルでは原則 None (ローカル ML 専用フィールド)。
                 # discontinued_at は active のみ登録するため None で明示 (deprecated は line 668 で skip)。
+                # provider は lowercase 正規化 (PR #27 Codex P2 反映):
+                #   `available_api_models.toml` は "OpenAI"/"Google" の display-case で記述されるが
+                #   `_infer_provider_from_model_id` の slash 経由出力は小文字 ("openai"/"google") のため
+                #   AnnotatorInfo.provider が混在する case-sensitive 不整合を解消する。
                 metadata = {
                     "api_model_id": model_id,
                     "model_name_on_provider": model_id,
-                    "provider": provider,
+                    "provider": str(provider).lower(),
                     "max_output_tokens": _safe_int(
                         model_info.get("max_output_tokens"), model_id, "max_output_tokens"
                     )

--- a/src/image_annotator_lib/core/types.py
+++ b/src/image_annotator_lib/core/types.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import datetime
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict, Union
@@ -408,6 +409,18 @@ class AnnotatorInfo:
     is_local: bool
     is_api: bool
     device: str | None = None
+    # --- Phase 2: 詳細メタデータ (Issue #19/#26, ADR 0005 責務境界: lib 側で統一提供) ---
+    provider: str | None = None
+    """プロバイダー名。ローカルモデルは "local"、API モデルは "openai"/"anthropic"/"google" 等。
+    config_registry に未登録の PydanticAI 直接モデルは model_id の slash 前から推論。"""
+    api_model_id: str | None = None
+    """上流 API のモデル識別子 (例: "gpt-4o-2024-11-20")。ローカルモデルは None。"""
+    estimated_size_gb: float | None = None
+    """ローカル ML モデルのダウンロードサイズ推定値 (GB)。API モデルは None。"""
+    discontinued_at: datetime.datetime | None = None
+    """廃止日時。現役モデルは None (ADR 0021: LiteLLM 統合後は LiteLLM 由来に切替予定)。"""
+    max_output_tokens: int | None = None
+    """WebAPI 呼び出し時のトークン上限。API モデルのみ設定。ローカルモデルは None。"""
 
 
 # --- pHash ベースの結果コンテナ (Issue #9) ---

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -51,13 +51,26 @@ def patched_registry():
     """`_MODEL_CLASS_OBJ_REGISTRY` を直接書き換えるためのフィクスチャ。
     呼び出し側が辞書と config を渡す。"""
 
-    def _setup(model_dict: dict, config_dict: dict | None = None, direct_models: list[str] | None = None):
-        """戻り値: () のコンテキストマネージャ。withで使う。"""
+    def _setup(
+        model_dict: dict,
+        config_dict: dict | None = None,
+        direct_models: list[str] | None = None,
+        webapi_metadata: dict | None = None,
+    ):
+        """戻り値: () のコンテキストマネージャ。withで使う。
+
+        Args:
+            model_dict: `_MODEL_CLASS_OBJ_REGISTRY` に設定するモデル名→クラス辞書
+            config_dict: `config_registry._merged_config_data` に設定する辞書
+            direct_models: PydanticAI 直接モデルの ID リスト
+            webapi_metadata: `_WEBAPI_MODEL_METADATA` (SSoT) に設定する辞書 (Issue #26)
+        """
         config_dict = config_dict or {}
         direct_models = direct_models or []
+        webapi_metadata = webapi_metadata or {}
 
         # _config が dict の場合はそれを書き換え、なければ get_all_config を patch
-        return _PatchedRegistryCtx(model_dict, config_dict, direct_models)
+        return _PatchedRegistryCtx(model_dict, config_dict, direct_models, webapi_metadata)
 
     return _setup
 
@@ -65,10 +78,17 @@ def patched_registry():
 class _PatchedRegistryCtx:
     """_MODEL_CLASS_OBJ_REGISTRY と get_all_config と agent_factory を一括 patch するコンテキスト。"""
 
-    def __init__(self, model_dict: dict, config_dict: dict, direct_models: list[str]):
+    def __init__(
+        self,
+        model_dict: dict,
+        config_dict: dict,
+        direct_models: list[str],
+        webapi_metadata: dict | None = None,
+    ):
         self.model_dict = model_dict
         self.config_dict = config_dict
         self.direct_models = direct_models
+        self.webapi_metadata = webapi_metadata or {}
         self._patches: list = []
 
     def __enter__(self):
@@ -77,7 +97,7 @@ class _PatchedRegistryCtx:
 
         self._patches.append(patch.object(registry, "_MODEL_CLASS_OBJ_REGISTRY", self.model_dict))
         self._patches.append(patch.object(registry, "_REGISTRY_INITIALIZED", True))
-        self._patches.append(patch.object(registry, "_WEBAPI_MODEL_METADATA", {}))
+        self._patches.append(patch.object(registry, "_WEBAPI_MODEL_METADATA", self.webapi_metadata))
         # config_registry の get / get_all_config は _merged_config_data を読むので、
         # 内部データを差し替えれば両方一貫した値を返せる。proxy の delattr 問題も回避できる。
         real_registry = get_config_registry()
@@ -254,3 +274,220 @@ def test_invariants_is_local_xor_is_api(patched_registry):
 
     # frozenset により hashable であることを確認 (frozen=True dataclass の必須条件)
     assert hash(result[0]) is not None
+
+
+# ============================================================================
+# Phase 2: AnnotatorInfo 詳細メタデータフィールド (Issue #26)
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_local_ml_model_has_provider_local_and_estimated_size(patched_registry):
+    """ローカル ML モデルは `provider="local"`, `estimated_size_gb` 取得, `api_model_id=None`。"""
+    with patched_registry(
+        model_dict={"wd-v1-4-tagger": _DummyTagger},
+        config_dict={
+            "wd-v1-4-tagger": {
+                "type": "tagger",
+                "device": "cuda",
+                "capabilities": ["tags"],
+                "estimated_size_gb": 1.5,
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    info = result[0]
+    assert info.provider == "local"
+    assert info.api_model_id is None
+    assert info.estimated_size_gb == 1.5
+    assert info.discontinued_at is None
+    assert info.max_output_tokens is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_webapi_model_phase2_fields_from_ssot(patched_registry):
+    """WebAPI モデルは `_WEBAPI_MODEL_METADATA` (SSoT) から Phase 2 フィールドを取得。"""
+    with patched_registry(
+        model_dict={"GPT-4o": PydanticAIWebAPIAnnotator},
+        webapi_metadata={
+            "GPT-4o": {
+                "api_model_id": "openai/gpt-4o",
+                "model_name_on_provider": "openai/gpt-4o",
+                "provider": "openai",
+                "max_output_tokens": 1800,
+                "estimated_size_gb": None,
+                "discontinued_at": None,
+                "type": "webapi",
+                "class": "PydanticAIWebAPIAnnotator",
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    info = result[0]
+    assert info.provider == "openai"
+    assert info.api_model_id == "openai/gpt-4o"
+    assert info.max_output_tokens == 1800
+    assert info.estimated_size_gb is None
+    assert info.discontinued_at is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_webapi_model_user_toml_overrides_ssot(patched_registry):
+    """WebAPI モデルで user TOML が SSoT より優先される (PR #24 backward compat 維持)。"""
+    with patched_registry(
+        model_dict={"GPT-4o": PydanticAIWebAPIAnnotator},
+        config_dict={
+            "GPT-4o": {
+                "api_model_id": "openai/gpt-4o-test-override",
+                "max_output_tokens": 9999,
+            }
+        },
+        webapi_metadata={
+            "GPT-4o": {
+                "api_model_id": "openai/gpt-4o",
+                "model_name_on_provider": "openai/gpt-4o",
+                "provider": "openai",
+                "max_output_tokens": 1800,
+                "estimated_size_gb": None,
+                "discontinued_at": None,
+                "type": "webapi",
+                "class": "PydanticAIWebAPIAnnotator",
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    info = result[0]
+    # user TOML 値が優先される
+    assert info.api_model_id == "openai/gpt-4o-test-override"
+    assert info.max_output_tokens == 9999
+    # user TOML に provider が無いので SSoT 値が採用される (merge 動作確認)
+    assert info.provider == "openai"
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_local_ml_excludes_webapi_metadata_codex_p2_6(patched_registry):
+    """Codex P2 #6 回帰防止: ローカル ML モデルに同名 WebAPI metadata は混入しない。
+
+    PR #22 旧実装では `or` フォールバックで `_WEBAPI_MODEL_METADATA` 由来の
+    `api_model_id` がローカル ML モデルに混入し、`_requires_api_key` が誤分類していた。
+    Issue #26 の排他分岐で WebAPI metadata はローカル ML 経路に流れない。
+    """
+    with patched_registry(
+        model_dict={"shared-name": _DummyTagger},
+        config_dict={
+            "shared-name": {
+                "type": "tagger",
+                "device": "cpu",
+                "capabilities": ["tags"],
+            }
+        },
+        webapi_metadata={
+            "shared-name": {
+                "api_model_id": "should-not-leak",
+                "model_name_on_provider": "should-not-leak",
+                "provider": "openai",
+                "max_output_tokens": 1800,
+                "estimated_size_gb": None,
+                "discontinued_at": None,
+                "type": "webapi",
+                "class": "PydanticAIWebAPIAnnotator",
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    info = result[0]
+    # ローカル ML モデルとして分類される (排他分岐の効果)
+    assert info.is_local is True
+    assert info.is_api is False
+    # WebAPI 由来の `api_model_id` は混入しない
+    assert info.api_model_id is None
+    # provider はローカル "local" にフォールバック
+    assert info.provider == "local"
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_phase2_safe_helpers_handle_malformed_metadata(patched_registry):
+    """Codex P2 #1, #2 回帰防止: malformed metadata 値でモデル消失しない。
+
+    `_safe_float` / `_safe_int` / `_parse_discontinued_at` が malformed 値を
+    warning + None フォールバックする (Issue #23 で取込済みヘルパーの効果)。
+    """
+    with patched_registry(
+        model_dict={"GPT-4o": PydanticAIWebAPIAnnotator},
+        webapi_metadata={
+            "GPT-4o": {
+                "api_model_id": "openai/gpt-4o",
+                "model_name_on_provider": "openai/gpt-4o",
+                "provider": "openai",
+                "max_output_tokens": "not-an-int",  # malformed
+                "estimated_size_gb": "not-a-float",  # malformed
+                "discontinued_at": "not-a-date",  # malformed
+                "type": "webapi",
+                "class": "PydanticAIWebAPIAnnotator",
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    # malformed 値が来てもモデルが listing から消えない
+    assert len(result) == 1
+    info = result[0]
+    assert info.name == "GPT-4o"
+    # 各フィールドが None フォールバック
+    assert info.max_output_tokens is None
+    assert info.estimated_size_gb is None
+    assert info.discontinued_at is None
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_pydanticai_direct_model_has_inferred_provider_and_api_model_id(patched_registry):
+    """PydanticAI 直接モデルは model_id から provider 推論 + api_model_id=model_id。"""
+    with patched_registry(
+        model_dict={},
+        direct_models=["google/gemini-2.5-pro", "anthropic/claude-3-5-sonnet-latest"],
+    ):
+        result = list_annotator_info()
+
+    by_name = {info.name: info for info in result}
+    assert by_name["google/gemini-2.5-pro"].provider == "google"
+    assert by_name["google/gemini-2.5-pro"].api_model_id == "google/gemini-2.5-pro"
+    assert by_name["anthropic/claude-3-5-sonnet-latest"].provider == "anthropic"
+    assert by_name["anthropic/claude-3-5-sonnet-latest"].api_model_id == "anthropic/claude-3-5-sonnet-latest"
+
+
+# ============================================================================
+# `_infer_provider_from_model_id` ユニットテスト
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_infer_provider_from_slash_format():
+    """`provider/model_name` 形式は slash 前を返す。"""
+    from image_annotator_lib.core.registry import _infer_provider_from_model_id
+
+    assert _infer_provider_from_model_id("google/gemini-2.5-pro") == "google"
+    assert _infer_provider_from_model_id("openai/gpt-4o") == "openai"
+    assert _infer_provider_from_model_id("anthropic/claude-3-5-sonnet") == "anthropic"
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_infer_provider_falls_back_for_non_slash_model_id():
+    """slash の無い model_id は infer_provider_class フォールバックを試みる。"""
+    from image_annotator_lib.core.registry import _infer_provider_from_model_id
+
+    # 既知の OpenAI モデル名 (slash なし) → "openai" 推論期待
+    # PydanticAI 内部実装変更で None になる可能性も許容するが、例外は raise しないこと
+    result = _infer_provider_from_model_id("gpt-4o")
+    assert result is None or isinstance(result, str)

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -491,3 +491,85 @@ def test_infer_provider_falls_back_for_non_slash_model_id():
     # PydanticAI 内部実装変更で None になる可能性も許容するが、例外は raise しないこと
     result = _infer_provider_from_model_id("gpt-4o")
     assert result is None or isinstance(result, str)
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_malformed_user_overrides_skips_only_bad_model(patched_registry):
+    """PR #27 Codex P1 回帰防止: malformed user TOML entry で listing 全体が abort しない。
+
+    `config_registry.get_all_config()` が dict 以外の truthy 値 (例: 文字列) を
+    返した場合、`{**webapi_metadata, **user_overrides}` で TypeError が発生する。
+    旧来の `or` フォールバック方式では TypeError が起きなかったため、本 PR の
+    排他分岐への切替で再導入された regression を防ぐ。
+    """
+    # 正常モデル + malformed entry を持つモデルを混在させる
+    with patched_registry(
+        model_dict={
+            "good-tagger": _DummyTagger,
+            "broken-tagger": _DummyTagger,
+        },
+        config_dict={
+            "good-tagger": {"type": "tagger", "device": "cpu", "capabilities": ["tags"]},
+            "broken-tagger": "this-is-a-string-not-a-dict",  # malformed (truthy + 非 dict)
+        },
+    ):
+        result = list_annotator_info()
+
+    # broken-tagger は構築失敗で skip されるが、good-tagger は listing に残る
+    names = {info.name for info in result}
+    assert "good-tagger" in names, "正常なモデルは listing に残るべき"
+    # broken-tagger は skip (空 dict として扱われ Phase 2 フィールド全て None)
+    # 厳密な仕様: 空 dict として AnnotatorInfo が構築される (model_class からの推論で動く)
+    # listing 全体が abort しないことが核心
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_malformed_webapi_user_override_does_not_abort_listing(patched_registry):
+    """PR #27 Codex P1 回帰防止 (WebAPI 側): malformed user override が来ても listing 全体が abort しない。
+
+    `config_registry._merged_config_data["BrokenWebAPI"] = int` のような malformed entry
+    があると、`get_model_capabilities` 等が内部で `int.get(...)` を呼んで AttributeError を
+    投げるが、`api.py.list_annotator_info` の try/except で該当モデル個別を skip し、
+    他のモデル (GoodWebAPI) は listing に残ることを保証する。
+    """
+    with patched_registry(
+        model_dict={
+            "GoodWebAPI": PydanticAIWebAPIAnnotator,
+            "BrokenWebAPI": PydanticAIWebAPIAnnotator,
+        },
+        config_dict={
+            "BrokenWebAPI": 12345,  # malformed (truthy + 非 dict、int)
+        },
+        webapi_metadata={
+            "GoodWebAPI": {
+                "api_model_id": "openai/gpt-4o",
+                "model_name_on_provider": "openai/gpt-4o",
+                "provider": "openai",
+                "max_output_tokens": 1800,
+                "estimated_size_gb": None,
+                "discontinued_at": None,
+                "type": "webapi",
+                "class": "PydanticAIWebAPIAnnotator",
+            },
+            "BrokenWebAPI": {
+                "api_model_id": "anthropic/claude-3-opus",
+                "model_name_on_provider": "anthropic/claude-3-opus",
+                "provider": "anthropic",
+                "max_output_tokens": 1800,
+                "estimated_size_gb": None,
+                "discontinued_at": None,
+                "type": "webapi",
+                "class": "PydanticAIWebAPIAnnotator",
+            },
+        },
+    ):
+        result = list_annotator_info()
+
+    # listing 全体は abort せず、正常な GoodWebAPI は残る (Codex P1 の核心)
+    names = {info.name for info in result}
+    assert "GoodWebAPI" in names, "正常なモデルは listing に残るべき (listing 全体 abort 防止)"
+    # BrokenWebAPI は内部処理で別ルート (get_model_capabilities → config_registry.get) の
+    # AttributeError が発生するが try/except で skip される
+    # 重要なのは「全体が abort しない」こと、個別 skip かどうかは実装詳細

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -526,6 +526,86 @@ def test_malformed_user_overrides_skips_only_bad_model(patched_registry):
 
 @pytest.mark.unit
 @pytest.mark.fast
+def test_provider_normalized_to_lowercase_across_sources(patched_registry):
+    """PR #27 Codex P2 回帰防止: provider 名は出所に関係なく lowercase に正規化される。
+
+    `available_api_models.toml` は "OpenAI"/"Google" の display-case で記述されるが、
+    `_infer_provider_from_model_id` の slash 経由出力は "openai"/"google" の小文字。
+    AnnotatorInfo.provider が混在すると case-sensitive consumer が誤分類する。
+    本テストは 3 経路 (registry/SSoT/直接モデル) すべてで lowercase で一貫することを保証する。
+    """
+    with patched_registry(
+        # Registry-backed WebAPI モデル: SSoT の display-case provider を持つ
+        model_dict={"GPT-4o": PydanticAIWebAPIAnnotator},
+        webapi_metadata={
+            "GPT-4o": {
+                "api_model_id": "openai/gpt-4o",
+                "model_name_on_provider": "openai/gpt-4o",
+                "provider": "OpenAI",  # ← display-case (TOML 記述)
+                "max_output_tokens": 1800,
+                "estimated_size_gb": None,
+                "discontinued_at": None,
+                "type": "webapi",
+                "class": "PydanticAIWebAPIAnnotator",
+            }
+        },
+        # 直接モデル: model_id slash 前から推論 (既に小文字)
+        direct_models=["google/gemini-2.5-pro", "anthropic/claude-3-5-sonnet-latest"],
+    ):
+        result = list_annotator_info()
+
+    by_name = {info.name: info for info in result}
+    # registry-backed: SSoT の "OpenAI" が "openai" に正規化されている
+    assert by_name["GPT-4o"].provider == "openai", (
+        f"registry-backed WebAPI provider が小文字でない: {by_name['GPT-4o'].provider!r}"
+    )
+    # direct モデル: 既に小文字 (一貫性確認)
+    assert by_name["google/gemini-2.5-pro"].provider == "google"
+    assert by_name["anthropic/claude-3-5-sonnet-latest"].provider == "anthropic"
+
+    # 全 provider が小文字 (case-sensitive consumer 向けの不変条件)
+    for info in result:
+        if info.provider is not None:
+            assert info.provider == info.provider.lower(), (
+                f"{info.name}: provider が小文字でない: {info.provider!r}"
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_user_toml_provider_also_normalized(patched_registry):
+    """user TOML 由来の `provider` も lowercase 正規化される (PR #27 Codex P2)。"""
+    with patched_registry(
+        model_dict={"CustomAPI": PydanticAIWebAPIAnnotator},
+        config_dict={
+            "CustomAPI": {
+                "api_model_id": "custom/model",
+                "provider": "Anthropic",  # ← user TOML での display-case
+            }
+        },
+        webapi_metadata={
+            "CustomAPI": {
+                "api_model_id": "anthropic/claude-3-5-sonnet",
+                "model_name_on_provider": "anthropic/claude-3-5-sonnet",
+                "provider": "anthropic",
+                "max_output_tokens": 1800,
+                "estimated_size_gb": None,
+                "discontinued_at": None,
+                "type": "webapi",
+                "class": "PydanticAIWebAPIAnnotator",
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    info = result[0]
+    # user TOML が SSoT を override するため "Anthropic" 由来だが、
+    # `_build_annotator_info_for_registry_model` で lowercase 正規化される
+    assert info.provider == "anthropic"
+
+
+@pytest.mark.unit
+@pytest.mark.fast
 def test_malformed_webapi_user_override_does_not_abort_listing(patched_registry):
     """PR #27 Codex P1 回帰防止 (WebAPI 側): malformed user override が来ても listing 全体が abort しない。
 


### PR DESCRIPTION
## Summary

Issue #26 の実装。Issue #19 Phase 2 (PR #22) を Issue #23 マージ後の状態で再構成し、
AnnotatorInfo に詳細メタデータフィールド (`provider`/`api_model_id`/`max_output_tokens`/
`discontinued_at`/`estimated_size_gb`) を追加する。

## 経緯

- PR #22 は Codex P2 #1〜#6 の連続指摘で棚上げ状態だった
- 根本原因 (`_WEBAPI_MODEL_METADATA` と `config_registry` の 2 系統並存) は Issue #23
  (PR #24) で SSoT 化により解消済み
- 本 PR で Issue #23 ベースから Phase 2 拡張フィールドを clean に再実装

## 変更内容 (5 commits)

### Commit 1 (`d068892`): AnnotatorInfo に Phase 2 詳細メタデータフィールドを追加
- `core/types.py` の `AnnotatorInfo` に optional フィールド 5 件追加
- `9edadfa` (PR #22) と同等の変更だが、Issue #23 ベース上に配置

### Commit 2 (`5852626`): _WEBAPI_MODEL_METADATA に Phase 2 詳細メタデータフィールドを格納
- `_register_webapi_models_from_discovery` で `discontinued_at: None`/`estimated_size_gb`/
  `max_output_tokens` を明示的に metadata に格納
- Issue #23 取込済みヘルパー (`_safe_int`/`_safe_float`) を活用し malformed 値を堅牢化
- `model_config.py.from_registry` の WebAPI 経路 filter に `discontinued_at` を追加

### Commit 3 (`527da14`): _build_annotator_info_for_*model に Phase 2 詳細メタデータ設定を追加
- `_infer_provider_from_model_id` ヘルパー追加 (PydanticAI 直接モデルの provider 推論)
- `_build_annotator_info_for_registry_model` で 5 フィールドを設定
  - `_safe_float` / `_safe_int` / `_parse_discontinued_at` 経由で堅牢取得 (Codex P2 #1, #2, #5 再発防止)
- `_build_annotator_info_for_direct_model` で provider 推論 + api_model_id=model_id

### Commit 4 (`6bc9222`): list_annotator_info を model_class ベースの排他分岐に書き換え (Codex P2 #6 根本対応)
- `or` フォールバック方式を廃止し、**`model_class.__name__ == "PydanticAIWebAPIAnnotator"`**
  ベースの排他分岐へ
- WebAPI モデル: SSoT base + user TOML override (PR #24 backward compat 維持)
- ローカル ML モデル: user TOML only (WebAPI metadata 混入経路が消滅)
- Codex P2 #6 (discovery `api_model_id` がローカルモデルに混入) の根本原因解消

### Commit 5 (`e9b7bc6`): Phase 2 メタデータ・排他分岐・provider 推論のテストを追加
- 8 件追加 (合計 `test_list_annotator_info.py` 7→15 件)
- Phase 2 フィールド設定、user TOML override、Codex P2 #1, #2, #6 回帰防止、
  `_infer_provider_from_model_id` 動作テスト

## PR #22 との関係

PR #22 (`feat/issue-19-phase2-extras-merge`) の 5 commits との対応:

| commit | 内容 | 本 PR での扱い |
|---|---|---|
| `9edadfa` | AnnotatorInfo フィールド追加 | **新規再実装** (Commit 1, 3) |
| `af26c44` | safe 型変換ヘルパー | **drop** (Issue #23 で取込済み) |
| `f84a265` | TOML local-date 対応 | **drop** (Issue #23 で取込済み) |
| `8d8affc` | discovery + config merge | **drop** (排他分岐に置換) |
| `67471e0` | malformed config abort 防止 | **再実装** (排他分岐 + try/except 維持) |

PR #22 自体は本 PR マージ後に close する想定 (or 同名で更新)。

## 検証

```bash
# 関連テスト
uv run pytest local_packages/image-annotator-lib/tests/unit/standard/core/ \
  local_packages/image-annotator-lib/tests/unit/fast/test_list_annotator_info.py
# 結果: 59 件 PASS

# unit 全体
uv run pytest -m unit local_packages/image-annotator-lib/tests/
# 結果: 443 件 PASS, 2 件 failed (本 PR 範囲外、main でも再現する既存問題)
```

事前存在 fail (本 PR 責任外):
- `test_predict_success_single_image` 等 (`_generate_tags` メソッド欠如、main で再現確認済み)
- `test_toriigate_tagger_format_with_assistant_prefix` (UnifiedAnnotationResult 比較ミス)

## Codex P2 #1-6 の解消状況

| # | PR #22 での問題 | 本 PR での解消経路 |
|---|---|---|
| #1 | float() で malformed 値でモデル消失 | Issue #23 で `_safe_float` 取込済み (Commit 2, 3 で活用) |
| #2 | int() で同上 + discontinued_at 型契約違反 | Issue #23 で `_safe_int`/`_parse_discontinued_at` 取込済み |
| #3 | discovery と config の片方しか採用 | **排他分岐で merge 戦略未定義問題が消滅** (Commit 4) |
| #4 | merge ロジックが try の外で全 abort | **排他分岐で merge 自体が不要** (Commit 4) |
| #5 | datetime.date 未対応 | Issue #23 で `_parse_discontinued_at` 取込済み |
| #6 | discovery api_model_id がローカルモデルに混入 | **model_class ベース排他分岐で混入経路消滅** (Commit 4) |

## 関連

- 起点: #19 (AnnotatorInfo の拡張)
- 棚上げ理由: PR #22 の Codex 連続 6 件 P2 指摘
- 根本原因解消: #23 (WebAPI メタデータレイヤーの単一情報源化, PR #24 で merge)
- 既存 PR (本 PR で代替): #22 (`feat/issue-19-phase2-extras-merge`)
- 関連 Issue: #25 (完全 SSoT 化、ADR 0021 完了後の作業)

🤖 Generated with [Claude Code](https://claude.com/claude-code)