### PR TITLE
feat(api_model_discovery): プロバイダー許可リストで非主要 LLM を除外

### DIFF
--- a/src/image_annotator_lib/core/api_model_discovery.py
+++ b/src/image_annotator_lib/core/api_model_discovery.py
@@ -41,8 +41,27 @@ _OPENROUTER_API_URL = "https://openrouter.ai/api/v1/models"
 _REQUEST_TIMEOUT = 10
 _SUPPORTED_LITELLM_MODES = {"chat", "responses"}
 
+# LiteLLM が公開する 100+ プロバイダーのうち、実運用で使うものに限定する。
+# キーは LiteLLM model_cost のキーが取りうる provider prefix (model_id.split("/", 1)[0])。
+# - openai: OpenAI 直接
+# - anthropic: Anthropic 直接
+# - gemini: Google AI Studio (Generative Language API)
+# - vertex_ai: Google Cloud Vertex AI (Gemini を含む)
+# - google: 一部のエイリアス・テスト用 prefix の互換
+# - openrouter: 集約プロバイダー
+_ALLOWED_LITELLM_PROVIDERS: frozenset[str] = frozenset(
+    {"openai", "anthropic", "gemini", "vertex_ai", "google", "openrouter"}
+)
+
 # 同時 background refresh を防ぐプロセス内ロック
 _refresh_lock = threading.Lock()
+
+
+def _is_allowed_provider(model_id: str) -> bool:
+    """model_id の provider prefix が許可リストに含まれるか判定する。"""
+    if "/" not in model_id:
+        return False
+    return model_id.split("/", 1)[0] in _ALLOWED_LITELLM_PROVIDERS
 
 
 def _fetch_from_litellm() -> list[dict[str, Any]]:
