### PR TITLE
refactor(#25): use LiteLLM metadata as WebAPI model SSoT

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -4,7 +4,7 @@
 
 ## 概要
 
-LiteLLM は OpenAI / Anthropic / Google など 100 以上のプロバイダーの 2600 以上のモデルを pip パッケージに同梱しています。`litellm.supports_vision(model_id)` を呼ぶだけでローカル DB を参照して Vision 対応を即時判定できるため、起動時のネットワーク I/O が不要です。
+LiteLLM は OpenAI / Anthropic / Google など 100 以上のプロバイダーの 2600 以上のモデルを pip パッケージに同梱しています。`litellm.supports_vision(model_id)` と `litellm.get_model_info(model_id)` を使い、Vision 対応かつ structured output 対応のモデルだけをアノテーション対象として登録します。
 
 ## インストール
 
@@ -99,6 +99,13 @@ schema_version = 1
 provider = "Google"
 model_name_short = "Gemini 2.5 Pro"
 display_name = "Google: Gemini 2.5 Pro"
+mode = "chat"
+max_input_tokens = 1048576
+max_output_tokens = 8192
+supports_vision = true
+supports_response_schema = true
+supports_function_calling = true
+supports_tool_choice = true
 created = "2025-01-01T00:00:00Z"
 modality = "text+image->text"
 input_modalities = ["text", "image"]
@@ -112,6 +119,9 @@ deprecated_on = None  # 廃止された場合は ISO 8601 タイムスタンプ
 |---|---|
 | `provider` | プロバイダー名（OpenAI / Anthropic / Google など） |
 | `display_name` | UI 表示用の名前 |
+| `supports_vision` | 画像入力対応。`true` のモデルだけ登録対象 |
+| `supports_response_schema` | structured output 対応。`true` のモデルだけ登録対象 |
+| `max_input_tokens` / `max_output_tokens` | LiteLLM DB 由来のトークン上限 |
 | `last_seen` | 最後に API レスポンスに現れた時刻 |
 | `deprecated_on` | 廃止が確認された時刻（`None` = アクティブ） |
 
@@ -123,6 +133,7 @@ deprecated_on = None  # 廃止された場合は ISO 8601 タイムスタンプ
 |---|---|---|
 | `IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS` | `7` | モデルリストの有効期間（日数）。この期間を超えると起動時にバックグラウンド refresh が実行される |
 | `IMAGE_ANNOTATOR_SKIP_API_DISCOVERY` | `false` | `true` に設定すると起動時の API discovery を完全スキップ。CI / オフライン環境で有用 |
+| `IMAGE_ANNOTATOR_ENABLE_OPENROUTER_FALLBACK` | `false` | `true` に設定すると LiteLLM 未収録モデル補完用の OpenRouter API fallback を有効化 |
 
 ```bash
 # TTL を 14 日に変更
@@ -156,4 +167,4 @@ uv run python tools/check_api_model_discovery.py
 
 ## OpenRouter フォールバック
 
-LiteLLM のローカル DB に未収録のモデル（OpenRouter 限定の free tier モデルなど）は、OpenRouter API から補完取得します。OpenRouter API が利用できない場合でも、LiteLLM のみでモデルリストが生成されます（degraded mode）。
+LiteLLM のローカル DB に未収録のモデル（OpenRouter 限定の free tier モデルなど）は、必要な場合のみ OpenRouter API から補完取得できます。既定では無効です。有効化した場合も、Vision・structured output・tool use 対応モデルだけを追加します。

--- a/docs/migration/0021-litellm-migration.md
+++ b/docs/migration/0021-litellm-migration.md
@@ -37,7 +37,7 @@ WebAPI モデル（`class` が `*ApiAnnotator` 系のエントリ）を削除し
 
 ### 2. 自動検出の動作確認
 
-ライブラリ（またはそれを組み込んだアプリケーション）を起動すると、初回起動時に LiteLLM DB から Vision 対応モデルが自動的に検出され、`config/available_api_models.toml` に保存されます。
+ライブラリ（またはそれを組み込んだアプリケーション）を起動すると、初回起動時に LiteLLM DB から Vision 対応かつ structured output 対応のモデルが自動的に検出され、`config/available_api_models.toml` に保存されます。
 
 ```bash
 # 手動で動作確認（プロジェクトルートから）
@@ -70,6 +70,7 @@ print("全モデル:", all_models)
 | WebAPI モデルを手動定義 | WebAPI モデルは LiteLLM が自動管理 |
 | OpenAI / Anthropic / Google のモデルを個別に列挙 | 不要（`config/available_api_models.toml` に自動生成） |
 | 廃止モデルは手動削除が必要 | `deprecated_on` フィールドで自動的にフィルタ |
+| user TOML の `api_model_id` でモデル差し替え | 廃止。`available_api_models.toml` 由来の metadata を使用 |
 
 ### `available_api_models.toml`
 
@@ -85,8 +86,14 @@ schema_version = 1
 [available_vision_models."openai/gpt-4o"]
 provider = "OpenAI"
 display_name = "OpenAI: gpt-4o"
+supports_vision = true
+supports_response_schema = true
+max_input_tokens = 128000
+max_output_tokens = 16384
 ...
 ```
+
+`supports_response_schema = false` のモデルは、画像入力に対応していてもアノテーション用の structured output が安定しないため通常の利用可能モデルには登録されません。
 
 ## オフライン環境での動作
 

--- a/src/image_annotator_lib/api.py
+++ b/src/image_annotator_lib/api.py
@@ -51,6 +51,15 @@ def list_available_annotators() -> list[str]:
     return _registry_list_annotators()
 
 
+def _warn_deprecated_webapi_user_model_definition(model_name: str, user_overrides: dict[str, Any]) -> None:
+    if "api_model_id" not in user_overrides and "model_name_on_provider" not in user_overrides:
+        return
+    logger.warning(
+        f"モデル '{model_name}' の user TOML WebAPI モデル定義は廃止済みです。"
+        "metadata は available_api_models.toml 由来を使用します。"
+    )
+
+
 def list_annotator_info() -> list[AnnotatorInfo]:
     """登録済み全アノテーターのメタデータを返す。
 
@@ -89,7 +98,7 @@ def list_annotator_info() -> list[AnnotatorInfo]:
     for model_name, model_class in _MODEL_CLASS_OBJ_REGISTRY.items():
         # WebAPI モデル / ローカル ML モデルの排他分岐 (Issue #26 Codex P2 #6 根本対応):
         #   - 判定基準: **model_class が PydanticAIWebAPIAnnotator か** (model_name 同名衝突に左右されない)
-        #   - WebAPI モデル: `_WEBAPI_MODEL_METADATA` (SSoT) を base、user TOML で上書き
+        #   - WebAPI モデル: `_WEBAPI_MODEL_METADATA` (SSoT) のみ参照
         #   - ローカル ML モデル: `config_registry` (user TOML) のみ参照
         # 旧来の `or` フォールバック方式 (PR #22) では discovery 経由の `api_model_id`
         # がローカル ML モデルに混入し `_requires_api_key` が誤分類する Codex P2 #6 が
@@ -111,12 +120,14 @@ def list_annotator_info() -> list[AnnotatorInfo]:
                     f"(取得型: {type(raw_user_overrides).__name__})。空 dict として扱います。"
                 )
             if is_webapi_class:
-                # WebAPI モデル: SSoT base + user TOML override (PR #24 backward compat)
+                # WebAPI モデル: metadata は SSoT のみ。user TOML は実行時 override 用で、
+                # api_model_id/provider/capability 等のモデル定義には使わない。
+                _warn_deprecated_webapi_user_model_definition(model_name, user_overrides)
                 raw_webapi_metadata = get_webapi_metadata(model_name)
                 webapi_metadata: dict[str, Any] = (
                     raw_webapi_metadata if isinstance(raw_webapi_metadata, dict) else {}
                 )
-                model_config = {**webapi_metadata, **user_overrides}
+                model_config = webapi_metadata
             else:
                 # ローカル ML モデル: user TOML のみ (WebAPI metadata は混入させない)
                 model_config = user_overrides

--- a/src/image_annotator_lib/core/annotation_runner.py
+++ b/src/image_annotator_lib/core/annotation_runner.py
@@ -123,19 +123,10 @@ class PydanticAIWebAPIWrapper(BaseAnnotator):
         self._api_model_id = None
 
     def __enter__(self):
-        # api_model_id 優先順位 (Issue #23 PR #24 Codex P2 反映):
-        #   1. config_registry (ユーザー TOML 由来) — override 用途を尊重
-        #   2. _WEBAPI_MODEL_METADATA (discovery SSoT)
-        # discovery 値を先に採用すると user TOML の意図的な api_model_id 上書き
-        # (例: 同一モデル名で別 endpoint の差し替え) が無視される backward compat 破壊
-        # が起きるため、`_build_agent_config` と同じ優先順位で揃える。
-        from .config import config_registry
         from .registry import get_webapi_metadata
 
-        self._api_model_id = config_registry.get(self.model_name, "api_model_id", default=None)
-        if not self._api_model_id:
-            webapi_metadata = get_webapi_metadata(self.model_name) or {}
-            self._api_model_id = webapi_metadata.get("api_model_id")
+        webapi_metadata = get_webapi_metadata(self.model_name) or {}
+        self._api_model_id = webapi_metadata.get("api_model_id")
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/src/image_annotator_lib/core/api_model_discovery.py
+++ b/src/image_annotator_lib/core/api_model_discovery.py
@@ -10,6 +10,11 @@ import threading
 from datetime import datetime as dt
 from typing import Any
 
+# image-annotator-lib は LiteLLM の pip 同梱 DB を SSoT にする。
+# LiteLLM は既定で import 時に remote cost map を取りに行くため、
+# ネットワークがない実行環境でも起動を待たないよう local backup を使う。
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
 import litellm
 import requests
 
@@ -28,21 +33,23 @@ from .constants import (
     AVAILABLE_API_MODELS_CONFIG_PATH,
     DEFAULT_API_MODELS_TTL_DAYS,
     ENV_API_MODELS_TTL_DAYS,
+    ENV_ENABLE_OPENROUTER_FALLBACK,
 )
 from .utils import convert_unix_to_iso8601, logger
 
 _OPENROUTER_API_URL = "https://openrouter.ai/api/v1/models"
 _REQUEST_TIMEOUT = 10
+_SUPPORTED_LITELLM_MODES = {"chat", "responses"}
 
 # 同時 background refresh を防ぐプロセス内ロック
 _refresh_lock = threading.Lock()
 
 
 def _fetch_from_litellm() -> list[dict[str, Any]]:
-    """LiteLLM のローカル DB から Vision 対応モデル一覧を取得する。
+    """LiteLLM のローカル DB からアノテーション互換モデル一覧を取得する。
 
     provider/model 形式の ID のみ処理し（エイリアス重複を除外）、
-    litellm.supports_vision() で Vision 対応を確認する。
+    Vision + structured output 対応モデルだけを採用する。
 
     Returns:
         整形済みモデルデータのリスト（'id' キーを含む）
@@ -57,12 +64,28 @@ def _fetch_from_litellm() -> list[dict[str, Any]]:
             info = litellm.get_model_info(model_id)
             if info is None:
                 continue
+            if not _is_litellm_model_annotation_compatible(info):
+                continue
             formatted = _format_litellm_model_for_toml(model_id, info)
             if formatted:
                 results.append(formatted)
         except Exception:
             continue
     return results
+
+
+def _is_litellm_model_annotation_compatible(info: dict[str, Any]) -> bool:
+    """LoRAIro/image-annotator-lib の画像アノテーションに適したモデルか判定する。
+
+    PydanticAI に ``AnnotationSchema`` を渡して構造化出力を要求するため、
+    Vision 対応に加えて response schema 対応を必須にする。
+    """
+    mode = info.get("mode", "chat")
+    return (
+        info.get("supports_vision") is True
+        and info.get("supports_response_schema") is True
+        and mode in _SUPPORTED_LITELLM_MODES
+    )
 
 
 def _format_litellm_model_for_toml(model_id: str, info: dict[str, Any]) -> dict[str, Any] | None:
@@ -87,6 +110,13 @@ def _format_litellm_model_for_toml(model_id: str, info: dict[str, Any]) -> dict[
         "display_name": model_id,
         "mode": info.get("mode", "chat"),
         "max_tokens": info.get("max_tokens"),
+        "max_input_tokens": info.get("max_input_tokens"),
+        "max_output_tokens": info.get("max_output_tokens"),
+        "supports_vision": info.get("supports_vision"),
+        "supports_response_schema": info.get("supports_response_schema"),
+        "supports_function_calling": info.get("supports_function_calling"),
+        "supports_tool_choice": info.get("supports_tool_choice"),
+        "supports_parallel_function_calling": info.get("supports_parallel_function_calling"),
         "input_cost_per_token": info.get("input_cost_per_token"),
         "output_cost_per_token": info.get("output_cost_per_token"),
         # last_seen, deprecated_on は _update_toml_with_api_results で付与
@@ -136,7 +166,9 @@ def _fetch_and_update_vision_models() -> dict[str, Any]:
     logger.info(f"LiteLLM DB から {len(litellm_models)} 件の Vision モデルを取得")
 
     # === OpenRouter フォールバック（LiteLLM 未収録モデルを補完）===
-    openrouter_models = _fetch_from_openrouter_fallback()
+    openrouter_models = []
+    if _openrouter_fallback_enabled():
+        openrouter_models = _fetch_from_openrouter_fallback()
     litellm_ids = {m["id"] for m in litellm_models}
     additional_models = [m for m in openrouter_models if m["id"] not in litellm_ids]
     if additional_models:
@@ -151,6 +183,16 @@ def _fetch_and_update_vision_models() -> dict[str, Any]:
 
     # TOML 書き込み失敗（save が例外を握りつぶす）でも in-memory の正確なデータを返す
     return updated_toml_data
+
+
+def _openrouter_fallback_enabled() -> bool:
+    """OpenRouter fallback を実行するか判定する。既定は無効。"""
+    return os.environ.get(ENV_ENABLE_OPENROUTER_FALLBACK, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def should_refresh(ttl_days: int | None = None) -> bool:
@@ -169,7 +211,9 @@ def should_refresh(ttl_days: int | None = None) -> bool:
             try:
                 ttl_days = int(env_val)
             except ValueError:
-                logger.warning(f"{ENV_API_MODELS_TTL_DAYS}={env_val!r} が整数でないため既定値を使用します。")
+                logger.warning(
+                    f"{ENV_API_MODELS_TTL_DAYS}={env_val!r} が整数でないため既定値を使用します。"
+                )
                 ttl_days = DEFAULT_API_MODELS_TTL_DAYS
         else:
             ttl_days = DEFAULT_API_MODELS_TTL_DAYS
@@ -196,7 +240,9 @@ def _refresh_worker() -> None:
         _fetch_and_update_vision_models()
         logger.info("バックグラウンド API モデル refresh が完了しました。")
     except Exception as e:
-        logger.warning(f"バックグラウンド API モデル refresh に失敗しました（次回 TTL 超過時に再試行）: {e}")
+        logger.warning(
+            f"バックグラウンド API モデル refresh に失敗しました（次回 TTL 超過時に再試行）: {e}"
+        )
     finally:
         _refresh_lock.release()
 
@@ -342,6 +388,11 @@ def _format_openrouter_model_for_toml(api_model_data: dict[str, Any]) -> dict[st
         "created": created_iso,
         "modality": architecture.get("modality"),
         "input_modalities": architecture.get("input_modalities"),
+        "mode": "chat",
+        "supports_vision": True,
+        "supports_response_schema": True,
+        "supports_function_calling": True,
+        "supports_tool_choice": True,
         # last_seen, deprecated_on は呼び出し元 (_update_toml_with_api_results) で追加
     }
 

--- a/src/image_annotator_lib/core/base/annotator.py
+++ b/src/image_annotator_lib/core/base/annotator.py
@@ -245,13 +245,13 @@ class BaseAnnotator(ABC):
             config_registryから設定を読み込んでConfig Objectに変換します。
         """
         logger.debug(f"後方互換: config_registryから '{model_name}' の設定を読み込み")
-        registry_dict = config_registry.get_all_config().get(model_name)
-        if not registry_dict:
-            # WebAPI モデルは Issue #23 以降 _WEBAPI_MODEL_METADATA (SSoT) からのみ読まれる。
-            # config_registry に登録されないため、フォールバックで getter 経由に問い合わせる。
-            from ..registry import get_webapi_metadata
+        # WebAPI モデルは Issue #25 以降 `_WEBAPI_MODEL_METADATA` のみを正本にする。
+        # 同名 user TOML があっても WebAPI モデル定義としては採用しない。
+        from ..registry import get_webapi_metadata
 
-            registry_dict = get_webapi_metadata(model_name)
+        registry_dict = get_webapi_metadata(model_name)
+        if not registry_dict:
+            registry_dict = config_registry.get_all_config().get(model_name)
         if not registry_dict:
             # model_nameが存在しない場合のエラー処理
             logger.error(f"モデル '{model_name}' の設定がconfig_registryに存在しません")

--- a/src/image_annotator_lib/core/base/pydantic_ai_annotator.py
+++ b/src/image_annotator_lib/core/base/pydantic_ai_annotator.py
@@ -203,17 +203,12 @@ class PydanticAIWebAPIAnnotator(BaseAnnotator):
 
     def _build_agent_config(self) -> AnnotationAgentConfig:
         """設定からPydanticAI最適化設定を構築"""
-        # api_model_id 優先順位 (Issue #23 PR #24 Codex P1 反映):
-        #   1. config_registry (ユーザー TOML 由来) — 後方互換性および override 用途
-        #   2. _WEBAPI_MODEL_METADATA (discovery SSoT)
-        # ADR 0021 の最終形では (1) は ADR 0021 移行完了時に廃止予定だが、
-        # 現時点では user TOML override (環境固有 endpoint redirect / テスト時動的差し替え)
-        # が正当な用途として機能しているため fallback 経路を維持する。
-        # discovery 経由の応急処置 (config_registry.set_system_value) は本 Issue で撤廃済み。
-        api_model_id = config_registry.get(self.model_name, "api_model_id", default=None)
-        if not api_model_id:
-            webapi_metadata = get_webapi_metadata(self.model_name) or {}
-            api_model_id = webapi_metadata.get("api_model_id")
+        # WebAPI モデル定義は ADR 0021 / Issue #25 の最終形として
+        # `_WEBAPI_MODEL_METADATA` (available_api_models.toml 由来) のみを正本にする。
+        # user TOML は temperature/timeout/custom_instructions 等の実行時 override 用であり、
+        # api_model_id の差し替えには使わない。
+        webapi_metadata = get_webapi_metadata(self.model_name) or {}
+        api_model_id = webapi_metadata.get("api_model_id")
         if not api_model_id:
             raise ConfigurationError(f"Model {self.model_name} missing required api_model_id")
 
@@ -340,11 +335,19 @@ class PydanticAIWebAPIAnnotator(BaseAnnotator):
                         UnifiedAnnotationResult(
                             model_name=self.model_name,
                             capabilities=capabilities,
-                            tags=accumulated_response.tags if hasattr(accumulated_response, "tags") else None,
-                            captions=accumulated_response.captions if hasattr(accumulated_response, "captions") else None,
-                            scores={"score": accumulated_response.score} if hasattr(accumulated_response, "score") and accumulated_response.score else None,
+                            tags=accumulated_response.tags
+                            if hasattr(accumulated_response, "tags")
+                            else None,
+                            captions=accumulated_response.captions
+                            if hasattr(accumulated_response, "captions")
+                            else None,
+                            scores={"score": accumulated_response.score}
+                            if hasattr(accumulated_response, "score") and accumulated_response.score
+                            else None,
                             provider_name=getattr(self, "provider_name", None) or "pydantic_ai",
-                            raw_output=accumulated_response.model_dump() if hasattr(accumulated_response, "model_dump") else None,
+                            raw_output=accumulated_response.model_dump()
+                            if hasattr(accumulated_response, "model_dump")
+                            else None,
                         )
                     )
                 else:
@@ -412,9 +415,13 @@ class PydanticAIWebAPIAnnotator(BaseAnnotator):
                             capabilities=capabilities,
                             tags=result.data.tags if hasattr(result.data, "tags") else None,
                             captions=result.data.captions if hasattr(result.data, "captions") else None,
-                            scores={"score": result.data.score} if hasattr(result.data, "score") and result.data.score else None,
+                            scores={"score": result.data.score}
+                            if hasattr(result.data, "score") and result.data.score
+                            else None,
                             provider_name=getattr(self, "provider_name", None) or "pydantic_ai",
-                            raw_output=result.data.model_dump() if hasattr(result.data, "model_dump") else None,
+                            raw_output=result.data.model_dump()
+                            if hasattr(result.data, "model_dump")
+                            else None,
                         )
                     )
 

--- a/src/image_annotator_lib/core/constants.py
+++ b/src/image_annotator_lib/core/constants.py
@@ -36,6 +36,8 @@ DEFAULT_PATHS = {
 DEFAULT_API_MODELS_TTL_DAYS = 7
 # TTL を環境変数で上書きするためのキー名
 ENV_API_MODELS_TTL_DAYS = "IMAGE_ANNOTATOR_API_MODELS_TTL_DAYS"
+# OpenRouter fallback は LiteLLM 未収録モデルを補完する実験的経路。既定では無効。
+ENV_ENABLE_OPENROUTER_FALLBACK = "IMAGE_ANNOTATOR_ENABLE_OPENROUTER_FALLBACK"
 
 # テンプレートパスも必要に応じてエクスポート (config.py で使う)
 # (直接定数を使うのでエクスポート不要かも)

--- a/src/image_annotator_lib/core/model_config.py
+++ b/src/image_annotator_lib/core/model_config.py
@@ -110,7 +110,7 @@ class WebAPIModelConfig(BaseModelConfig):
 
     # 生成パラメータ(PydanticAI用、Optional)
     temperature: float | None = Field(default=None, ge=0.0, le=2.0, description="サンプリング温度")
-    max_output_tokens: int | None = Field(default=None, gt=0, le=8192, description="最大トークン数")
+    max_output_tokens: int | None = Field(default=None, gt=0, le=200000, description="最大トークン数")
     top_p: float | None = Field(default=None, ge=0.0, le=1.0, description="Top-Pサンプリング")
     top_k: int | None = Field(default=None, gt=0, description="Top-Kサンプリング")
 
@@ -176,6 +176,16 @@ class ModelConfigFactory:
                         # には対応フィールドがないためフィルタリングする
                         "provider",
                         "type",
+                        "mode",
+                        "max_input_tokens",
+                        "max_tokens",
+                        "supports_vision",
+                        "supports_response_schema",
+                        "supports_function_calling",
+                        "supports_tool_choice",
+                        "supports_parallel_function_calling",
+                        "input_cost_per_token",
+                        "output_cost_per_token",
                         # Issue #26: Phase 2 詳細メタデータ。AnnotatorInfo 構築専用で
                         # WebAPIModelConfig 自体のフィールドではない
                         "discontinued_at",
@@ -186,11 +196,7 @@ class ModelConfigFactory:
                 logger.debug(f"ローカルMLモデルとして '{model_name}' をパース")
                 # Filter out fields not in LocalMLModelConfig
                 # capabilities are retrieved via config_registry.get() for dynamic capability support
-                filtered_dict = {
-                    k: v
-                    for k, v in config_dict.items()
-                    if k not in ("capabilities",)
-                }
+                filtered_dict = {k: v for k, v in config_dict.items() if k not in ("capabilities",)}
                 return LocalMLModelConfig(**filtered_dict)
             else:
                 error_msg = f"モデル '{model_name}' の設定に 'model_path' または 'model_name_on_provider' がありません"

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -388,7 +388,8 @@ def get_webapi_metadata(model_name: str) -> dict[str, Any] | None:
 
     Returns:
         メタデータ辞書 (``api_model_id`` / ``provider`` / ``max_output_tokens`` /
-        ``type`` / ``class`` などを含む)。未登録なら ``None``。
+        ``supports_vision`` / ``supports_response_schema`` / ``type`` / ``class`` などを含む)。
+        未登録なら ``None``。
     """
     return _WEBAPI_MODEL_METADATA.get(model_name)
 
@@ -588,9 +589,7 @@ def _build_annotator_info_for_registry_model(
             model_config.get("estimated_size_gb"), model_name, "estimated_size_gb"
         ),
         discontinued_at=_parse_discontinued_at(model_config.get("discontinued_at"), model_name),
-        max_output_tokens=_safe_int(
-            model_config.get("max_output_tokens"), model_name, "max_output_tokens"
-        ),
+        max_output_tokens=_safe_int(model_config.get("max_output_tokens"), model_name, "max_output_tokens"),
     )
 
 
@@ -697,6 +696,22 @@ def _parse_discontinued_at(value: Any, model_name: str) -> datetime.datetime | N
     return None
 
 
+def _is_annotation_compatible_webapi_model(model_id: str, model_info: dict[str, Any]) -> bool:
+    if model_info.get("deprecated_on") is not None:
+        return False
+    if model_info.get("supports_vision") is not True:
+        logger.debug(f"モデルID '{model_id}' は Vision 非対応のためスキップします。")
+        return False
+    if model_info.get("supports_response_schema") is not True:
+        logger.debug(f"モデルID '{model_id}' は structured output 非対応のためスキップします。")
+        return False
+    mode = model_info.get("mode", "chat")
+    if mode not in {"chat", "responses"}:
+        logger.debug(f"モデルID '{model_id}' は mode={mode!r} のためスキップします。")
+        return False
+    return True
+
+
 def _register_webapi_models_from_discovery() -> None:
     """available_api_models.toml を読み込み、WebAPI モデルをレジストリに直接登録する。
 
@@ -725,8 +740,9 @@ def _register_webapi_models_from_discovery() -> None:
                 logger.warning(f"モデルID '{model_id}' の情報形式が不正です。スキップします。")
                 continue
 
-            if model_info.get("deprecated_on") is not None:
+            if not _is_annotation_compatible_webapi_model(model_id, model_info):
                 continue
+            mode = model_info.get("mode", "chat")
 
             model_name_short = model_info.get("model_name_short")
             provider = model_info.get("provider")
@@ -759,10 +775,28 @@ def _register_webapi_models_from_discovery() -> None:
                     "api_model_id": model_id,
                     "model_name_on_provider": model_id,
                     "provider": str(provider).lower(),
+                    "mode": mode,
+                    "max_input_tokens": _safe_int(
+                        model_info.get("max_input_tokens"), model_id, "max_input_tokens"
+                    ),
                     "max_output_tokens": _safe_int(
                         model_info.get("max_output_tokens"), model_id, "max_output_tokens"
                     )
                     or 1800,
+                    "max_tokens": _safe_int(model_info.get("max_tokens"), model_id, "max_tokens"),
+                    "supports_vision": True,
+                    "supports_response_schema": True,
+                    "supports_function_calling": bool(model_info.get("supports_function_calling")),
+                    "supports_tool_choice": bool(model_info.get("supports_tool_choice")),
+                    "supports_parallel_function_calling": bool(
+                        model_info.get("supports_parallel_function_calling")
+                    ),
+                    "input_cost_per_token": _safe_float(
+                        model_info.get("input_cost_per_token"), model_id, "input_cost_per_token"
+                    ),
+                    "output_cost_per_token": _safe_float(
+                        model_info.get("output_cost_per_token"), model_id, "output_cost_per_token"
+                    ),
                     "estimated_size_gb": _safe_float(
                         model_info.get("estimated_size_gb"), model_id, "estimated_size_gb"
                     ),

--- a/src/image_annotator_lib/core/simplified_agent_factory.py
+++ b/src/image_annotator_lib/core/simplified_agent_factory.py
@@ -37,13 +37,15 @@ class SimplifiedAgentFactory:
                 toml_data: dict[str, Any] = result.get("toml_data", {})
                 self._all_models_data = toml_data
                 self._available_models = [
-                    mid for mid, data in toml_data.items()
-                    if isinstance(data, dict) and data.get("deprecated_on") is None
+                    mid
+                    for mid, data in toml_data.items()
+                    if isinstance(data, dict)
+                    and data.get("deprecated_on") is None
+                    and data.get("supports_vision") is True
+                    and data.get("supports_response_schema") is True
+                    and data.get("mode", "chat") in {"chat", "responses"}
                 ]
-                logger.info(
-                    f"利用可能モデル: {len(self._available_models)} 件"
-                    f" (全 {len(toml_data)} 件中)"
-                )
+                logger.info(f"利用可能モデル: {len(self._available_models)} 件 (全 {len(toml_data)} 件中)")
             else:
                 logger.error(f"Failed to discover models: {result.get('error', 'Unknown error')}")
                 if not self._available_models:

--- a/src/image_annotator_lib/model_class/annotator_webapi/anthropic_api.py
+++ b/src/image_annotator_lib/model_class/annotator_webapi/anthropic_api.py
@@ -5,8 +5,8 @@ from typing import Any
 from PIL import Image
 
 from ...core.base import WebApiBaseAnnotator
-from ...core.config import config_registry
 from ...core.provider_manager import ProviderManager
+from ...core.registry import get_webapi_metadata
 from ...core.types import UnifiedAnnotationResult
 from ...core.utils import logger
 
@@ -26,7 +26,9 @@ class AnthropicApiAnnotator(WebApiBaseAnnotator):
         logger.debug(f"Entering context for Anthropic annotator: {self.model_name}")
         return self
 
-    def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any) -> None:
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any
+    ) -> None:
         """Context manager exit."""
         pass
 
@@ -36,7 +38,7 @@ class AnthropicApiAnnotator(WebApiBaseAnnotator):
 
     def _run_inference(self, processed: list[Image.Image]) -> list[UnifiedAnnotationResult]:
         """Run inference via ProviderManager."""
-        api_model_id = config_registry.get(self.model_name, "api_model_id")
+        api_model_id = (get_webapi_metadata(self.model_name) or {}).get("api_model_id")
         if not api_model_id:
             from ...core.utils import get_model_capabilities
 

--- a/src/image_annotator_lib/model_class/annotator_webapi/google_api.py
+++ b/src/image_annotator_lib/model_class/annotator_webapi/google_api.py
@@ -5,8 +5,8 @@ from typing import Any
 from PIL import Image
 
 from ...core.base import WebApiBaseAnnotator
-from ...core.config import config_registry
 from ...core.provider_manager import ProviderManager
+from ...core.registry import get_webapi_metadata
 from ...core.types import UnifiedAnnotationResult
 from ...core.utils import logger
 
@@ -38,7 +38,7 @@ class GoogleApiAnnotator(WebApiBaseAnnotator):
 
     def _run_inference(self, processed: list[Image.Image]) -> list[UnifiedAnnotationResult]:
         """Run inference via ProviderManager."""
-        api_model_id = config_registry.get(self.model_name, "api_model_id")
+        api_model_id = (get_webapi_metadata(self.model_name) or {}).get("api_model_id")
         if not api_model_id:
             from ...core.utils import get_model_capabilities
 

--- a/src/image_annotator_lib/model_class/annotator_webapi/openai_api_chat.py
+++ b/src/image_annotator_lib/model_class/annotator_webapi/openai_api_chat.py
@@ -3,8 +3,8 @@ from typing import Any
 from PIL import Image
 
 from ...core.base import WebApiBaseAnnotator
-from ...core.config import config_registry
 from ...core.provider_manager import ProviderManager
+from ...core.registry import get_webapi_metadata
 from ...core.types import UnifiedAnnotationResult
 from ...core.utils import logger
 
@@ -24,7 +24,9 @@ class OpenRouterApiAnnotator(WebApiBaseAnnotator):
         logger.debug(f"Entering context for OpenRouter annotator: {self.model_name}")
         return self
 
-    def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any) -> None:
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any
+    ) -> None:
         """Context manager exit."""
         pass
 
@@ -34,7 +36,7 @@ class OpenRouterApiAnnotator(WebApiBaseAnnotator):
 
     def _run_inference(self, processed: list[Image.Image]) -> list[UnifiedAnnotationResult]:
         """Run inference via ProviderManager."""
-        api_model_id = config_registry.get(self.model_name, "api_model_id")
+        api_model_id = (get_webapi_metadata(self.model_name) or {}).get("api_model_id")
         if not api_model_id:
             from ...core.utils import get_model_capabilities
 

--- a/src/image_annotator_lib/model_class/annotator_webapi/openai_api_response.py
+++ b/src/image_annotator_lib/model_class/annotator_webapi/openai_api_response.py
@@ -3,8 +3,8 @@ from typing import Any
 from PIL import Image
 
 from ...core.base import WebApiBaseAnnotator
-from ...core.config import config_registry
 from ...core.provider_manager import ProviderManager
+from ...core.registry import get_webapi_metadata
 from ...core.types import UnifiedAnnotationResult
 from ...core.utils import logger
 
@@ -24,7 +24,9 @@ class OpenAIApiAnnotator(WebApiBaseAnnotator):
         logger.debug(f"Entering context for OpenAI annotator: {self.model_name}")
         return self
 
-    def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any) -> None:
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any
+    ) -> None:
         """Context manager exit."""
         pass
 
@@ -34,7 +36,7 @@ class OpenAIApiAnnotator(WebApiBaseAnnotator):
 
     def _run_inference(self, processed: list[Image.Image]) -> list[UnifiedAnnotationResult]:
         """Run inference via ProviderManager."""
-        api_model_id = config_registry.get(self.model_name, "api_model_id")
+        api_model_id = (get_webapi_metadata(self.model_name) or {}).get("api_model_id")
         if not api_model_id:
             from ...core.utils import get_model_capabilities
 

--- a/tests/unit/core/test_api_model_discovery.py
+++ b/tests/unit/core/test_api_model_discovery.py
@@ -27,6 +27,13 @@ MOCK_VISION_MODEL_IDS = {"openai/gpt-4o", "anthropic/claude-3-5-sonnet-20241022"
 MOCK_MODEL_INFO = {
     "mode": "chat",
     "max_tokens": 16384,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "supports_vision": True,
+    "supports_response_schema": True,
+    "supports_function_calling": True,
+    "supports_tool_choice": True,
+    "supports_parallel_function_calling": True,
     "input_cost_per_token": 2.5e-06,
     "output_cost_per_token": 1.0e-05,
 }
@@ -65,7 +72,7 @@ def mock_toml_paths(tmp_path):
 
 @pytest.mark.unit
 def test_fetch_from_litellm_returns_only_vision_models(mock_litellm):
-    """Vision 対応モデルのみ返し、非対応・prefix なし ID は除外される。"""
+    """Vision + structured output 対応モデルのみ返し、非対応・prefix なし ID は除外される。"""
     results = _fetch_from_litellm()
     ids = {m["id"] for m in results}
 
@@ -74,6 +81,44 @@ def test_fetch_from_litellm_returns_only_vision_models(mock_litellm):
     assert "google/gemini-1.5-pro" in ids
     assert "openai/gpt-3.5-turbo" not in ids  # Vision 非対応
     assert "gpt-4o" not in ids  # prefix なし → スキップ
+
+
+@pytest.mark.unit
+def test_fetch_from_litellm_excludes_vision_model_without_response_schema(mock_litellm):
+    """Vision 対応でも structured output 非対応なら除外される。"""
+
+    def get_model_info(model: str):
+        info = MOCK_MODEL_INFO.copy()
+        if model == "google/gemini-1.5-pro":
+            info["supports_response_schema"] = False
+        return info if model in MOCK_VISION_MODEL_IDS else None
+
+    mock_litellm.get_model_info.side_effect = get_model_info
+
+    results = _fetch_from_litellm()
+    ids = {m["id"] for m in results}
+
+    assert "openai/gpt-4o" in ids
+    assert "google/gemini-1.5-pro" not in ids
+
+
+@pytest.mark.unit
+def test_fetch_from_litellm_excludes_non_chat_modes(mock_litellm):
+    """画像生成など AnnotationSchema 実行対象外 mode は除外される。"""
+
+    def get_model_info(model: str):
+        info = MOCK_MODEL_INFO.copy()
+        if model == "google/gemini-1.5-pro":
+            info["mode"] = "image_generation"
+        return info if model in MOCK_VISION_MODEL_IDS else None
+
+    mock_litellm.get_model_info.side_effect = get_model_info
+
+    results = _fetch_from_litellm()
+    ids = {m["id"] for m in results}
+
+    assert "openai/gpt-4o" in ids
+    assert "google/gemini-1.5-pro" not in ids
 
 
 @pytest.mark.unit
@@ -87,6 +132,7 @@ def test_fetch_from_litellm_result_contains_id(mock_litellm):
 @pytest.mark.unit
 def test_fetch_from_litellm_skips_on_exception(mock_litellm):
     """supports_vision が例外を投げても他のモデルの処理は継続する。"""
+
     def supports_vision_with_error(model: str) -> bool:
         if model == "anthropic/claude-3-5-sonnet-20241022":
             raise RuntimeError("API error")
@@ -114,7 +160,20 @@ def test_format_litellm_model_required_keys():
     result = _format_litellm_model_for_toml("openai/gpt-4o", info)
 
     assert result is not None
-    for key in ("id", "provider", "model_name_short", "display_name", "mode", "max_tokens"):
+    for key in (
+        "id",
+        "provider",
+        "model_name_short",
+        "display_name",
+        "mode",
+        "max_tokens",
+        "max_input_tokens",
+        "max_output_tokens",
+        "supports_vision",
+        "supports_response_schema",
+        "supports_function_calling",
+        "supports_tool_choice",
+    ):
         assert key in result, f"Key '{key}' missing from result"
 
 
@@ -149,13 +208,33 @@ def test_format_litellm_model_rejects_no_prefix():
 @pytest.mark.unit
 def test_format_litellm_model_cost_fields():
     """コスト情報が正しくマッピングされる。"""
-    info = {"mode": "chat", "max_tokens": 8192, "input_cost_per_token": 3e-06, "output_cost_per_token": 1.5e-05}
+    info = {
+        "mode": "chat",
+        "max_tokens": 8192,
+        "input_cost_per_token": 3e-06,
+        "output_cost_per_token": 1.5e-05,
+    }
     result = _format_litellm_model_for_toml("google/gemini-1.5-pro", info)
 
     assert result is not None
     assert result["max_tokens"] == 8192
     assert result["input_cost_per_token"] == 3e-06
     assert result["output_cost_per_token"] == 1.5e-05
+
+
+@pytest.mark.unit
+def test_format_litellm_model_capability_fields():
+    """LiteLLM capability 情報が TOML 保存形式に引き継がれる。"""
+    result = _format_litellm_model_for_toml("openai/gpt-4o", MOCK_MODEL_INFO.copy())
+
+    assert result is not None
+    assert result["supports_vision"] is True
+    assert result["supports_response_schema"] is True
+    assert result["supports_function_calling"] is True
+    assert result["supports_tool_choice"] is True
+    assert result["supports_parallel_function_calling"] is True
+    assert result["max_input_tokens"] == 128000
+    assert result["max_output_tokens"] == 16384
 
 
 # ==============================================================================
@@ -245,7 +324,9 @@ def test_discover_calls_litellm_when_toml_empty(mock_litellm, mock_toml_paths):
     with (
         patch("image_annotator_lib.core.api_model_discovery.load_available_api_models", return_value={}),
         patch("image_annotator_lib.core.api_model_discovery.save_available_api_models"),
-        patch("image_annotator_lib.core.api_model_discovery._fetch_from_openrouter_fallback", return_value=[]),
+        patch(
+            "image_annotator_lib.core.api_model_discovery._fetch_from_openrouter_fallback", return_value=[]
+        ),
     ):
         result = discover_available_vision_models(force_refresh=False)
 
@@ -259,7 +340,9 @@ def test_discover_force_refresh_calls_litellm(mock_litellm, mock_toml_paths):
     """force_refresh=True で LiteLLM から取得し、TOML を更新する。"""
     mock_toml_paths.write_text('[openai/gpt-4o]\nprovider="OpenAI"\n')
 
-    with patch("image_annotator_lib.core.api_model_discovery._fetch_from_openrouter_fallback", return_value=[]):
+    with patch(
+        "image_annotator_lib.core.api_model_discovery._fetch_from_openrouter_fallback", return_value=[]
+    ):
         result = discover_available_vision_models(force_refresh=True)
 
     assert "models" in result
@@ -307,7 +390,11 @@ def test_update_toml_sets_last_seen_on_new_model():
 def test_update_toml_sets_deprecated_on_for_missing_model():
     """API 結果に存在しない既存モデルに deprecated_on が設定される。"""
     existing = {
-        "openai/old-model": {"provider": "OpenAI", "deprecated_on": None, "last_seen": "2025-01-01T00:00:00Z"}
+        "openai/old-model": {
+            "provider": "OpenAI",
+            "deprecated_on": None,
+            "last_seen": "2025-01-01T00:00:00Z",
+        }
     }
     api_models: list = []  # API からは何も返らない
 
@@ -320,9 +407,7 @@ def test_update_toml_sets_deprecated_on_for_missing_model():
 def test_update_toml_does_not_overwrite_existing_deprecated_on():
     """既に deprecated_on が設定されているモデルは上書きしない。"""
     existing_date = "2025-06-01T00:00:00Z"
-    existing = {
-        "openai/very-old-model": {"provider": "OpenAI", "deprecated_on": existing_date}
-    }
+    existing = {"openai/very-old-model": {"provider": "OpenAI", "deprecated_on": existing_date}}
     api_models: list = []
 
     result = _update_toml_with_api_results(existing, api_models, "2026-04-27T00:00:00Z")

--- a/tests/unit/core/test_model_config.py
+++ b/tests/unit/core/test_model_config.py
@@ -332,12 +332,12 @@ class TestWebAPIModelConfig:
 
     def test_max_output_tokens_validation_exceeds_limit(self):
         """max_output_tokensの検証（上限超過）"""
-        with pytest.raises(ValidationError, match="Input should be less than or equal to 8192"):
+        with pytest.raises(ValidationError, match="Input should be less than or equal to 200000"):
             WebAPIModelConfig(
                 model_name="test_model",
                 class_name="TestClass",
                 api_model_id="model-id",
-                max_output_tokens=8193,
+                max_output_tokens=200001,
             )
 
 

--- a/tests/unit/core/test_simplified_agent_factory.py
+++ b/tests/unit/core/test_simplified_agent_factory.py
@@ -28,6 +28,16 @@ _BASE_MODEL_IDS = [
 ]
 
 
+def _active_model_data(provider: str) -> dict:
+    return {
+        "provider": provider,
+        "deprecated_on": None,
+        "mode": "chat",
+        "supports_vision": True,
+        "supports_response_schema": True,
+    }
+
+
 @pytest.fixture
 def mock_model_discovery():
     """Mock discover_available_vision_models。
@@ -42,10 +52,7 @@ def mock_model_discovery():
     Returns:
         Mock function returning model discovery result
     """
-    mock_toml_data = {
-        mid: {"provider": mid.split("/")[0].capitalize(), "deprecated_on": None}
-        for mid in _BASE_MODEL_IDS
-    }
+    mock_toml_data = {mid: _active_model_data(mid.split("/")[0].capitalize()) for mid in _BASE_MODEL_IDS}
     with patch(
         "image_annotator_lib.core.simplified_agent_factory.discover_available_vision_models"
     ) as mock_discover:
@@ -60,9 +67,12 @@ def mock_model_discovery_with_deprecated():
     discover_available_vision_models が toml_data（deprecated 含む）を返す。
     """
     mock_toml_data = {
-        "openai/gpt-4o": {"provider": "OpenAI", "deprecated_on": None},
-        "openai/gpt-3.5-turbo": {"provider": "OpenAI", "deprecated_on": "2025-01-01T00:00:00Z"},
-        "anthropic/claude-3-5-sonnet-20241022": {"provider": "Anthropic", "deprecated_on": None},
+        "openai/gpt-4o": _active_model_data("OpenAI"),
+        "openai/gpt-3.5-turbo": {
+            **_active_model_data("OpenAI"),
+            "deprecated_on": "2025-01-01T00:00:00Z",
+        },
+        "anthropic/claude-3-5-sonnet-20241022": _active_model_data("Anthropic"),
     }
     with patch(
         "image_annotator_lib.core.simplified_agent_factory.discover_available_vision_models"
@@ -410,6 +420,33 @@ def test_get_available_models_excludes_deprecated(mock_model_discovery_with_depr
 
 
 @pytest.mark.unit
+def test_get_available_models_excludes_schema_incompatible_models():
+    """get_available_models() は structured output 非対応モデルを除外する。"""
+    toml_data = {
+        "openai/gpt-4o": _active_model_data("OpenAI"),
+        "openai/gpt-4-turbo-vision-preview": {
+            **_active_model_data("OpenAI"),
+            "supports_response_schema": False,
+        },
+        "azure/gpt-image-2": {
+            **_active_model_data("Azure"),
+            "mode": "image_generation",
+        },
+    }
+    with patch(
+        "image_annotator_lib.core.simplified_agent_factory.discover_available_vision_models"
+    ) as mock_discover:
+        mock_discover.return_value = {"models": list(toml_data.keys()), "toml_data": toml_data}
+
+        factory = SimplifiedAgentFactory()
+        models = factory.get_available_models()
+
+    assert "openai/gpt-4o" in models
+    assert "openai/gpt-4-turbo-vision-preview" not in models
+    assert "azure/gpt-image-2" not in models
+
+
+@pytest.mark.unit
 def test_list_all_models_includes_deprecated(mock_model_discovery_with_deprecated):
     """list_all_models() は廃止済みモデルも含む全モデルを返す。"""
     factory = SimplifiedAgentFactory()
@@ -445,9 +482,12 @@ def test_is_model_deprecated_false_for_unknown(mock_model_discovery_with_depreca
 def test_list_all_models_uses_toml_data_from_discovery():
     """list_all_models() は discovery の toml_data（deprecated 含む全モデル）を返す。"""
     toml_data = {
-        "openai/gpt-4o": {"provider": "OpenAI", "deprecated_on": None},
-        "openai/gpt-3.5-turbo": {"provider": "OpenAI", "deprecated_on": "2025-01-01T00:00:00Z"},
-        "anthropic/claude-3-5-sonnet-20241022": {"provider": "Anthropic", "deprecated_on": None},
+        "openai/gpt-4o": _active_model_data("OpenAI"),
+        "openai/gpt-3.5-turbo": {
+            **_active_model_data("OpenAI"),
+            "deprecated_on": "2025-01-01T00:00:00Z",
+        },
+        "anthropic/claude-3-5-sonnet-20241022": _active_model_data("Anthropic"),
     }
     with patch(
         "image_annotator_lib.core.simplified_agent_factory.discover_available_vision_models"
@@ -472,8 +512,8 @@ def test_get_available_models_uses_discovery_toml_data_not_stale_cache():
     """
     # discovery の toml_data では再アクティブ化済みで deprecated_on = None
     toml_data_from_discovery = {
-        "openai/gpt-4o": {"provider": "OpenAI", "deprecated_on": None},
-        "openai/reactivated-model": {"provider": "OpenAI", "deprecated_on": None},
+        "openai/gpt-4o": _active_model_data("OpenAI"),
+        "openai/reactivated-model": _active_model_data("OpenAI"),
     }
     with patch(
         "image_annotator_lib.core.simplified_agent_factory.discover_available_vision_models"

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -337,8 +337,8 @@ def test_webapi_model_phase2_fields_from_ssot(patched_registry):
 
 @pytest.mark.unit
 @pytest.mark.fast
-def test_webapi_model_user_toml_overrides_ssot(patched_registry):
-    """WebAPI モデルで user TOML が SSoT より優先される (PR #24 backward compat 維持)。"""
+def test_webapi_model_user_toml_api_model_id_does_not_override_ssot(patched_registry):
+    """WebAPI モデル定義は SSoT のみを採用し、user TOML api_model_id は無視される。"""
     with patched_registry(
         model_dict={"GPT-4o": PydanticAIWebAPIAnnotator},
         config_dict={
@@ -363,10 +363,8 @@ def test_webapi_model_user_toml_overrides_ssot(patched_registry):
         result = list_annotator_info()
 
     info = result[0]
-    # user TOML 値が優先される
-    assert info.api_model_id == "openai/gpt-4o-test-override"
-    assert info.max_output_tokens == 9999
-    # user TOML に provider が無いので SSoT 値が採用される (merge 動作確認)
+    assert info.api_model_id == "openai/gpt-4o"
+    assert info.max_output_tokens == 1800
     assert info.provider == "openai"
 
 
@@ -462,7 +460,9 @@ def test_pydanticai_direct_model_has_inferred_provider_and_api_model_id(patched_
     assert by_name["google/gemini-2.5-pro"].provider == "google"
     assert by_name["google/gemini-2.5-pro"].api_model_id == "google/gemini-2.5-pro"
     assert by_name["anthropic/claude-3-5-sonnet-latest"].provider == "anthropic"
-    assert by_name["anthropic/claude-3-5-sonnet-latest"].api_model_id == "anthropic/claude-3-5-sonnet-latest"
+    assert (
+        by_name["anthropic/claude-3-5-sonnet-latest"].api_model_id == "anthropic/claude-3-5-sonnet-latest"
+    )
 
 
 # ============================================================================
@@ -573,8 +573,8 @@ def test_provider_normalized_to_lowercase_across_sources(patched_registry):
 
 @pytest.mark.unit
 @pytest.mark.fast
-def test_user_toml_provider_also_normalized(patched_registry):
-    """user TOML 由来の `provider` も lowercase 正規化される (PR #27 Codex P2)。"""
+def test_webapi_user_toml_provider_does_not_override_ssot(patched_registry):
+    """WebAPI provider は SSoT の値を採用し、user TOML provider はモデル定義に使わない。"""
     with patched_registry(
         model_dict={"CustomAPI": PydanticAIWebAPIAnnotator},
         config_dict={
@@ -599,9 +599,8 @@ def test_user_toml_provider_also_normalized(patched_registry):
         result = list_annotator_info()
 
     info = result[0]
-    # user TOML が SSoT を override するため "Anthropic" 由来だが、
-    # `_build_annotator_info_for_registry_model` で lowercase 正規化される
     assert info.provider == "anthropic"
+    assert info.api_model_id == "anthropic/claude-3-5-sonnet"
 
 
 @pytest.mark.unit

--- a/tests/unit/standard/core/test_registry.py
+++ b/tests/unit/standard/core/test_registry.py
@@ -162,21 +162,33 @@ MOCK_API_MODELS_WITH_DEPRECATED = {
     "google/gemini-pro-1.5": {
         "provider": "google",
         "model_name_short": "Gemini 1.5 Pro",
+        "mode": "chat",
+        "supports_vision": True,
+        "supports_response_schema": True,
         "deprecated_on": None,
     },
     "openai/gpt-4o": {
         "provider": "openai",
         "model_name_short": "GPT-4o",
+        "mode": "chat",
+        "supports_vision": True,
+        "supports_response_schema": True,
         "deprecated_on": None,
     },
     "openai/old-model": {
         "provider": "openai",
         "model_name_short": "Old Model",
+        "mode": "chat",
+        "supports_vision": True,
+        "supports_response_schema": True,
         "deprecated_on": "2024-01-01T00:00:00Z",  # 廃止済み → スキップ
     },
     "anthropic/claude-3-sonnet": {
         # model_name_short missing → スキップ
         "provider": "anthropic",
+        "mode": "chat",
+        "supports_vision": True,
+        "supports_response_schema": True,
         "deprecated_on": None,
     },
     "invalid_format_model": "this_is_not_a_dict",  # 不正形式 → スキップ
@@ -360,9 +372,7 @@ def test_resolve_model_class_obsolete_returns_none():
     """古いプロバイダー固有クラスが指定された場合、Noneが返される。"""
     available = {"OpenAIApiAnnotator": type("OpenAIApiAnnotator", (), {})}
 
-    result = registry._resolve_model_class(
-        "OpenAIApiAnnotator", "test-model", available, None, "annotator"
-    )
+    result = registry._resolve_model_class("OpenAIApiAnnotator", "test-model", available, None, "annotator")
     assert result is None
 
 
@@ -373,9 +383,7 @@ def test_resolve_model_class_local_model():
     local_cls = type("LocalMLAnnotator", (), {})
     available = {"LocalMLAnnotator": local_cls}
 
-    result = registry._resolve_model_class(
-        "LocalMLAnnotator", "test-model", available, None, "annotator"
-    )
+    result = registry._resolve_model_class("LocalMLAnnotator", "test-model", available, None, "annotator")
     assert result is local_cls
 
 
@@ -383,9 +391,7 @@ def test_resolve_model_class_local_model():
 @pytest.mark.fast
 def test_resolve_model_class_not_found():
     """存在しないクラスが指定された場合、Noneが返される。"""
-    result = registry._resolve_model_class(
-        "NonExistentClass", "test-model", {}, None, "annotator"
-    )
+    result = registry._resolve_model_class("NonExistentClass", "test-model", {}, None, "annotator")
     assert result is None
 
 

--- a/tests/unit/standard/core/test_webapi_metadata_isolation.py
+++ b/tests/unit/standard/core/test_webapi_metadata_isolation.py
@@ -55,11 +55,25 @@ _DISCOVERY_PAYLOAD = {
     "google/gemini-2.5-pro": {
         "provider": "google",
         "model_name_short": "Gemini 2.5 Pro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 8192,
+        "supports_vision": True,
+        "supports_response_schema": True,
+        "supports_function_calling": True,
+        "supports_tool_choice": True,
         "deprecated_on": None,
     },
     "openai/gpt-4o": {
         "provider": "openai",
         "model_name_short": "GPT-4o",
+        "mode": "chat",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "supports_vision": True,
+        "supports_response_schema": True,
+        "supports_function_calling": True,
+        "supports_tool_choice": True,
         "deprecated_on": None,
     },
 }
@@ -142,6 +156,10 @@ def test_get_webapi_metadata_returns_full_metadata(
     assert metadata["api_model_id"] == "google/gemini-2.5-pro"
     assert metadata["model_name_on_provider"] == "google/gemini-2.5-pro"
     assert metadata["provider"] == "google"
+    assert metadata["supports_vision"] is True
+    assert metadata["supports_response_schema"] is True
+    assert metadata["max_input_tokens"] == 1048576
+    assert metadata["max_output_tokens"] == 8192
     assert metadata["class"] == "PydanticAIWebAPIAnnotator"
     assert metadata["type"] == "webapi"
 
@@ -151,6 +169,41 @@ def test_get_webapi_metadata_returns_none_for_unregistered():
     """未登録モデル名に対して `get_webapi_metadata()` は None を返す。"""
     with patch.object(registry, "_WEBAPI_MODEL_METADATA", {}):
         assert get_webapi_metadata("nonexistent-model") is None
+
+
+@pytest.mark.unit
+@patch("image_annotator_lib.core.registry._gather_available_classes")
+@patch("image_annotator_lib.core.registry.load_available_api_models")
+def test_register_webapi_models_requires_response_schema(
+    mock_load_api_models,
+    mock_gather_classes,
+    isolated_registry,
+):
+    """Vision 対応でも structured output 非対応モデルは登録されない。"""
+    mock_load_api_models.return_value = {
+        "openai/gpt-4o": {
+            "provider": "openai",
+            "model_name_short": "GPT-4o",
+            "mode": "chat",
+            "supports_vision": True,
+            "supports_response_schema": True,
+            "deprecated_on": None,
+        },
+        "openai/gpt-4-turbo-vision-preview": {
+            "provider": "openai",
+            "model_name_short": "GPT-4 Turbo Vision",
+            "mode": "chat",
+            "supports_vision": True,
+            "supports_response_schema": False,
+            "deprecated_on": None,
+        },
+    }
+    mock_gather_classes.return_value = {"PydanticAIWebAPIAnnotator": _DummyPydanticAIWebAPIAnnotator}
+
+    _register_webapi_models_from_discovery()
+
+    assert get_webapi_metadata("GPT-4o") is not None
+    assert get_webapi_metadata("GPT-4 Turbo Vision") is None
 
 
 @pytest.mark.unit
@@ -186,24 +239,13 @@ def test_base_annotator_loads_webapi_config_via_metadata_fallback(
 
 
 # ============================================================================
-# User TOML override の優先順位テスト (Codex P1/P2 backward compat 保証)
-#
-# 設計上の問題: SSoT 化を 100% 達成するには user TOML での WebAPI モデル定義を
-# 完全排除する必要があるが、ADR 0021 移行は未完了で、user TOML override は
-# 環境固有の endpoint redirect やテスト時の動的差し替えなど正当な用途を持つ。
-# 本セクションは「user TOML 優先 → discovery metadata fallback」の優先順位を
-# 保証する回帰防止テスト。
+# User TOML WebAPI 定義廃止テスト (Issue #25 完全 SSoT 化)
 # ============================================================================
 
 
 @pytest.mark.unit
-def test_pydantic_ai_annotator_prefers_config_registry_over_discovery_metadata():
-    """`PydanticAIWebAPIAnnotator._build_agent_config` が user TOML 値を優先する。
-
-    discovery metadata に `gpt-4o-2024-08-06` が登録されていても、
-    config_registry にユーザー設定値 `gpt-4o-mini-test` があればそちらを採用する
-    (Codex P2 backward compat 保証)。
-    """
+def test_pydantic_ai_annotator_ignores_user_toml_api_model_id():
+    """`PydanticAIWebAPIAnnotator` は user TOML の api_model_id を採用しない。"""
     from image_annotator_lib.core.base.pydantic_ai_annotator import PydanticAIWebAPIAnnotator
 
     real_registry = get_config_registry()
@@ -220,6 +262,8 @@ def test_pydantic_ai_annotator_prefers_config_registry_over_discovery_metadata()
             "model_name_on_provider": "gpt-4o-2024-08-06",
             "provider": "openai",
             "max_output_tokens": 1800,
+            "supports_vision": True,
+            "supports_response_schema": True,
             "type": "webapi",
             "class": "PydanticAIWebAPIAnnotator",
         }
@@ -228,9 +272,7 @@ def test_pydantic_ai_annotator_prefers_config_registry_over_discovery_metadata()
     with patch.object(real_registry, "_merged_config_data", user_overrides):
         with patch.object(registry, "_WEBAPI_MODEL_METADATA", discovery_metadata):
             annotator = PydanticAIWebAPIAnnotator("GPT-4o")
-            assert annotator.config.model_id == "gpt-4o-mini-test", (
-                "user TOML 由来の api_model_id が discovery より優先されるべき"
-            )
+            assert annotator.config.model_id == "gpt-4o-2024-08-06"
 
 
 @pytest.mark.unit
@@ -245,6 +287,8 @@ def test_pydantic_ai_annotator_falls_back_to_discovery_metadata_when_no_user_con
             "model_name_on_provider": "gpt-4o-2024-08-06",
             "provider": "openai",
             "max_output_tokens": 1800,
+            "supports_vision": True,
+            "supports_response_schema": True,
             "type": "webapi",
             "class": "PydanticAIWebAPIAnnotator",
         }
@@ -257,11 +301,8 @@ def test_pydantic_ai_annotator_falls_back_to_discovery_metadata_when_no_user_con
 
 
 @pytest.mark.unit
-def test_pydantic_ai_webapi_wrapper_honors_user_toml_override():
-    """`PydanticAIWebAPIWrapper.__enter__` も user TOML 値を優先する (Codex P2)。
-
-    `_build_agent_config` と同じ優先順位で揃え、override 用途を尊重する。
-    """
+def test_pydantic_ai_webapi_wrapper_ignores_user_toml_api_model_id():
+    """`PydanticAIWebAPIWrapper.__enter__` も SSoT の api_model_id だけを採用する。"""
     from image_annotator_lib.core.annotation_runner import PydanticAIWebAPIWrapper
 
     real_registry = get_config_registry()
@@ -278,6 +319,8 @@ def test_pydantic_ai_webapi_wrapper_honors_user_toml_override():
             "model_name_on_provider": "anthropic/claude-3-5-sonnet-latest",
             "provider": "anthropic",
             "max_output_tokens": 1800,
+            "supports_vision": True,
+            "supports_response_schema": True,
             "type": "webapi",
             "class": "PydanticAIWebAPIAnnotator",
         }
@@ -285,10 +328,6 @@ def test_pydantic_ai_webapi_wrapper_honors_user_toml_override():
 
     with patch.object(real_registry, "_merged_config_data", user_overrides):
         with patch.object(registry, "_WEBAPI_MODEL_METADATA", discovery_metadata):
-            wrapper = PydanticAIWebAPIWrapper(
-                "Claude 3.5 Sonnet", _DummyPydanticAIWebAPIAnnotator
-            )
+            wrapper = PydanticAIWebAPIWrapper("Claude 3.5 Sonnet", _DummyPydanticAIWebAPIAnnotator)
             with wrapper:
-                assert wrapper._api_model_id == "claude-3-5-sonnet-test-override", (
-                    "user TOML 由来の api_model_id が discovery より優先されるべき"
-                )
+                assert wrapper._api_model_id == "anthropic/claude-3-5-sonnet-latest"


### PR DESCRIPTION
## Summary

- Use LiteLLM bundled metadata as the SSoT for WebAPI model definitions
- Register only annotation-compatible WebAPI models: vision + structured output + chat/responses mode
- Remove user TOML `api_model_id` fallback for WebAPI models while keeping runtime settings overrides
- Keep OpenRouter fallback disabled by default behind `IMAGE_ANNOTATOR_ENABLE_OPENROUTER_FALLBACK`
- Update docs and tests for ADR 0021 / Issue #25 behavior

Closes #25

## Verification

- `uv run pytest tests/unit/core/test_api_model_discovery.py tests/unit/standard/core/test_webapi_metadata_isolation.py tests/unit/standard/core/test_registry.py tests/unit/fast/test_list_annotator_info.py tests/unit/core/test_simplified_agent_factory.py tests/unit/core/test_model_config.py`
  - 122 passed, 1 warning
- `ruff format --check` on changed Python files
- `ruff check --select C901 src/image_annotator_lib/api.py src/image_annotator_lib/core/registry.py`
- `python -m py_compile` on changed Python files
