### PR TITLE
feat(#52): normalize bare claude-* IDs to anthropic/<bare> (ADR 0023 Phase 1.10)

### DIFF
--- a/src/image_annotator_lib/core/api_model_discovery.py
+++ b/src/image_annotator_lib/core/api_model_discovery.py
@@ -24,15 +24,47 @@ from .utils import logger
 
 _SUPPORTED_LITELLM_MODES: frozenset[str] = frozenset({"chat", "responses"})
 
+# ADR 0023 Phase 1.10 (Issue #52): LiteLLM 同梱 DB は Anthropic 直接モデルを `claude-*` の
+# bare 名で格納するため、`anthropic/` プレフィックスを補完して `_BUILDER_DISPATCH` 対象に乗せる。
+# スコープ拡張時はこの tuple に prefix を追加すれば `_canonicalize_litellm_id()` 経路で対応可能。
+_ANTHROPIC_BARE_PREFIXES: tuple[str, ...] = ("claude-",)
+
+
+def _canonicalize_litellm_id(model_id: str) -> str | None:
+    """LiteLLM 同梱 DB のキーを `provider/model` 形式に正規化する (ADR 0023 Phase 1.10)。
+
+    LiteLLM 同梱 DB は Anthropic 直接モデルを `claude-opus-4-6` のような bare 名で
+    格納している。`is_allowed_provider()` の `/` チェックで全除外されると Anthropic
+    直接プロバイダー経路が registry に登録されないため、`anthropic/<bare>` 形式に補完する。
+
+    Args:
+        model_id: LiteLLM 同梱 DB のキー (slash 入り or bare)。
+
+    Returns:
+        正規化後の `provider/model` 形式 ID。スコープ外の bare 名 (`claude-` 以外で
+        始まる、または slash を含まないが `_ANTHROPIC_BARE_PREFIXES` に該当しない形式)
+        は None。
+    """
+    if "/" in model_id:
+        return model_id
+    if model_id.startswith(_ANTHROPIC_BARE_PREFIXES):
+        return f"anthropic/{model_id}"
+    return None
+
 
 def is_allowed_provider(model_id: str) -> bool:
     """model_id の provider prefix が `SUPPORTED_PROVIDERS` に含まれるか判定する。
 
     `core/model_id.py` の dispatch table を SSoT とし、本ファイル独自の allowlist は持たない。
+
+    ADR 0023 Phase 1.10 (Issue #52): bare `claude-*` (LiteLLM JSON で `/` 無しで格納される
+    Anthropic 直接モデル) は `_canonicalize_litellm_id()` で `anthropic/<bare>` に補完して
+    判定する。
     """
-    if "/" not in model_id:
+    canonical = _canonicalize_litellm_id(model_id)
+    if canonical is None:
         return False
-    provider = model_id.split("/", 1)[0]
+    provider = canonical.split("/", 1)[0]
     return provider in SUPPORTED_PROVIDERS
 
 
@@ -61,19 +93,25 @@ def _format_litellm_metadata(model_id: str, info: dict[str, Any]) -> dict[str, A
     registry / CLI / DB に伝播し、推論時に `_BUILDER_DISPATCH` 未知 prefix で
     `UnknownProviderError` が発生していた。
 
+    Issue #52 (ADR 0023 Phase 1.10): bare `claude-*` 形式 (LiteLLM JSON で Anthropic 直接
+    モデルが格納される形式) は `_canonicalize_litellm_id()` で `anthropic/<bare>` に正規化
+    した値を `model_name_short` / `display_name` に設定する。
+
     Returns:
-        フォーマット済 dict。`provider/model` 形式でない model_id は None。
+        フォーマット済 dict。`_canonicalize_litellm_id()` がスコープ外と判定した model_id
+        (`/` 無しかつ `claude-` で始まらない形式) は None。
     """
-    if "/" not in model_id:
+    canonical = _canonicalize_litellm_id(model_id)
+    if canonical is None:
         return None
 
-    provider_raw, _ = model_id.split("/", 1)
+    provider_raw, _ = canonical.split("/", 1)
     provider = "OpenAI" if provider_raw == "openai" else provider_raw.capitalize()
 
     return {
         "provider": provider,
-        "model_name_short": model_id,
-        "display_name": model_id,
+        "model_name_short": canonical,
+        "display_name": canonical,
         "mode": info.get("mode", "chat"),
         "max_tokens": info.get("max_tokens"),
         "max_input_tokens": info.get("max_input_tokens"),
@@ -101,7 +139,10 @@ def _collect_models(
         exclude_deprecated: True なら `deprecation_date` が設定されている entry を除外。
 
     Returns:
-        `litellm_model_id -> metadata` のマッピング。
+        `<正規化後 litellm_model_id> -> metadata` のマッピング。Issue #52 (ADR 0023
+        Phase 1.10) 以降、bare `claude-*` は `anthropic/claude-*` に正規化された
+        キーで格納される。slash 入り ID はそのまま LiteLLM オリジナルキーがキーとなる
+        (Issue #51 / Phase 1.9)。
     """
     metadata: dict[str, dict[str, Any]] = {}
     for model_id in litellm.model_cost.keys():
@@ -120,7 +161,9 @@ def _collect_models(
             continue
         formatted = _format_litellm_metadata(model_id, info)
         if formatted:
-            metadata[model_id] = formatted
+            # ADR 0023 Phase 1.10 (Issue #52): dict キーは正規化後 ID で統一。
+            # registry / CLI / LoRAIro DB 列に伝播する `model_name_short` と一致させる。
+            metadata[formatted["model_name_short"]] = formatted
     return metadata
 
 

--- a/tests/unit/core/test_api_model_discovery_filter.py
+++ b/tests/unit/core/test_api_model_discovery_filter.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 import pytest
 
 from image_annotator_lib.core.api_model_discovery import (
+    _canonicalize_litellm_id,
     _format_litellm_metadata,
     _is_litellm_model_annotation_compatible,
+    is_allowed_provider,
 )
 
 
@@ -140,3 +142,83 @@ class TestFormatLitellmMetadata:
         assert metadata["model_name_short"] == "openai/gpt-4o"
         assert metadata["display_name"] == "openai/gpt-4o"
         assert metadata["provider"] == "OpenAI"
+
+    def test_claude_bare_canonicalized(self):
+        """Issue #52: bare `claude-*` は `anthropic/<bare>` に正規化される。"""
+        info = {"supports_vision": True, "supports_function_calling": True, "mode": "chat"}
+        metadata = _format_litellm_metadata("claude-opus-4-6", info)
+        assert metadata is not None
+        assert metadata["model_name_short"] == "anthropic/claude-opus-4-6"
+        assert metadata["display_name"] == "anthropic/claude-opus-4-6"
+        assert metadata["provider"] == "Anthropic"
+
+    def test_claude_bare_with_date_suffix_canonicalized(self):
+        """Issue #52: 日付サフィックス付きの bare `claude-*` も同様に正規化される。"""
+        info = {"supports_vision": True, "supports_function_calling": True, "mode": "chat"}
+        metadata = _format_litellm_metadata("claude-3-5-sonnet-20241022", info)
+        assert metadata is not None
+        assert metadata["model_name_short"] == "anthropic/claude-3-5-sonnet-20241022"
+        assert metadata["provider"] == "Anthropic"
+
+    def test_non_claude_bare_returns_none(self):
+        """Issue #52: claude- 以外の bare 名 (gpt-4o 等) は除外維持。"""
+        info = {"supports_vision": True, "supports_function_calling": True, "mode": "chat"}
+        assert _format_litellm_metadata("gpt-4o", info) is None
+        # Bedrock 形式 `anthropic.claude-*` も `claude-` で始まらないので除外
+        assert _format_litellm_metadata("anthropic.claude-3-5-sonnet", info) is None
+
+
+@pytest.mark.unit
+class TestCanonicalizeLitellmId:
+    """`_canonicalize_litellm_id()` の境界条件 (Issue #52 / ADR 0023 Phase 1.10)。"""
+
+    def test_slash_id_passthrough(self):
+        """slash 入り ID はそのまま返される。"""
+        assert _canonicalize_litellm_id("openai/gpt-4o") == "openai/gpt-4o"
+        assert _canonicalize_litellm_id("anthropic/claude-3-5-sonnet-20241022") == (
+            "anthropic/claude-3-5-sonnet-20241022"
+        )
+        assert _canonicalize_litellm_id("openrouter/z-ai/glm-4.7") == "openrouter/z-ai/glm-4.7"
+
+    def test_claude_bare_normalized(self):
+        """bare `claude-*` は `anthropic/<bare>` に補完される。"""
+        assert _canonicalize_litellm_id("claude-opus-4-6") == "anthropic/claude-opus-4-6"
+        assert _canonicalize_litellm_id("claude-3-5-sonnet-20241022") == (
+            "anthropic/claude-3-5-sonnet-20241022"
+        )
+        assert _canonicalize_litellm_id("claude-haiku-4-5") == "anthropic/claude-haiku-4-5"
+
+    def test_non_claude_bare_returns_none(self):
+        """`claude-` 以外の bare 名は対応外として None。"""
+        assert _canonicalize_litellm_id("gpt-4o") is None
+        # Bedrock 形式: ドット区切りで `claude-` で始まらない
+        assert _canonicalize_litellm_id("anthropic.claude-3-5-sonnet") is None
+        assert _canonicalize_litellm_id("invalid_id_no_slash") is None
+
+    def test_empty_string_returns_none(self):
+        """空文字も None。"""
+        assert _canonicalize_litellm_id("") is None
+
+
+@pytest.mark.unit
+class TestIsAllowedProviderBareName:
+    """`is_allowed_provider()` の Phase 1.10 拡張 (Issue #52)。"""
+
+    def test_claude_bare_allowed(self):
+        """bare `claude-*` は anthropic 経由で SUPPORTED_PROVIDERS 通過。"""
+        assert is_allowed_provider("claude-opus-4-6") is True
+        assert is_allowed_provider("claude-haiku-4-5") is True
+
+    def test_non_claude_bare_rejected(self):
+        """claude- 以外の bare 名は除外維持。"""
+        assert is_allowed_provider("gpt-4o") is False
+        # Bedrock 形式の bare 名 (claude- で始まらない) は除外
+        assert is_allowed_provider("anthropic.claude-3-5-sonnet") is False
+
+    def test_slash_id_unchanged(self):
+        """slash 入り ID の判定は Phase 1.9 と変わらず。"""
+        assert is_allowed_provider("openai/gpt-4o") is True
+        assert is_allowed_provider("anthropic/claude-3-5-sonnet-20241022") is True
+        assert is_allowed_provider("openrouter/z-ai/glm-4.7") is True
+        # SUPPORTED_PROVIDERS 外はそのまま除外 (vertex_ai は dispatch 未対応)
+        assert is_allowed_provider("vertex_ai/claude-opus-4-6") is False


### PR DESCRIPTION
## Summary

LiteLLM 同梱 DB が Anthropic 直接モデルを bare 名 (`claude-opus-4-6`, `claude-sonnet-4-6` 等、19 件) で格納しているため、`is_allowed_provider()` の `if "/" not in model_id: return False` チェックが Anthropic 直接プロバイダー経路を全除外していた。OpenRouter 経由 (`openrouter/anthropic/claude-*`) のみが registry に登録され、`_BUILDER_DISPATCH["anthropic"]` (= `_build_anthropic_ref`) は既に `anthropic/<model>` 形式をサポートしているにも関わらず CLI / 推論面からは到達不能だった。

`_canonicalize_litellm_id()` ヘルパーを追加し、bare `claude-*` を `anthropic/<bare>` に補完して registry / CLI / LoRAIro DB の SSoT に乗せる。Issue #51 (Phase 1.9) で確立した「LiteLLM オリジナルキーと完全 ID をそのまま伝播する」原則の延長線。

## Changes

- `src/image_annotator_lib/core/api_model_discovery.py`:
  - `_ANTHROPIC_BARE_PREFIXES = ("claude-",)` 定数と `_canonicalize_litellm_id()` ヘルパーを新設
  - `is_allowed_provider()` を refactor し、bare `claude-*` も SUPPORTED_PROVIDERS 通過するように
  - `_format_litellm_metadata()` を canonicalize 経由にし、bare 入力時は `model_name_short` / `display_name` に `anthropic/<bare>` を格納
  - `_collect_models()` の dict キーを正規化後 ID に統一 (`metadata[formatted["model_name_short"]] = formatted`)
- `tests/unit/core/test_api_model_discovery_filter.py`: 新規 2 クラス追加 (`TestCanonicalizeLitellmId` 4 ケース、`TestIsAllowedProviderBareName` 3 ケース) + 既存 `TestFormatLitellmMetadata` に 3 ケース追加 (計 10 ケース新規)

### 変更不要箇所 (確認済)

- `core/model_id.py` `_BUILDER_DISPATCH["anthropic"]`: `_build_anthropic_ref` は既に `anthropic/<model>` 形式をサポート
- `is_model_deprecated()`: `litellm.get_model_info()` は bare/slash 両形式で同一 metadata を返す挙動を確認済み。逆正規化処理は不要
- `core/registry.py`: `model_name_short` を辞書値からそのままキーとして登録するため整合

## スコープ

- **対象**: LiteLLM JSON の bare `claude-*` (Anthropic 直接モデル、19 件)
- **対象外**: Bedrock/Vertex 経由の bare 形式 (`anthropic.claude-*`, `claude-X@YYYYMMDD` 等、約 178 件)。これらは `_BUILDER_DISPATCH` に builder 追加が必要なため別 ADR で扱う

## Test plan

- [x] `uv run pytest tests/unit/core/test_api_model_discovery_filter.py tests/unit/core/test_model_id.py -v` — 42 PASS (新規 10 件 + 既存 32 件)
- [x] `uv run pytest tests/` (excluding pre-existing failures) — 613 passed / 18 skipped
- [x] LoRAIro 側 annotation/CLI/services tests 148 PASS (影響なし)
- [x] `lorairo-cli models list` で `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5` 等 19 件が完全 ID で追加表示。webapi モデル数 71 → 90 件、総計 104 → 123 件
- [x] Pre-existing failures (BDD features の 5 件 + tagger_transformers の 1 件) は main でも再現する既知の問題 (Phase 1.9 PR で確認済み)

## ADR 連携

LoRAIro 側 ADR 0023 に Phase 1.10 補遺セクションを追加する別 PR を出します (submodule bump 込み)。

## Related

- Closes #52
- Refs ADR 0023 line 109 (prefix 解析対象規定の解釈拡張)
- 前提条件: PR #53 / Phase 1.9 (マージ済み)
- 関連未対応: #39 (重複登録)、LoRAIro Issue #238 (schema 変更)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
