### PR TITLE
fix(#57): ToriiGate test を _format_predictions 戻り値型に追従させる

### DIFF
--- a/tests/unit/model_class/test_tagger_transformers.py
+++ b/tests/unit/model_class/test_tagger_transformers.py
@@ -14,6 +14,7 @@ import pytest
 import torch
 from PIL import Image
 
+from image_annotator_lib.core.types import TaskCapability, UnifiedAnnotationResult
 from image_annotator_lib.model_class.tagger_transformers import BLIP2Tagger, BLIPTagger, GITTagger
 
 
@@ -670,9 +671,15 @@ def test_toriigate_tagger_format_with_assistant_prefix(
             assert call_args[1]["skip_special_tokens"] is True
 
             # Verify "Assistant: " prefix stripped
+            # _format_predictions returns list[UnifiedAnnotationResult] (captioner なので captions field に格納)
             assert len(result) == 1
-            assert result[0] == "A photo of a cat sitting on a table"
-            assert "Assistant: " not in result[0]
+            assert isinstance(result[0], UnifiedAnnotationResult)
+            assert result[0].model_name == "test_toriigate"
+            assert TaskCapability.CAPTIONS in result[0].capabilities
+            assert result[0].captions == ["A photo of a cat sitting on a table"]
+            assert "Assistant: " not in result[0].captions[0]
+            assert result[0].framework == "transformers"
+            assert result[0].error is None
 
     # Test case 2: Without "Assistant: " prefix
     mock_processor.batch_decode.return_value = ["Simple caption text"]
@@ -689,4 +696,7 @@ def test_toriigate_tagger_format_with_assistant_prefix(
 
             # Verify text returned as-is when no prefix
             assert len(result) == 1
-            assert result[0] == "Simple caption text"
+            assert isinstance(result[0], UnifiedAnnotationResult)
+            assert result[0].captions == ["Simple caption text"]
+            assert result[0].framework == "transformers"
+            assert result[0].error is None


### PR DESCRIPTION
## Summary

`tests/unit/model_class/test_tagger_transformers.py::test_toriigate_tagger_format_with_assistant_prefix` の assertion が古い `list[str]` 戻り値前提のまま残っていた既存バグを修正。`ToriiGateTagger._format_predictions()` は `list[UnifiedAnnotationResult]` を返す現在の契約に test を追従させる。

Closes #57

## 発見契機

LoRAIro PR https://github.com/NEXTAltair/LoRAIro/pull/251 (Issue #247) で image-annotator-lib の CI job が独立稼働してから検出。LoRAIro 本体 CI は ADR 0016 で image-annotator-lib を coverage source 除外していたため、これまで未検出だった。

## 変更

- `from image_annotator_lib.core.types import TaskCapability, UnifiedAnnotationResult` を file 上部 import 群に追加
- Test case 1 (Assistant prefix あり、L673-675): 文字列比較 → `UnifiedAnnotationResult.captions` field 比較 + `isinstance` / `model_name` / `capabilities` / `framework` / `error` も assert
- Test case 2 (Assistant prefix なし、L691-692): 同様に修正

## 受け入れ条件 (Issue #57)

- [x] `test_toriigate_tagger_format_with_assistant_prefix` が pass する
- [x] `result[0] == "..."` 形式の古い assertion が該当テストから消える
- [x] `ToriiGateTagger._format_predictions()` の戻り値型は `list[UnifiedAnnotationResult]` のまま維持
- [x] image-annotator-lib テストが `--deselect` なしで pass する
- [ ] LoRAIro 側 submodule pin 更新後、PR #251 で追加した `--deselect` 行を撤去する (本 PR merge 後の LoRAIro 側 followup PR で対応)

## ローカル検証

\`\`\`text
$ uv run pytest tests/unit/model_class/test_tagger_transformers.py -v
collected 10 items

tests/unit/model_class/test_tagger_transformers.py::test_transformers_tagger_initialization PASSED
tests/unit/model_class/test_tagger_transformers.py::test_transformers_tagger_preprocessing PASSED
...
tests/unit/model_class/test_tagger_transformers.py::test_toriigate_tagger_format_with_assistant_prefix PASSED [100%]

============================= 10 passed in 18.28s ==============================
\`\`\`

## Test plan

- [ ] image-annotator-lib リポジトリ側で test_tagger_transformers.py 全 pass を CI/local で確認
- [ ] LoRAIro 側 followup PR で本 merge commit に submodule pin 更新 + `--deselect` 撤去
- [ ] LoRAIro CI の test-image-annotator-lib job が `--deselect` なしで 620+ passed になることを確認

## 関連

- LoRAIro PR #251 (Issue #247): https://github.com/NEXTAltair/LoRAIro/pull/251
- LoRAIro Issue #247: https://github.com/NEXTAltair/LoRAIro/issues/247

🤖 Generated with [Claude Code](https://claude.com/claude-code)