### PR TITLE
feat(#47): PydanticAI output normalization for AnnotationSchema drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ The `ModelLoad` class implements sophisticated memory management:
 
 **Implementation Pattern:**
 - 単一 base class `WebApiAnnotator` で OpenAI / Anthropic / Google / OpenRouter を統一処理
-- Structured output は PydanticAI default Tool Output で得る (Pydantic schema = `AnnotationSchema` in `core/types.py`)
+- Structured output は PydanticAI default Tool Output で得る。`Agent.output_type` には `core/output_normalization.py:normalize_annotation_output` (callable) を渡し、軽微な drift (文字列 tags / 数値文字列 score 等) を `AnnotationSchema` (in `core/types.py`) validation の **前** に正規化する (Issue #47)
 - Provider 別差異 (`openrouter:` prefix 等) は `core/model_id.py` の `_BUILDER_DISPATCH` テーブルに集約
 - **API Model Discovery** (`core/api_model_discovery.py`) — LiteLLM 同梱 DB から runtime に WebAPI モデル一覧と capability metadata を取得 (TOML キャッシュなし)。絞り込み主条件は `supports_vision` + `supports_function_calling` (Issue #45)。`supports_response_schema` は判定に使わない
 - WebAPI モデル登録は `core/registry.py:_register_webapi_models_from_discovery()` が `WebApiAnnotator` を直接 registry に entry する (旧 `PydanticAIWebAPIAnnotator` 経由は Phase 1.x で廃止)
@@ -208,6 +208,7 @@ estimated_size_gb = 1.5
 - API key は `api_keys: dict[str, str]` 経由で provider object に明示注入 (`os.environ` mutate 禁止)
 - 画像入力は `core/image_preprocess.preprocess_images_to_binary()` で `BinaryContent` 化
 - Structured output は `await agent.run([prompt_text, binary_content])` の sequence 形式
+- `Agent.output_type` は `core/output_normalization.py:normalize_annotation_output` (callable) — PydanticAI が tool として LLM に公開し、関数の docstring が tool description として使われる。`AnnotationSchema` 直指定ではなく callable 経路を採る (Issue #47: validation 前正規化を集約)
 
 ### WebAPI Inference Architecture (ADR 0023 Phase 1)
 
@@ -219,7 +220,8 @@ estimated_size_gb = 1.5
 > [#35 (device 判定分離)](https://github.com/NEXTAltair/image-annotator-lib/issues/35) /
 > [#42 (refusal 例外階層)](https://github.com/NEXTAltair/image-annotator-lib/issues/42) /
 > [#41 (litellm_model_id rename)](https://github.com/NEXTAltair/image-annotator-lib/issues/41) /
-> [#45 (function_calling 主条件)](https://github.com/NEXTAltair/image-annotator-lib/issues/45)
+> [#45 (function_calling 主条件)](https://github.com/NEXTAltair/image-annotator-lib/issues/45) /
+> [#47 (output normalization)](https://github.com/NEXTAltair/image-annotator-lib/issues/47)
 
 **責務分離:**
 
@@ -228,7 +230,8 @@ estimated_size_gb = 1.5
 | WebAPI モデル discovery / capability metadata | LiteLLM 同梱 DB (runtime call、TOML キャッシュなし) |
 | 推論実行 / multimodal input / structured output / output retry | PydanticAI native provider/model |
 | LiteLLM ID と PydanticAI 実行 descriptor の mapping | `core/model_id.py` |
-| Schema → Result 変換 / 軽微正規化 | `core/result_adapter.py` |
+| 軽微正規化 (validation 前 / Issue #47) | `core/output_normalization.py` |
+| Schema → Result 変換 (validation 後) | `core/result_adapter.py` |
 | PIL Image → BinaryContent 変換 | `core/image_preprocess.py` |
 | BaseAnnotator wrapping (registry 登録 WebAPI モデル) | `core/webapi_annotator.py` |
 | Agent 構築・実行 (キャッシュなし) | `core/provider_manager.py` |
@@ -247,14 +250,25 @@ estimated_size_gb = 1.5
    - 推論呼び出しごとに Agent / Provider / Model を新規作成 (キャッシュなし)
    - Capability check は不要 (Issue #45 で discovery 段階に集約済み)
    - PydanticAI: `await agent.run([prompt_text, binary_content])` の sequence 形式
-   - `output_retries=1` で structured output validation failure を 1 回再生成
+   - `Agent.output_type` には `core/output_normalization.py:normalize_annotation_output` (callable) を渡す (Issue #47)
+   - `output_retries=1` で **output normalization / schema validation failure を 1 回再生成** (`ModelRetry` 経由)
 
-3. **`core/webapi_annotator.py`** — `BaseAnnotator` 継承の汎用 wrapper
+3. **`core/output_normalization.py`** — PydanticAI output function による軽微正規化 (Issue #47)
+   - `normalize_annotation_output(tags, captions, score) -> AnnotationSchema`
+   - `tags=str` (カンマ分割) / `captions=str` / `score=numeric_string` / trim / drop empty を validation 前に補正
+   - 補正不能 (None / dict / list 内非文字列 等) は `ModelRetry` を raise
+   - 壊れた JSON 修復 / free text からの regex 復元 / provider 別 parser は実装しない
+
+4. **`core/result_adapter.py`** — 検証済み schema → 結果変換 (Phase 1.7 / Issue #47)
+   - `to_annotation_result(schema_output, phash, error)`: 検証済み `AnnotationSchema` → `AnnotationResult` 変換
+   - 最終防衛 trim/drop empty のみ残す (主経路は `core/output_normalization.py` 側)
+
+5. **`core/webapi_annotator.py`** — `BaseAnnotator` 継承の汎用 wrapper
    - registry 登録 WebAPI モデル経由でインスタンス化される (Issue #45 で direct LiteLLM ID dispatch 経路は廃止)
    - `BaseAnnotator.__init__` の `config_registry` 依存を回避するため最小限の field 設定
    - `__enter__` / `__exit__` は no-op
 
-4. **`core/api_model_discovery.py`** — LiteLLM 同梱 DB の runtime query
+6. **`core/api_model_discovery.py`** — LiteLLM 同梱 DB の runtime query
    - `discover_available_vision_models()` → `{"models": [...], "metadata": {...}}`
    - `get_available_models()` / `list_all_models()` / `is_model_deprecated()` を helper として公開
    - 旧 `available_api_models.toml` キャッシュ / TTL refresh / OpenRouter fallback は廃止

--- a/src/image_annotator_lib/core/output_normalization.py
+++ b/src/image_annotator_lib/core/output_normalization.py
@@ -1,0 +1,95 @@
+"""PydanticAI output normalization for WebAPI annotation results.
+
+ADR 0023 Issue #47: PydanticAI `Agent.output_type` に渡す callable として
+`normalize_annotation_output` を提供する。callable は PydanticAI が **tool**
+として LLM に公開するため、関数の docstring は LLM 視点の description として
+書く (内部実装詳細はこの module docstring に分離)。
+
+軽微な drift 補正は `AnnotationSchema` validation の **前** に行う:
+- `tags` の文字列 (カンマ区切りまたは単一) → `list[str]`
+- `captions` の文字列 (単一) → `list[str]`
+- `score` の数値文字列 → `float`
+- 各要素の trim、空文字除去
+
+補正不能 (None / dict / list 内非文字列 / 解釈不能 score 等) は `ModelRetry`
+を raise し、PydanticAI `output_retries=1` に従って LLM 再生成へ流す。
+壊れた JSON 修復 / free text からの regex 復元 / provider 別 parser は実装しない。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import ValidationError
+from pydantic_ai import ModelRetry
+
+from .types import AnnotationSchema
+
+
+def _normalize_string_items(value: Any, *, field_name: str, split_commas: bool) -> list[str]:
+    """Normalize tag/caption values allowed by ADR 0023."""
+    if isinstance(value, str):
+        raw_items = value.split(",") if split_commas and "," in value else [value]
+    elif isinstance(value, list):
+        raw_items = value
+    else:
+        raise ModelRetry(f"`{field_name}` must be a string or list of strings")
+
+    normalized: list[str] = []
+    for item in raw_items:
+        if not isinstance(item, str):
+            raise ModelRetry(f"`{field_name}` must contain only strings")
+        text = item.strip()
+        if text:
+            normalized.append(text)
+    return normalized
+
+
+def _normalize_score(value: Any) -> float:
+    """Normalize numeric score values allowed by ADR 0023."""
+    if isinstance(value, bool):
+        raise ModelRetry("`score` must be a number")
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError as exc:
+            raise ModelRetry("`score` must be a numeric string") from exc
+    raise ModelRetry("`score` must be a number or numeric string")
+
+
+def normalize_annotation_output(tags: Any, captions: Any, score: Any) -> AnnotationSchema:
+    """Provide image annotation results.
+
+    Call this tool to return your image analysis as structured data.
+    Each argument may be either the strict shape or a permissive variant:
+    obvious string-form drift is normalized automatically before validation.
+
+    Args:
+        tags: Tags identifying image elements (characters, composition, lighting, etc).
+            Preferred shape is a list of strings (e.g. ``["1girl", "blue eyes",
+            "school uniform"]``). A single comma-separated string is also accepted
+            and will be split on commas.
+        captions: Caption strings describing the image. Preferred shape is a list
+            of strings (e.g. ``["A young student sitting at a desk in a sunlit
+            classroom."]``). A single string is also accepted and will be wrapped
+            in a one-item list (no comma split).
+        score: Quality score. Preferred shape is a number (`AnnotationSchema`
+            stores it as ``float``; the typical range used by `BASE_PROMPT` is
+            1.00 - 10.00). A numeric string such as ``"7.25"`` is also accepted.
+
+    Returns:
+        Validated `AnnotationSchema` with the normalized fields.
+    """
+    normalized_tags = _normalize_string_items(tags, field_name="tags", split_commas=True)
+    normalized_captions = _normalize_string_items(captions, field_name="captions", split_commas=False)
+    normalized_score = _normalize_score(score)
+
+    try:
+        return AnnotationSchema(tags=normalized_tags, captions=normalized_captions, score=normalized_score)
+    except ValidationError as exc:
+        raise ModelRetry("annotation output does not match AnnotationSchema") from exc
+
+
+__all__ = ["normalize_annotation_output"]

--- a/src/image_annotator_lib/core/provider_manager.py
+++ b/src/image_annotator_lib/core/provider_manager.py
@@ -26,11 +26,13 @@ from ..exceptions.errors import (
 from ..model_class.annotator_webapi.webapi_shared import BASE_PROMPT
 from .image_preprocess import preprocess_images_to_binary
 from .model_id import build_pydantic_model, resolve_model_ref
+from .output_normalization import normalize_annotation_output
 from .result_adapter import to_annotation_result
-from .types import AnnotationResult, AnnotationSchema
+from .types import AnnotationResult
 from .utils import calculate_phash, logger
 
-# ADR 0023 Phase 1 retry policy: structured output validation failure を 1 回再生成
+# ADR 0023 Phase 1 retry policy: output normalization / schema validation failure を 1 回再生成。
+# HTTP/API transient retry is handled separately by Issue #46 transport retry work.
 _OUTPUT_RETRIES = 1
 
 # Agent.run の user message として渡す短い指示。BASE_PROMPT は system_prompt 側で詳細を伝える。
@@ -80,7 +82,7 @@ class ProviderManager:
             model = build_pydantic_model(ref, api_key, config)
             agent = Agent(
                 model=model,
-                output_type=AnnotationSchema,
+                output_type=normalize_annotation_output,
                 system_prompt=BASE_PROMPT,
                 output_retries=_OUTPUT_RETRIES,
             )

--- a/src/image_annotator_lib/core/result_adapter.py
+++ b/src/image_annotator_lib/core/result_adapter.py
@@ -1,58 +1,21 @@
-"""PydanticAI `AnnotationSchema` → `AnnotationResult` 変換 (ADR 0023 Phase 1)。
+"""PydanticAI `AnnotationSchema` → `AnnotationResult` conversion.
 
 ADR 0023 `### Schema → Result 変換` を実装する責務集約モジュール。
 `ProviderManager` は inference 実行のみを担当し、結果変換ロジックは持たない。
+Validation 前の軽微な schema 揺れは `core.output_normalization` が PydanticAI
+output 処理内で補正する。
 
 参考: docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md
 """
 
 from __future__ import annotations
 
-from typing import Any
-
 from .types import AnnotationResult, AnnotationSchema
 
 
-def _normalize_string_list(value: Any) -> list[str]:
-    """ADR 0023 `Output normalization` の軽微正規化を適用する。
-
-    - `value` が文字列ならカンマ分割または single item list 化
-    - 各要素の前後空白を除去
-    - 空文字を除外
-
-    壊れた JSON の手修復や regex ベースの強引な復元は行わない。
-    """
-    if value is None:
-        return []
-    if isinstance(value, str):
-        # 文字列ならカンマ分割を試みる。カンマがなければ single item list。
-        items = value.split(",") if "," in value else [value]
-    elif isinstance(value, (list, tuple)):
-        items = list(value)
-    else:
-        return []
-    normalized: list[str] = []
-    for item in items:
-        if item is None:
-            continue
-        text = str(item).strip()
-        if text:
-            normalized.append(text)
-    return normalized
-
-
-def _normalize_score(value: Any) -> float | None:
-    """`score` フィールドを float に正規化する。失敗時は None。"""
-    if value is None:
-        return None
-    if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
-        try:
-            return float(value.strip())
-        except ValueError:
-            return None
-    return None
+def _clean_string_list(value: list[str]) -> list[str]:
+    """Final-defense cleanup for already validated schema lists."""
+    return [item.strip() for item in value if item.strip()]
 
 
 def to_annotation_result(
@@ -79,18 +42,13 @@ def to_annotation_result(
             error=error,
         )
 
-    raw_tags = getattr(schema_output, "tags", None)
-    raw_captions = getattr(schema_output, "captions", None)
-    raw_score = getattr(schema_output, "score", None)
+    normalized_tags = _clean_string_list(schema_output.tags)
+    normalized_captions = _clean_string_list(schema_output.captions)
 
-    normalized_tags = _normalize_string_list(raw_tags)
-    normalized_captions = _normalize_string_list(raw_captions)
-    normalized_score = _normalize_score(raw_score)
-
-    formatted_output: dict[str, Any] = {
+    formatted_output: dict[str, object] = {
         "tags": normalized_tags,
         "captions": normalized_captions,
-        "score": normalized_score,
+        "score": schema_output.score,
     }
 
     return AnnotationResult(

--- a/tests/unit/core/test_output_normalization.py
+++ b/tests/unit/core/test_output_normalization.py
@@ -1,0 +1,57 @@
+"""Issue #47: PydanticAI output normalization tests."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_ai import ModelRetry
+
+from image_annotator_lib.core.output_normalization import normalize_annotation_output
+
+
+class TestNormalizeAnnotationOutput:
+    """Minor output drift is normalized before `AnnotationSchema` validation."""
+
+    def test_normalizes_string_tags_caption_and_score(self) -> None:
+        result = normalize_annotation_output(
+            tags="cat, smile, outdoors",
+            captions="a cat sitting outside",
+            score="0.82",
+        )
+
+        assert result.tags == ["cat", "smile", "outdoors"]
+        assert result.captions == ["a cat sitting outside"]
+        assert result.score == 0.82
+
+    def test_single_string_tag_becomes_single_item_list(self) -> None:
+        result = normalize_annotation_output(tags="cat", captions=["caption"], score=1)
+
+        assert result.tags == ["cat"]
+        assert result.captions == ["caption"]
+        assert result.score == 1.0
+
+    def test_trims_and_drops_empty_items(self) -> None:
+        result = normalize_annotation_output(
+            tags=[" cat ", "", "  ", "dog"],
+            captions=[" caption ", ""],
+            score=0.5,
+        )
+
+        assert result.tags == ["cat", "dog"]
+        assert result.captions == ["caption"]
+
+    @pytest.mark.parametrize(
+        ("tags", "captions", "score"),
+        [
+            ({"tag": "cat"}, ["caption"], 0.5),
+            (["cat", 123], ["caption"], 0.5),
+            (["cat"], {"caption": "bad"}, 0.5),
+            (["cat"], ["caption", None], 0.5),
+            (["cat"], ["caption"], "not-a-number"),
+            (["cat"], ["caption"], True),
+        ],
+    )
+    def test_unsupported_values_raise_model_retry(
+        self, tags: object, captions: object, score: object
+    ) -> None:
+        with pytest.raises(ModelRetry):
+            normalize_annotation_output(tags=tags, captions=captions, score=score)

--- a/tests/unit/core/test_provider_manager_output_normalization.py
+++ b/tests/unit/core/test_provider_manager_output_normalization.py
@@ -1,0 +1,41 @@
+"""Issue #47: ProviderManager uses PydanticAI output normalization."""
+
+from __future__ import annotations
+
+from PIL import Image
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from image_annotator_lib.core.output_normalization import normalize_annotation_output
+from image_annotator_lib.core.provider_manager import ProviderManager
+
+
+def test_provider_manager_returns_normalized_annotation_result() -> None:
+    agent = Agent(
+        model=TestModel(
+            custom_output_args={
+                "tags": "cat, dog",
+                "captions": "a cat outside",
+                "score": "0.82",
+            }
+        ),
+        output_type=normalize_annotation_output,
+        output_retries=1,
+    )
+    image = Image.new("RGB", (8, 8), color="white")
+
+    results = ProviderManager.run_inference_with_model(
+        model_name="test-webapi",
+        images_list=[image],
+        litellm_model_id="openai/gpt-4o",
+        _test_agent=agent,
+    )
+
+    result = next(iter(results.values()))
+    assert result["error"] is None
+    assert result["tags"] == ["cat", "dog"]
+    assert result["formatted_output"] == {
+        "tags": ["cat", "dog"],
+        "captions": ["a cat outside"],
+        "score": 0.82,
+    }

--- a/tests/unit/core/test_result_adapter.py
+++ b/tests/unit/core/test_result_adapter.py
@@ -37,6 +37,8 @@ class TestToAnnotationResult:
         assert result["formatted_output"] is None
 
     def test_strips_whitespace(self) -> None:
+        # Issue #47: pre-validation normalization lives in output_normalization.
+        # result_adapter keeps only final-defense cleanup for validated schema values.
         schema = AnnotationSchema(tags=["  1girl  ", "blue eyes  "], captions=["  a girl"], score=8.0)
         result = to_annotation_result(schema, phash="abc")
         assert result["tags"] == ["1girl", "blue eyes"]
@@ -45,6 +47,7 @@ class TestToAnnotationResult:
         assert formatted["captions"] == ["a girl"]
 
     def test_excludes_empty_strings(self) -> None:
+        # Issue #47: this is final-defense cleanup, not raw output repair.
         schema = AnnotationSchema(tags=["1girl", "", "  ", "blue eyes"], captions=[], score=5.0)
         result = to_annotation_result(schema, phash="abc")
         assert result["tags"] == ["1girl", "blue eyes"]


### PR DESCRIPTION
## Summary
ADR 0023 line 50-55 / 595-600 で確定済みの「structured output validation / 軽微正規化を PydanticAI に寄せる」方針に従い、軽微正規化を `AnnotationSchema` validation の **前** に行う output function に集約する (B案、Issue #47)。

`BASE_PROMPT` は LLM に「`tags: comma-separated string`」「`caption: single string`」を指示する一方、`AnnotationSchema` は `list[str]` を期待するため drift は構造的に発生する。本 PR 以前は `output_retries=1` の LLM 再生成のみが補正手段だったため、retry 失敗時に inference 全体が失敗していた。output function 経路では drift をコード側で補正してそのまま valid 化できる。

## 実装

### `core/output_normalization.py` (新規)
- `normalize_annotation_output(tags, captions, score) -> AnnotationSchema`
- PydanticAI `Agent.output_type` に渡す callable。PydanticAI が tool として LLM に公開
- docstring は LLM-facing description (内部実装説明は module docstring に分離)
- 許可する正規化:
  - tags: 文字列 (カンマ分割または single item) → `list[str]`、各要素 trim、空除外
  - captions: 文字列 (single) → `list[str]`、trim、空除外 (カンマ分割しない)
  - score: 数値文字列 → `float` (bool は明示拒否)
- 補正不能 (None / dict / list 内非文字列 等) は `ModelRetry` を raise し PydanticAI `output_retries=1` 経由で再生成

### `core/provider_manager.py`
- `Agent(output_type=AnnotationSchema, ...)` → `Agent(output_type=normalize_annotation_output, ...)`
- `AnnotationSchema` import 削除、retry policy comment 更新 (Issue #46 transport retry 別タスクと明記)

### `core/result_adapter.py` (簡素化)
- 旧 `_normalize_string_list()` / `_normalize_score()` (pre-validation 補正) を削除
- `_clean_string_list()` 最終防衛のみ残す
- `to_annotation_result()` は検証済み `AnnotationSchema` → `AnnotationResult` 変換専任

### `CLAUDE.md`
- Web API Integration / WebAPI Inference Architecture / PydanticAI-Specific Guidelines セクションに output normalization の責務を追記
- 関連 ISSUE 一覧に #47 を追加

## 実装しない補正 (ADR 0023 と整合)

- 壊れた JSON の手修復
- free text からの regex 強制復元
- provider 別 parser layer
- Issue #46 (HTTP/API transport retry) — 別 issue / 別 PR

## 受け入れ条件 (すべて満たす)

- [x] `tags=\"cat, dog\"` → `[\"cat\", \"dog\"]`
- [x] `captions=\"...\"` → `[...]`
- [x] `score=\"0.82\"` → `0.82`
- [x] trim/drop empty が output 処理内で行われる
- [x] 補正不能で `ModelRetry`
- [x] `ProviderManager` が output function を `Agent.output_type` に渡す
- [x] `result_adapter.py` は変換専任
- [x] 壊れた JSON 修復・regex 復元・provider 別 parser を追加していない
- [x] `output_retries=1` 維持

## Test plan
- [x] 新規 16 ケース PASS (`test_output_normalization.py` 9 ケース + `test_provider_manager_output_normalization.py` 1 ケース + `test_result_adapter.py` 6 ケース)
- [x] 既存 refusal / capability / annotation_runner / webapi_annotator test 64 ケース PASS
- [x] 全 unit test 512 PASS (1 件 pre-existing failure 除く)
- [x] ruff format / check (Issue #47 ファイル) clean
- [x] mypy: main HEAD と同じ 6 件、新規エラーなし
- [ ] 実 LLM での integration test (CI 後に手動検証)

## Related
- Issue: #47
- ADR: [LoRAIro `0023-pydanticai-litellm-webapi-inference-boundary.md`](https://github.com/NEXTAltair/LoRAIro/blob/main/docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md) line 50-55 / 595-600
- 後続 PR: LoRAIro 側で submodule bump + ADR 0023 Phase 1.7 補遺 (PR-B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)