### PR TITLE
fix: BLIP2 系モデルの type を captioner に修正

### DIFF
--- a/config/annotator_config.toml
+++ b/config/annotator_config.toml
@@ -125,48 +125,48 @@ model_path = "Salesforce/blip2-opt-2.7b"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 16.74
-type = "tagger"
+type = "captioner"
 
 ["blip2-opt-2.7b-coco"]
 model_path = "Salesforce/blip2-opt-2.7b-coco"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 16.743
-type = "tagger"
+type = "captioner"
 
 ["blip2-opt-6.7b"]
 model_path = "Salesforce/blip2-opt-6.7b"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 34.658
-type = "tagger"
+type = "captioner"
 
 ["blip2-opt-6.7b-coco"]
 model_path = "Salesforce/blip2-opt-6.7b-coco"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 34.661
-type = "tagger"
+type = "captioner"
 
 [blip2-flan-t5-xl]
 model_path = "Salesforce/blip2-flan-t5-xl"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 17.624
-type = "tagger"
+type = "captioner"
 
 [blip2-flan-t5-xl-coco]
 model_path = "Salesforce/blip2-flan-t5-xl-coco"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 17.627
-type = "tagger"
+type = "captioner"
 
 [blip2-flan-t5-xxl]
 model_path = "Salesforce/blip2-flan-t5-xxl"
 class = "BLIP2Tagger"
 device = "cpu"
-type = "tagger"
+type = "captioner"
 
 [GITLargeCaptioning]
 model_path = "microsoft/git-large-coco"

--- a/src/image_annotator_lib/resources/system/annotator_config.toml
+++ b/src/image_annotator_lib/resources/system/annotator_config.toml
@@ -125,48 +125,48 @@ model_path = "Salesforce/blip2-opt-2.7b"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 16.74
-type = "tagger"
+type = "captioner"
 
 ["blip2-opt-2.7b-coco"]
 model_path = "Salesforce/blip2-opt-2.7b-coco"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 16.743
-type = "tagger"
+type = "captioner"
 
 ["blip2-opt-6.7b"]
 model_path = "Salesforce/blip2-opt-6.7b"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 34.658
-type = "tagger"
+type = "captioner"
 
 ["blip2-opt-6.7b-coco"]
 model_path = "Salesforce/blip2-opt-6.7b-coco"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 34.661
-type = "tagger"
+type = "captioner"
 
 [blip2-flan-t5-xl]
 model_path = "Salesforce/blip2-flan-t5-xl"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 17.624
-type = "tagger"
+type = "captioner"
 
 [blip2-flan-t5-xl-coco]
 model_path = "Salesforce/blip2-flan-t5-xl-coco"
 class = "BLIP2Tagger"
 device = "cpu"
 estimated_size_gb = 17.627
-type = "tagger"
+type = "captioner"
 
 [blip2-flan-t5-xxl]
 model_path = "Salesforce/blip2-flan-t5-xxl"
 class = "BLIP2Tagger"
 device = "cpu"
-type = "tagger"
+type = "captioner"
 
 [GITLargeCaptioning]
 model_path = "microsoft/git-large-coco"


### PR DESCRIPTION
## Summary

\`annotator_config.toml\` の \`[blip2-*]\` 7 セクションで \`type = "tagger"\` と宣言されていたが、BLIP2 はキャプション生成モデルなので **\`type = "captioner"\` が正しい**。

UI/CLI の category カラムで `blip2-flan-t5-xl` 等が "tagger" カテゴリに分類されており、表示の混乱と \`get_model_capabilities()\` の挙動矛盾を引き起こしていた。

## 修正対象 (各 7 セクション)

- \`src/image_annotator_lib/resources/system/annotator_config.toml\` (一次ソース)
- \`config/annotator_config.toml\` (sample)

両方で以下のセクションの \`type\` を \`tagger → captioner\` に変更:
\`blip2-opt-2.7b\` / \`-coco\` / \`-6.7b\` / \`-6.7b-coco\` / \`blip2-flan-t5-xl\` / \`-coco\` / \`-xxl\`

クラス名 \`BLIP2Tagger\` は影響範囲が広いため **据え置き** (リネームが必要なら別 PR)。

## 経緯 (git history より)

- \`747bce6\` (2025-04-12): BLIP2 系セクション初期投入時は \`type\` フィールドなし
- \`8620f1d\` (2025-07-28) "config: Update project configuration...": **\`type\` フィールド一括追加時にクラス名 'BLIP2Tagger' の "Tagger" に引きずられて \`type = "tagger"\` を機械的に割り当て** (本バグ混入箇所)
- \`90a5065\` "fix: get_model_capabilities() にtypeフィールドからのフォールバック推論を追加": この \`type\` 値が UI/CLI category に伝播するように

## なぜテストが落ちなかったか

\`tests/unit/model_class/test_tagger_transformers.py\` では BLIP/BLIP2/GIT 系を **既に \`type = "captioner"\`** で書いていた (line 98, 257, 278, 362, 383, 418, 471, 550, 631)。テスト側は実態に合っていたが、system config だけ取り残されていた状態。本 PR で system config が正しい実態と一致する。

## Test plan

- [x] \`uv run pytest tests/unit/model_class/test_tagger_transformers.py\` で 9/10 PASS
  - 1 件失敗 (\`test_toriigate_tagger_format_with_assistant_prefix\`) は本 PR 前から再現する既存 rot で無関係
- [ ] LoRAIro 側 \`lorairo-cli models list\` で \`blip2-*\` が \`captioner\` カテゴリに表示されることを confirm (submodule pointer 更新後)

🤖 Generated with [Claude Code](https://claude.com/claude-code)