### PR TITLE
feat(#41): AnnotatorInfo.api_model_id を litellm_model_id にリネーム

### DIFF
--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -410,7 +410,7 @@ def get_webapi_metadata(model_name: str) -> dict[str, Any] | None:
         model_name: ``model_name_short`` (例: ``"GPT-4o"``)。
 
     Returns:
-        メタデータ辞書 (``api_model_id`` / ``provider`` / ``max_output_tokens`` /
+        メタデータ辞書 (``litellm_model_id`` / ``provider`` / ``max_output_tokens`` /
         ``supports_vision`` / ``supports_response_schema`` / ``type`` / ``class`` などを含む)。
         未登録なら ``None``。
     """
@@ -589,12 +589,12 @@ def _build_annotator_info_for_registry_model(
         "local" if is_local else (str(raw_provider).lower() if raw_provider is not None else None)
     )
 
-    # ADR 0023 Phase 1 (Issue #35, PR #40): WebAPI モデルの外部 ID は metadata の
-    # `litellm_model_id` を SSoT として参照する。`AnnotatorInfo.api_model_id` field は
-    # LoRAIro DB schema との互換のため keep し、ここに `litellm_model_id` を設定する。
+    # ADR 0023 Phase 2 (Issue #41): metadata の `litellm_model_id` SSoT を
+    # `AnnotatorInfo.litellm_model_id` field に直接公開する。LoRAIro 側は ADR 0023
+    # line 73 に従い `api_model_id` 互換シムを廃止し、`litellm_model_id` を読む。
     # ローカル ML モデルは外部 ID を持たないため None。
     raw_litellm_id = model_config.get("litellm_model_id") if is_api else None
-    api_model_id: str | None = str(raw_litellm_id) if raw_litellm_id is not None else None
+    litellm_model_id: str | None = str(raw_litellm_id) if raw_litellm_id is not None else None
 
     return AnnotatorInfo(
         name=model_name,
@@ -604,7 +604,7 @@ def _build_annotator_info_for_registry_model(
         is_api=is_api,
         device=device if isinstance(device, str) else None,
         provider=provider,
-        api_model_id=api_model_id,
+        litellm_model_id=litellm_model_id,
         estimated_size_gb=_safe_float(
             model_config.get("estimated_size_gb"), model_name, "estimated_size_gb"
         ),
@@ -639,7 +639,7 @@ def _build_annotator_info_for_direct_model(model_id: str) -> AnnotatorInfo:
         is_api=True,
         device=None,
         provider=_infer_provider_from_model_id(model_id),
-        api_model_id=model_id,  # 直接モデルは model_id 自体が上流 API の識別子
+        litellm_model_id=model_id,  # 直接モデルは model_id 自体が LiteLLM ID
     )
 
 

--- a/src/image_annotator_lib/core/types.py
+++ b/src/image_annotator_lib/core/types.py
@@ -315,8 +315,12 @@ class AnnotatorInfo:
     provider: str | None = None
     """プロバイダー名。ローカルモデルは "local"、API モデルは "openai"/"anthropic"/"google" 等。
     config_registry に未登録の PydanticAI 直接モデルは model_id の slash 前から推論。"""
-    api_model_id: str | None = None
-    """上流 API のモデル識別子 (例: "gpt-4o-2024-11-20")。ローカルモデルは None。"""
+    litellm_model_id: str | None = None
+    """LiteLLM ID (例: "openai/gpt-4o")。ローカルモデルは None。
+
+    ADR 0023 Phase 2 (Issue #41): 旧 `api_model_id` field は本 field にリネームされた。
+    LoRAIro 側は ADR 0023 line 73 に従い互換シムを残さず一括破壊的変更で追従する。
+    """
     estimated_size_gb: float | None = None
     """ローカル ML モデルのダウンロードサイズ推定値 (GB)。API モデルは None。"""
     discontinued_at: datetime.datetime | None = None

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -305,7 +305,7 @@ def test_local_ml_model_has_provider_local_and_estimated_size(patched_registry):
 
     info = result[0]
     assert info.provider == "local"
-    assert info.api_model_id is None
+    assert info.litellm_model_id is None
     assert info.estimated_size_gb == 1.5
     assert info.discontinued_at is None
     assert info.max_output_tokens is None
@@ -334,7 +334,7 @@ def test_webapi_model_phase2_fields_from_ssot(patched_registry):
 
     info = result[0]
     assert info.provider == "openai"
-    assert info.api_model_id == "openai/gpt-4o"
+    assert info.litellm_model_id == "openai/gpt-4o"
     assert info.max_output_tokens == 1800
     assert info.estimated_size_gb is None
     assert info.discontinued_at is None
@@ -368,7 +368,7 @@ def test_webapi_model_user_toml_api_model_id_does_not_override_ssot(patched_regi
         result = list_annotator_info()
 
     info = result[0]
-    assert info.api_model_id == "openai/gpt-4o"
+    assert info.litellm_model_id == "openai/gpt-4o"
     assert info.max_output_tokens == 1800
     assert info.provider == "openai"
 
@@ -411,7 +411,7 @@ def test_local_ml_excludes_webapi_metadata_codex_p2_6(patched_registry):
     assert info.is_local is True
     assert info.is_api is False
     # WebAPI 由来の `api_model_id` は混入しない
-    assert info.api_model_id is None
+    assert info.litellm_model_id is None
     # provider はローカル "local" にフォールバック
     assert info.provider == "local"
 
@@ -463,10 +463,11 @@ def test_pydanticai_direct_model_has_inferred_provider_and_api_model_id(patched_
 
     by_name = {info.name: info for info in result}
     assert by_name["google/gemini-2.5-pro"].provider == "google"
-    assert by_name["google/gemini-2.5-pro"].api_model_id == "google/gemini-2.5-pro"
+    assert by_name["google/gemini-2.5-pro"].litellm_model_id == "google/gemini-2.5-pro"
     assert by_name["anthropic/claude-3-5-sonnet-latest"].provider == "anthropic"
     assert (
-        by_name["anthropic/claude-3-5-sonnet-latest"].api_model_id == "anthropic/claude-3-5-sonnet-latest"
+        by_name["anthropic/claude-3-5-sonnet-latest"].litellm_model_id
+        == "anthropic/claude-3-5-sonnet-latest"
     )
 
 
@@ -605,7 +606,7 @@ def test_webapi_user_toml_provider_does_not_override_ssot(patched_registry):
 
     info = result[0]
     assert info.provider == "anthropic"
-    assert info.api_model_id == "anthropic/claude-3-5-sonnet"
+    assert info.litellm_model_id == "anthropic/claude-3-5-sonnet"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

ADR 0023 line 73「`available_api_models.toml` 由来の旧 `api_model_id` は本 ADR で廃止する (互換シムを残さない)」を public API レベルで実現する一括破壊的変更 (Option A)。

Phase 1.x までで内部の `api_model_id` シムは消えていたが、`AnnotatorInfo` 公開 field と LoRAIro DB column が `api_model_id` のまま残っていた。本 PR で完全に新名称へ移行する。

## 変更点

- `core/types.py`: `AnnotatorInfo.api_model_id` → `litellm_model_id`
- `core/registry.py`: `_build_annotator_info_for_registry_model` / `_build_annotator_info_for_direct_model` で field 名と内部変数名を統一、`get_webapi_metadata` の docstring 更新
- `tests/unit/fast/test_list_annotator_info.py`: 7 件の assertion を新名称に追従

## 連携 PR

- LoRAIro 側: NEXTAltair/LoRAIro#<TBD-B1> — DB column rename + Alembic migration + 6 file refs
- 本 PR が先行マージ → LoRAIro PR で submodule pointer bump + LoRAIro 側の追従

## ADR

[LoRAIro ADR 0023 Phase 2](https://github.com/NEXTAltair/LoRAIro/blob/main/docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md)

## Test Plan

- [x] `tests/unit/fast/test_list_annotator_info.py`: 19 case 全 PASS
- [x] `tests/unit/`: 関連箇所のテスト全 PASS (pre-existing toriigate test failure は本 PR と無関係)
- [x] `make lint && make typecheck`: 既存エラー以外の新規エラーなし

Issue: #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)