### PR TITLE
fix(#51): preserve full LiteLLM ID in _format_litellm_metadata

### DIFF
--- a/src/image_annotator_lib/core/api_model_discovery.py
+++ b/src/image_annotator_lib/core/api_model_discovery.py
@@ -55,18 +55,24 @@ def _is_litellm_model_annotation_compatible(info: dict[str, Any]) -> bool:
 def _format_litellm_metadata(model_id: str, info: dict[str, Any]) -> dict[str, Any] | None:
     """LiteLLM の `get_model_info()` 結果を共通 metadata 形式に整形する。
 
+    Issue #51 (ADR 0023 Phase 1.9): `model_name_short` は LiteLLM 同梱 DB のオリジナルキー
+    と同一の完全 ID を保持する。旧実装は `split("/", 1)[1]` で provider prefix を剥がしていた
+    ため、`openrouter/<inner>/<model>` (例: `openrouter/z-ai/glm-4.7`) で prefix 欠落形が
+    registry / CLI / DB に伝播し、推論時に `_BUILDER_DISPATCH` 未知 prefix で
+    `UnknownProviderError` が発生していた。
+
     Returns:
         フォーマット済 dict。`provider/model` 形式でない model_id は None。
     """
     if "/" not in model_id:
         return None
 
-    provider_raw, provider_model_id = model_id.split("/", 1)
+    provider_raw, _ = model_id.split("/", 1)
     provider = "OpenAI" if provider_raw == "openai" else provider_raw.capitalize()
 
     return {
         "provider": provider,
-        "model_name_short": provider_model_id,
+        "model_name_short": model_id,
         "display_name": model_id,
         "mode": info.get("mode", "chat"),
         "max_tokens": info.get("max_tokens"),

--- a/tests/unit/core/test_api_model_discovery_filter.py
+++ b/tests/unit/core/test_api_model_discovery_filter.py
@@ -109,3 +109,34 @@ class TestFormatLitellmMetadata:
     def test_invalid_model_id_returns_none(self):
         """`provider/model` 形式でない ID は None を返す。"""
         assert _format_litellm_metadata("invalid_id_no_slash", {}) is None
+
+    def test_openrouter_nested_keeps_full_id(self):
+        """Issue #51: openrouter/<inner>/<model> は model_name_short が完全 ID と一致する。
+
+        旧実装は `split("/", 1)[1]` で `openrouter/` prefix を剥がし `z-ai/glm-4.7` を
+        返していたため、推論時に `_BUILDER_DISPATCH` 未知 prefix で UnknownProviderError が
+        発生していた。修正後は LiteLLM オリジナルキーをそのまま保持する。
+        """
+        info = {"supports_vision": True, "supports_function_calling": True, "mode": "chat"}
+        metadata = _format_litellm_metadata("openrouter/z-ai/glm-4.7", info)
+        assert metadata is not None
+        assert metadata["model_name_short"] == "openrouter/z-ai/glm-4.7"
+        assert metadata["display_name"] == "openrouter/z-ai/glm-4.7"
+        assert metadata["provider"] == "Openrouter"
+
+    def test_openrouter_openai_keeps_full_id(self):
+        """Issue #51: openrouter/openai/<model> も同様に prefix を保持する。"""
+        info = {"supports_vision": True, "supports_function_calling": True, "mode": "chat"}
+        metadata = _format_litellm_metadata("openrouter/openai/gpt-4.1", info)
+        assert metadata is not None
+        assert metadata["model_name_short"] == "openrouter/openai/gpt-4.1"
+        assert metadata["display_name"] == "openrouter/openai/gpt-4.1"
+
+    def test_direct_provider_id_uses_full_id(self):
+        """Issue #51: openai/<model> 直接形式も model_name_short = 完全 ID。"""
+        info = {"supports_vision": True, "supports_function_calling": True, "mode": "chat"}
+        metadata = _format_litellm_metadata("openai/gpt-4o", info)
+        assert metadata is not None
+        assert metadata["model_name_short"] == "openai/gpt-4o"
+        assert metadata["display_name"] == "openai/gpt-4o"
+        assert metadata["provider"] == "OpenAI"

--- a/tests/unit/core/test_model_id.py
+++ b/tests/unit/core/test_model_id.py
@@ -46,6 +46,9 @@ class TestResolveModelRef:
             ("google/gemini-2.5-pro", "google", "gemini-2.5-pro"),
             ("gemini/gemini-2.5-flash", "google", "gemini-2.5-flash"),  # alias
             ("openrouter/google/gemini-2.5-pro", "openrouter", "google/gemini-2.5-pro"),
+            # Issue #51: 未知 inner provider の OpenRouter 経路も openrouter builder に dispatch される
+            ("openrouter/z-ai/glm-4.7", "openrouter", "z-ai/glm-4.7"),
+            ("openrouter/qwen/qwen2-vl-72b-instruct", "openrouter", "qwen/qwen2-vl-72b-instruct"),
         ],
     )
     def test_resolves_supported_provider(


### PR DESCRIPTION
## Summary

`_format_litellm_metadata()` の `model_name_short` を **LiteLLM 同梱 DB のオリジナルキーと同一の完全 ID** に揃える修正。registry / CLI / LoRAIro DB の `litellm_model_id` 列が同一値で SSoT 統一される。

旧実装は `split("/", 1)[1]` で provider prefix を剥がした文字列を返していたため、`openrouter/z-ai/glm-4.7` のような nested LiteLLM ID は `model_name_short = "z-ai/glm-4.7"` となり、推論時 `resolve_model_ref()` が `_BUILDER_DISPATCH` 未知 prefix で `UnknownProviderError` を出していた (#51)。

本 PR では `_format_litellm_metadata()` の 1 行のみを修正し、`is_allowed_provider()` は変更しない。`openrouter/<inner>/<model>` は既に第 1 要素 (`openrouter`) で SUPPORTED_PROVIDERS 通過するため、Issue #51 の「OpenRouter 配下は全表示」要件は既に満たしている。inner provider (`z-ai`, `qwen`, `mistralai` 等) の追加フィルタは入れない。

## Changes

- `src/image_annotator_lib/core/api_model_discovery.py`: `_format_litellm_metadata()` の `model_name_short` を完全 LiteLLM ID (= `model_id`) に変更。`display_name` も同一値となるが既存呼び出し側互換のため両 field を残す
- `tests/unit/core/test_api_model_discovery_filter.py`: 3 ケース追加 (`openrouter/z-ai/glm-4.7`, `openrouter/openai/gpt-4.1`, `openai/gpt-4o`)
- `tests/unit/core/test_model_id.py`: parametrize に 2 ケース追加 (`openrouter/z-ai/glm-4.7`, `openrouter/qwen/qwen2-vl-72b-instruct`) で registry → 推論ルーティングを保証

## Test plan

- [x] `uv run pytest tests/unit/core/test_api_model_discovery_filter.py tests/unit/core/test_model_id.py -v` — 32 PASS
- [x] `uv run pytest tests/` (excluding pre-existing failures) — 603 passed / 18 skipped
- [x] LoRAIro 側 `lorairo-cli models list` — `openrouter/z-ai/glm-4.7`, `openrouter/qwen/qwen3.5-...` 等が完全 ID で 71 件表示、prefix 欠落形は消失
- [x] `test_tagger_transformers::test_toriigate_tagger_format_with_assistant_prefix` および BDD features の 5 件 failure は main でも再現する pre-existing failure と確認済み

## ADR 連携

LoRAIro 側 ADR 0023 に Phase 1.9 補遺セクションを追加する別 PR を出します (submodule bump 込み)。

## Related

- Closes #51
- Refs ADR 0023 line 65-77 (ID 境界規定) / line 109 (prefix 解析対象)
- 別 Issue として #52 (Phase 1.10 — Anthropic bare 名対応) を起票済み (本 PR マージ後着手)
- LoRAIro Issue #238 (`schema.Model.litellm_model_id` 列の完全 ID 化、別 PR で対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
