### PR TITLE
fix(#31): user TOML WebAPI 定義の deprecation 警告を削除

### DIFF
--- a/src/image_annotator_lib/api.py
+++ b/src/image_annotator_lib/api.py
@@ -51,15 +51,6 @@ def list_available_annotators() -> list[str]:
     return _registry_list_annotators()
 
 
-def _warn_deprecated_webapi_user_model_definition(model_name: str, user_overrides: dict[str, Any]) -> None:
-    if "api_model_id" not in user_overrides and "model_name_on_provider" not in user_overrides:
-        return
-    logger.warning(
-        f"モデル '{model_name}' の user TOML WebAPI モデル定義は廃止済みです。"
-        "metadata は available_api_models.toml 由来を使用します。"
-    )
-
-
 def list_annotator_info() -> list[AnnotatorInfo]:
     """登録済み全アノテーターのメタデータを返す。
 
@@ -122,7 +113,6 @@ def list_annotator_info() -> list[AnnotatorInfo]:
             if is_webapi_class:
                 # WebAPI モデル: metadata は SSoT のみ。user TOML は実行時 override 用で、
                 # api_model_id/provider/capability 等のモデル定義には使わない。
-                _warn_deprecated_webapi_user_model_definition(model_name, user_overrides)
                 raw_webapi_metadata = get_webapi_metadata(model_name)
                 webapi_metadata: dict[str, Any] = (
                     raw_webapi_metadata if isinstance(raw_webapi_metadata, dict) else {}


### PR DESCRIPTION
## Summary

Closes #31

PR #28 (Issue #25) で user TOML の WebAPI モデル定義は完全に SSoT 経由となり、`api.py:list_annotator_info()` の WebAPI 分岐では `user_overrides` は実質未使用 (L113-121: `webapi_metadata` のみが `model_config` に渡る)。

\`_warn_deprecated_webapi_user_model_definition()\` は移行ガイダンスとしての temporary measure だったが、その役目を終えたため削除する。

## 変更点

- \`api.py\`: \`_warn_deprecated_webapi_user_model_definition()\` 関数定義削除 (旧 L54-60)
- \`api.py\`: \`list_annotator_info()\` 内の呼び出し削除 (旧 L116)

差分: **+0 / -10 行**、1 ファイルのみ。

## 影響範囲

- \`is_webapi_class\` 分岐の SSoT 経由 metadata 取得ロジックは **無変更**
- ローカル ML モデルの user TOML override (\`temperature\` / \`timeout\` 等) には **影響なし**
- 旧形式 user TOML を持つ場合の挙動は **無変更** (引き続き \`user_overrides\` は WebAPI 分岐で無視される)
- WARNING ログが出なくなるだけ

## Test plan

- [x] api.py / src 全体に削除関数への残参照なし (\`grep _warn_deprecated_webapi_user_model_definition\` 0 件)
- [x] tests に削除関数への参照なし
- [x] \`uv run pytest tests/unit/core/test_api_model_discovery.py tests/unit/standard/core/test_registry.py tests/unit/fast/test_api.py\` で **79 件 PASS**
  - 既存 1 件 (\`test_pydanticai_wrapper_predict_handles_provider_error\`) failure は本 PR 前から再現する既存 rot で本 PR と無関係
- [x] \`ruff check\` クリーン

## 関連

- Issue #31 (本 PR でクローズ)
- ADR 0021: LiteLLM-Driven WebAPI Model Registry (Step 7)
- PR #28 (Issue #25): user TOML \`api_model_id\` fallback 削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)