@@ -56,7 +75,7 @@ def _fetch_from_litellm() -> list[dict[str, Any]]:
     """
     results = []
     for model_id in litellm.model_cost.keys():
-        if "/" not in model_id:
+        if not _is_allowed_provider(model_id):
             continue
         try:
             if not litellm.supports_vision(model_id):
@@ -281,11 +300,20 @@ def discover_available_vision_models(force_refresh: bool = False) -> dict[str, A
     if not force_refresh:
         existing_toml_data = load_available_api_models()
         if existing_toml_data:
-            model_ids = list(existing_toml_data.keys())
+            # 過去に許可外プロバイダーが書き込まれた古いキャッシュも、ここで結果から除外する。
+            # TOML 自体は触らず、戻り値から落とすだけにして手動編集を尊重する。
+            filtered_toml_data = {
+                model_id: entry
+                for model_id, entry in existing_toml_data.items()
+                if _is_allowed_provider(model_id)
+            }
+            model_ids = list(filtered_toml_data.keys())
+            dropped = len(existing_toml_data) - len(filtered_toml_data)
             logger.info(
                 f"ローカルファイル ({AVAILABLE_API_MODELS_CONFIG_PATH}) から {len(model_ids)} 件のモデル情報を読み込みました。"
+                + (f" (許可外プロバイダー {dropped} 件を除外)" if dropped else "")
             )
-            return {"models": model_ids, "toml_data": existing_toml_data}
+            return {"models": model_ids, "toml_data": filtered_toml_data}
         else:
             logger.info(
                 f"ローカルファイル ({AVAILABLE_API_MODELS_CONFIG_PATH}) が存在しないか空です。LiteLLM DB から取得します。"

--- a/tests/unit/core/test_api_model_discovery.py
+++ b/tests/unit/core/test_api_model_discovery.py
@@ -8,6 +8,7 @@ from image_annotator_lib.core.api_model_discovery import (
     _fetch_from_litellm,
     _fetch_from_openrouter_fallback,
     _format_litellm_model_for_toml,
+    _is_allowed_provider,
     _update_toml_with_api_results,
     discover_available_vision_models,
 )
@@ -20,6 +21,8 @@ MOCK_LITELLM_MODEL_COST = {
     "anthropic/claude-3-5-sonnet-20241022": {"max_tokens": 8192},
     "google/gemini-1.5-pro": {"max_tokens": 2097152},
     "gpt-4o": {"max_tokens": 16384},  # prefix なしエイリアス → スキップされる
+    "groq/llama-3.1-70b": {"max_tokens": 8192},  # 許可外プロバイダー → スキップされる
+    "cohere/command-r": {"max_tokens": 4096},  # 許可外プロバイダー → スキップされる
 }
 
 MOCK_VISION_MODEL_IDS = {"openai/gpt-4o", "anthropic/claude-3-5-sonnet-20241022", "google/gemini-1.5-pro"}
@@ -48,8 +51,8 @@ def mock_litellm():
     with patch("image_annotator_lib.core.api_model_discovery.litellm") as mock_ll:
         mock_ll.model_cost = MOCK_LITELLM_MODEL_COST
         mock_ll.supports_vision.side_effect = lambda model: model in MOCK_VISION_MODEL_IDS
-        mock_ll.get_model_info.side_effect = (
-            lambda model: MOCK_MODEL_INFO.copy() if model in MOCK_VISION_MODEL_IDS else None
+        mock_ll.get_model_info.side_effect = lambda model: (
+            MOCK_MODEL_INFO.copy() if model in MOCK_VISION_MODEL_IDS else None
         )
         yield mock_ll
 
@@ -63,6 +66,46 @@ def mock_toml_paths(tmp_path):
         patch("image_annotator_lib.core.config.AVAILABLE_API_MODELS_CONFIG_PATH", toml_path),
     ):
         yield toml_path
+
+
+# ==============================================================================
+# _is_allowed_provider() のテスト
+# ==============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "openai/gpt-4o",
+        "anthropic/claude-3-5-sonnet",
+        "gemini/gemini-1.5-pro",
+        "vertex_ai/gemini-1.5-pro",
+        "google/gemini-1.5-pro",
+        "openrouter/anthropic/claude-3-opus",
+    ],
+)
+def test_is_allowed_provider_accepts_three_majors_and_openrouter(model_id):
+    """OpenAI / Anthropic / Google (gemini/vertex_ai/google) / OpenRouter は許可される。"""
+    assert _is_allowed_provider(model_id) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "groq/llama-3.1-70b",
+        "cohere/command-r",
+        "mistral/mistral-large",
+        "azure/gpt-4o",  # Azure は許可外 (OpenAI 直接ではない)
+        "xai/grok-2",
+        "gpt-4o",  # prefix なし
+        "",
+    ],
+)
+def test_is_allowed_provider_rejects_others(model_id):
+    """三大プロバイダーと OpenRouter 以外は除外される。"""
+    assert _is_allowed_provider(model_id) is False
 
 
 # ==============================================================================
@@ -81,6 +124,19 @@ def test_fetch_from_litellm_returns_only_vision_models(mock_litellm):
     assert "google/gemini-1.5-pro" in ids
     assert "openai/gpt-3.5-turbo" not in ids  # Vision 非対応
     assert "gpt-4o" not in ids  # prefix なし → スキップ
+    assert "groq/llama-3.1-70b" not in ids  # 許可外プロバイダー → スキップ
+    assert "cohere/command-r" not in ids  # 許可外プロバイダー → スキップ
+
+
+@pytest.mark.unit
+def test_fetch_from_litellm_skips_disallowed_providers_before_litellm_calls(mock_litellm):
+    """許可外プロバイダーは supports_vision / get_model_info を呼ぶ前に除外される。"""
+    _ = _fetch_from_litellm()
+
+    called_models = {call.args[0] for call in mock_litellm.supports_vision.call_args_list}
+    assert "groq/llama-3.1-70b" not in called_models
+    assert "cohere/command-r" not in called_models
+    assert "openai/gpt-4o" in called_models
 
 
 @pytest.mark.unit
@@ -313,6 +369,24 @@ def test_discover_uses_cache_when_toml_exists(mock_litellm, mock_toml_paths):
     assert "openai/gpt-4o" in result["models"]
     assert "openai/gpt-4o" in result["toml_data"]
     mock_litellm.supports_vision.assert_not_called()
+
+
+@pytest.mark.unit
+def test_discover_filters_disallowed_providers_from_cache(mock_litellm, mock_toml_paths):
+    """既存 TOML に許可外プロバイダーのエントリが残っていても結果から除外される。"""
+    mock_toml_paths.write_text(
+        '[openai/gpt-4o]\nprovider="OpenAI"\n'
+        '[groq/llama-3.1-70b]\nprovider="Groq"\n'
+        '[cohere/command-r]\nprovider="Cohere"\n'
+    )
+
+    result = discover_available_vision_models(force_refresh=False)
+
+    assert "openai/gpt-4o" in result["models"]
+    assert "groq/llama-3.1-70b" not in result["models"]
+    assert "cohere/command-r" not in result["models"]
+    assert "groq/llama-3.1-70b" not in result["toml_data"]
+    assert "cohere/command-r" not in result["toml_data"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

LiteLLM の `model_cost` DB には 100+ プロバイダーが含まれており、UI/CLI のモデル選択に使わない LLM (Groq, Cohere, Mistral, Azure, xAI 等) まで一覧に出てうっとうしいので、**三大プロバイダー (OpenAI / Anthropic / Google) + OpenRouter** に絞り込む。

許可リスト:
\`\`\`python
_ALLOWED_LITELLM_PROVIDERS = frozenset({
    "openai",      # OpenAI 直接
    "anthropic",   # Anthropic 直接
    "gemini",      # Google AI Studio
    "vertex_ai",   # Google Cloud Vertex AI (Gemini を含む)
    "google",      # 一部のエイリアス・テスト用 prefix の互換
    "openrouter",  # 集約プロバイダー
})
\`\`\`

## 変更点

### `src/image_annotator_lib/core/api_model_discovery.py`

- `_ALLOWED_LITELLM_PROVIDERS` 定数を追加
- `_is_allowed_provider(model_id)` ヘルパーを追加
- `_fetch_from_litellm()` のループ先頭で許可外プロバイダーをスキップ
  - `supports_vision()` / `get_model_info()` を呼ぶ前に弾くので無駄な LiteLLM 呼び出しが減る
- `discover_available_vision_models()` の TOML キャッシュ読み込みパスでもフィルタ適用
  - 既存ユーザーが古いキャッシュ TOML を持っていても **再 refresh を待たず即効** で許可外モデルが消える
  - ただし TOML ファイル自体は触らず、戻り値から落とすだけ (手動編集を尊重)

### `tests/unit/core/test_api_model_discovery.py`

- `_is_allowed_provider()` のテスト 13 件 (parametrize) 追加
- `_fetch_from_litellm()` のテストに許可外プロバイダー (groq, cohere) のケース追加
- `_fetch_from_litellm_skips_disallowed_providers_before_litellm_calls` で LiteLLM API 呼び出し回避を検証
- `discover_available_vision_models()` のキャッシュフィルタテスト追加

## 影響範囲・スコープ

- **対象**: `image-annotator-lib` の WebAPI モデル discovery のみ
- **対象外**:
  - LoRAIro 側の表示ロジック (CLI/GUI) は無変更で挙動が改善する (キャッシュフィルタの効果)
  - ローカル ML モデル (ONNX/Transformers/CLIP) は無関係
  - PydanticAI 推論経路は無関係 (実行時は \`api_model_id\` で直接アクセス)

## ADR 0021 との関係

ADR 0021 のスコープ境界では「OpenAI / Anthropic / Google / OpenRouter / **xAI**」が想定されているが、本 PR では xAI を保留 (LoRAIro 側で実利用がないため)。将来 xAI が必要になれば許可リストに 1 行追加するだけで対応可能。

`available_api_models.toml` キャッシュへの書き込みも、許可外プロバイダーは入らなくなるため、運用上のクリーン化が継続的に進む。

## Test plan

- [x] 既存 unit/core テスト 36 件 + 新規 14 件 PASS (\`uv run pytest tests/unit/core/test_api_model_discovery.py\`)
- [x] unit/core + unit/fast の回帰なし (451 件 PASS、既存 5 件失敗は本 PR と無関係な \`config_registry\` モジュール属性問題で main HEAD でも再現)
- [x] Ruff format 適用済み、新規追加分は lint クリーン (既存コード由来の RUF001/RUF003 は本 PR では触らず)
- [ ] LoRAIro 側で実際に Annotator GUI を開いてモデル一覧が絞り込まれていることを確認 (submodule pointer 更新後)

## マージ後の作業

LoRAIro 側で submodule pointer を本 PR の merge commit に更新する別 PR が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)