### PR TITLE
fix: WebAPI モデルの capabilities 警告を解消

### DIFF
--- a/src/image_annotator_lib/core/utils.py
+++ b/src/image_annotator_lib/core/utils.py
@@ -303,7 +303,12 @@ def determine_effective_device(requested_device: str, model_name: str | None = N
 def get_model_capabilities(model_name: str) -> set[Any]:
     """モデル名からcapabilitiesを取得する。
 
-    設定ファイルに明示的なcapabilitiesがない場合、typeフィールドから推論する。
+    解決順序:
+        1. WebAPI モデル (`_WEBAPI_MODEL_METADATA` SSoT に登録済み) なら
+           Vision LLM は tags/captions/scores 全タスクをサポートするため全 capability を返す。
+        2. 設定ファイル (config_registry) の `capabilities` フィールドが明示されていればそれを使う。
+        3. 設定ファイルの `type` フィールドから推論する (tagger/scorer/captioner)。
+        4. 解決できなければ WARNING を出して空 set を返す。
 
     Args:
         model_name: モデル名
@@ -312,9 +317,14 @@ def get_model_capabilities(model_name: str) -> set[Any]:
         set: TaskCapabilityのセット
     """
     from .config import config_registry
+    from .registry import get_webapi_metadata
     from .types import TaskCapability
 
-    # 設定ファイルからcapabilitiesを取得
+    # 1. WebAPI モデルは Vision LLM として tags/captions/scores 全対応
+    if get_webapi_metadata(model_name) is not None:
+        return {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
+
+    # 2. 設定ファイルからcapabilitiesを取得
     capabilities_config = config_registry.get(model_name, "capabilities", [])
 
     if not capabilities_config:

--- a/tests/unit/test_capability_utils.py
+++ b/tests/unit/test_capability_utils.py
@@ -87,3 +87,21 @@ class TestGetModelCapabilities:
 
         # Should handle None as empty list and return empty set
         assert capabilities == set()
+
+    @patch("image_annotator_lib.core.registry.get_webapi_metadata")
+    def test_get_model_capabilities_webapi_returns_all_three(self, mock_get_webapi_metadata):
+        """WebAPI モデルは Vision LLM として tags/captions/scores 全 capability を返す。
+
+        WARNING ('capabilitiesが設定されていません') が ~80 件の WebAPI モデル
+        全件で出ていた問題の修正。SSoT (`_WEBAPI_MODEL_METADATA`) に登録済みなら
+        config_registry を見ずに即時全 capability を返す。
+        """
+        mock_get_webapi_metadata.return_value = {
+            "api_model_id": "openai/gpt-4o",
+            "provider": "openai",
+            "type": "webapi",
+        }
+
+        capabilities = get_model_capabilities("gpt-4o")
+
+        assert capabilities == {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}


### PR DESCRIPTION
## Summary

LiteLLM 由来の WebAPI モデル (現状 ~80 件) で、起動時に大量の WARNING が出ていた:

\`\`\`
WARNING | image_annotator_lib.core.utils:get_model_capabilities -
モデル 'gemini-2.0-flash-lite' のcapabilitiesが設定されていません
\`\`\`

## 原因

\`_register_webapi_models_from_discovery()\` は SSoT (\`_WEBAPI_MODEL_METADATA\`) に metadata を登録するが、\`capabilities\` フィールドは含めていない。
一方 \`get_model_capabilities()\` は \`config_registry\` のみ参照していたため、WebAPI モデルでは:

1. \`config_registry.get(name, "capabilities")\` → \`[]\` (未登録)
2. \`config_registry.get(name, "type")\` → \`""\` (\`type="webapi"\` は SSoT 側にあって config_registry 側にない)
3. fallback 推論も効かず → WARNING

## 修正

\`get_model_capabilities()\` の解決順序の先頭に **WebAPI モデル判定** を追加。SSoT に登録されているモデルは即時で全 3 capability (tags/captions/scores) を返す:

\`\`\`python
if get_webapi_metadata(model_name) is not None:
    return {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
\`\`\`

WebAPI Vision LLM (OpenAI / Anthropic / Google / OpenRouter) は \`AnnotationSchema\` (PydanticAI) で tags + captions + score をまとめて返せるため、3 タスク全部を持たせるのが妥当。

## 影響範囲

- WARNING 解消
- WebAPI モデル経由の \`UnifiedAnnotationResult.capabilities\` が \`set()\` (空) → \`{TAGS, CAPTIONS, SCORES}\` になる
  - 結果フィルタリング・分類処理が正しく動くようになる
- ローカル ML モデル (\`config_registry\` 経由) には **影響なし** (解決順序 2/3 は無変更)

## Test plan

- [x] \`tests/unit/test_capability_utils.py\` で 7 件 + 新規 1 件 = **8 件 PASS**
  - 新テスト: \`test_get_model_capabilities_webapi_returns_all_three\`
- [x] ruff format クリーン
- [ ] LoRAIro 側 \`lorairo-cli models list\` で \`get_model_capabilities\` 系 WARNING が出ないことを confirm (submodule pointer 更新後)

## 関連

- ADR 0021: LiteLLM-Driven WebAPI Model Registry
- PR #28 (#25): WebAPI metadata SSoT 化 (本件はその後の派生)

🤖 Generated with [Claude Code](https://claude.com/claude-code)