### PR TITLE
fix(#60): _canonicalize_litellm_id を litellm_provider field SSoT 方式に置換

### DIFF
--- a/src/image_annotator_lib/core/api_model_discovery.py
+++ b/src/image_annotator_lib/core/api_model_discovery.py
@@ -24,44 +24,61 @@ from .utils import logger
 
 _SUPPORTED_LITELLM_MODES: frozenset[str] = frozenset({"chat", "responses"})
 
-# ADR 0023 Phase 1.10 (Issue #52): LiteLLM 同梱 DB は Anthropic 直接モデルを `claude-*` の
-# bare 名で格納するため、`anthropic/` プレフィックスを補完して `_BUILDER_DISPATCH` 対象に乗せる。
-# スコープ拡張時はこの tuple に prefix を追加すれば `_canonicalize_litellm_id()` 経路で対応可能。
-_ANTHROPIC_BARE_PREFIXES: tuple[str, ...] = ("claude-",)
 
+def _canonicalize_litellm_id(
+    model_id: str,
+    info: dict[str, Any] | None = None,
+) -> str | None:
+    """LiteLLM 同梱 DB のキーを `provider/model` 形式に正規化する (Issue #60)。
 
-def _canonicalize_litellm_id(model_id: str) -> str | None:
-    """LiteLLM 同梱 DB のキーを `provider/model` 形式に正規化する (ADR 0023 Phase 1.10)。
+    LiteLLM 同梱 DB の各 entry が持つ ``litellm_provider`` field を SSoT として
+    provider を判定する。bare ID については ``litellm_provider`` が
+    ``SUPPORTED_PROVIDERS`` に含まれる場合のみ ``provider/<bare>`` に補完する。
+    slash 入り ID はそのまま返す (LiteLLM 側で既に正規化済前提)。
 
-    LiteLLM 同梱 DB は Anthropic 直接モデルを `claude-opus-4-6` のような bare 名で
-    格納している。`is_allowed_provider()` の `/` チェックで全除外されると Anthropic
-    直接プロバイダー経路が registry に登録されないため、`anthropic/<bare>` 形式に補完する。
+    旧実装 (Issue #52, ADR 0023 Phase 1.10) は ``_ANTHROPIC_BARE_PREFIXES = ("claude-",)``
+    で Anthropic bare 名のみハードコード補完していたため、OpenAI (gpt-4o, gpt-5.2, o3, ...)
+    や Gemini (gemini-1.5-pro 等) の bare 名が ``None`` で除外される問題があった
+    (LoRAIro#253 連動)。LiteLLM ``litellm_provider`` field 経由で provider を判定する
+    ことで新モデル名規則に追従不要・新 provider 追加は ``_BUILDER_DISPATCH`` 更新 1 行で
+    完了する構造になる。
 
     Args:
-        model_id: LiteLLM 同梱 DB のキー (slash 入り or bare)。
+        model_id: LiteLLM ``model_cost`` のキー (slash 入り or bare)。
+        info: ``litellm.model_cost[model_id]`` の dict (任意)。None なら関数内で
+            lookup する。``_collect_models`` ループ内のように既に取得済の場合は
+            渡すと重複 lookup を避けられる。
 
     Returns:
-        正規化後の `provider/model` 形式 ID。スコープ外の bare 名 (`claude-` 以外で
-        始まる、または slash を含まないが `_ANTHROPIC_BARE_PREFIXES` に該当しない形式)
-        は None。
+        正規化後の ``provider/model`` 形式 ID。``litellm_provider`` が
+        ``SUPPORTED_PROVIDERS`` に含まれない bare ID、LiteLLM DB に存在しない bare ID、
+        または ``litellm_provider`` field 欠落の bare ID は None。
     """
     if "/" in model_id:
         return model_id
-    if model_id.startswith(_ANTHROPIC_BARE_PREFIXES):
-        return f"anthropic/{model_id}"
-    return None
+    if info is None:
+        info = litellm.model_cost.get(model_id)
+    if info is None:
+        return None
+    provider = info.get("litellm_provider")
+    if not provider or provider not in SUPPORTED_PROVIDERS:
+        return None
+    return f"{provider}/{model_id}"
 
 
-def is_allowed_provider(model_id: str) -> bool:
-    """model_id の provider prefix が `SUPPORTED_PROVIDERS` に含まれるか判定する。
+def is_allowed_provider(model_id: str, info: dict[str, Any] | None = None) -> bool:
+    """model_id の provider が ``SUPPORTED_PROVIDERS`` に含まれるか判定する。
 
-    `core/model_id.py` の dispatch table を SSoT とし、本ファイル独自の allowlist は持たない。
+    ``core/model_id.py`` の dispatch table を SSoT とし、本ファイル独自の allowlist は持たない。
 
-    ADR 0023 Phase 1.10 (Issue #52): bare `claude-*` (LiteLLM JSON で `/` 無しで格納される
-    Anthropic 直接モデル) は `_canonicalize_litellm_id()` で `anthropic/<bare>` に補完して
-    判定する。
+    Issue #60: bare ID は LiteLLM 同梱 DB の ``litellm_provider`` field を介して
+    provider を判定する (``_canonicalize_litellm_id()`` 経由)。
+
+    Args:
+        model_id: LiteLLM ``model_cost`` のキー (slash 入り or bare)。
+        info: ``litellm.model_cost[model_id]`` の dict (任意)。重複 lookup 回避用。
     """
-    canonical = _canonicalize_litellm_id(model_id)
+    canonical = _canonicalize_litellm_id(model_id, info=info)
     if canonical is None:
         return False
     provider = canonical.split("/", 1)[0]
@@ -97,11 +114,16 @@ def _format_litellm_metadata(model_id: str, info: dict[str, Any]) -> dict[str, A
     モデルが格納される形式) は `_canonicalize_litellm_id()` で `anthropic/<bare>` に正規化
     した値を `model_name_short` / `display_name` に設定する。
 
+    Issue #60: `_canonicalize_litellm_id()` の正規化規則を LiteLLM ``litellm_provider``
+    field SSoT 方式に置換 (claude- ハードコードから移行)。bare ID は OpenAI / Anthropic /
+    Gemini を含む ``SUPPORTED_PROVIDERS`` 全ての ``provider/<bare>`` に正規化される。
+
     Returns:
         フォーマット済 dict。`_canonicalize_litellm_id()` がスコープ外と判定した model_id
-        (`/` 無しかつ `claude-` で始まらない形式) は None。
+        (LiteLLM ``litellm_provider`` が ``SUPPORTED_PROVIDERS`` 外、または bare ID で
+        LiteLLM DB に該当 entry が無い) は None。
     """
-    canonical = _canonicalize_litellm_id(model_id)
+    canonical = _canonicalize_litellm_id(model_id, info=info)
     if canonical is None:
         return None
 
@@ -139,14 +161,16 @@ def _collect_models(
         exclude_deprecated: True なら `deprecation_date` が設定されている entry を除外。
 
     Returns:
-        `<正規化後 litellm_model_id> -> metadata` のマッピング。Issue #52 (ADR 0023
-        Phase 1.10) 以降、bare `claude-*` は `anthropic/claude-*` に正規化された
-        キーで格納される。slash 入り ID はそのまま LiteLLM オリジナルキーがキーとなる
-        (Issue #51 / Phase 1.9)。
+        `<正規化後 litellm_model_id> -> metadata` のマッピング。Issue #60 以降、
+        bare ID は LiteLLM ``litellm_provider`` field SSoT 方式で
+        ``<provider>/<bare>`` に正規化されたキーで格納される。slash 入り ID は
+        そのまま LiteLLM オリジナルキーがキーとなる (Issue #51 / Phase 1.9)。
     """
     metadata: dict[str, dict[str, Any]] = {}
-    for model_id in litellm.model_cost.keys():
-        if not is_allowed_provider(model_id):
+    for model_id, info_cost in litellm.model_cost.items():
+        # Issue #60: model_cost の raw info を is_allowed_provider に渡し、
+        # 重複 lookup を避ける (内部で litellm_provider field を参照する)。
+        if not is_allowed_provider(model_id, info=info_cost):
             continue
         try:
             info = litellm.get_model_info(model_id)
@@ -161,7 +185,7 @@ def _collect_models(
             continue
         formatted = _format_litellm_metadata(model_id, info)
         if formatted:
-            # ADR 0023 Phase 1.10 (Issue #52): dict キーは正規化後 ID で統一。
+            # Issue #60: dict キーは正規化後 ID で統一。
             # registry / CLI / LoRAIro DB 列に伝播する `model_name_short` と一致させる。
             metadata[formatted["model_name_short"]] = formatted
     return metadata

--- a/tests/unit/core/test_api_model_discovery_filter.py
+++ b/tests/unit/core/test_api_model_discovery_filter.py
@@ -144,8 +144,17 @@ class TestFormatLitellmMetadata:
         assert metadata["provider"] == "OpenAI"
 
     def test_claude_bare_canonicalized(self):
-        """Issue #52: bare `claude-*` は `anthropic/<bare>` に正規化される。"""
-        info = {"supports_vision": True, "supports_function_calling": True, "mode": "chat"}
+        """Issue #52 / #60: bare ``claude-*`` は ``anthropic/<bare>`` に正規化される。
+
+        Issue #60 以降は ``info['litellm_provider']`` を SSoT として参照するため、
+        テストでは ``litellm_provider`` を明示して LiteLLM DB 依存を排除する。
+        """
+        info = {
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "mode": "chat",
+            "litellm_provider": "anthropic",
+        }
         metadata = _format_litellm_metadata("claude-opus-4-6", info)
         assert metadata is not None
         assert metadata["model_name_short"] == "anthropic/claude-opus-4-6"
@@ -153,19 +162,51 @@ class TestFormatLitellmMetadata:
         assert metadata["provider"] == "Anthropic"
 
     def test_claude_bare_with_date_suffix_canonicalized(self):
-        """Issue #52: 日付サフィックス付きの bare `claude-*` も同様に正規化される。"""
-        info = {"supports_vision": True, "supports_function_calling": True, "mode": "chat"}
+        """Issue #52 / #60: 日付サフィックス付き bare ``claude-*`` も正規化される。"""
+        info = {
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "mode": "chat",
+            "litellm_provider": "anthropic",
+        }
         metadata = _format_litellm_metadata("claude-3-5-sonnet-20241022", info)
         assert metadata is not None
         assert metadata["model_name_short"] == "anthropic/claude-3-5-sonnet-20241022"
         assert metadata["provider"] == "Anthropic"
 
-    def test_non_claude_bare_returns_none(self):
-        """Issue #52: claude- 以外の bare 名 (gpt-4o 等) は除外維持。"""
-        info = {"supports_vision": True, "supports_function_calling": True, "mode": "chat"}
-        assert _format_litellm_metadata("gpt-4o", info) is None
-        # Bedrock 形式 `anthropic.claude-*` も `claude-` で始まらないので除外
+    def test_openai_bare_canonicalized(self):
+        """Issue #60: bare ``gpt-4o`` 等は ``openai/<bare>`` に正規化される。
+
+        旧実装 (Issue #52) は ``claude-*`` のみ補完していたが、本 PR で LiteLLM
+        ``litellm_provider`` field SSoT 方式に切り替え、OpenAI bare 名も対応した。
+        """
+        info = {
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "mode": "chat",
+            "litellm_provider": "openai",
+        }
+        metadata = _format_litellm_metadata("gpt-4o", info)
+        assert metadata is not None
+        assert metadata["model_name_short"] == "openai/gpt-4o"
+        assert metadata["display_name"] == "openai/gpt-4o"
+        assert metadata["provider"] == "OpenAI"
+
+    def test_unsupported_litellm_provider_bare_returns_none(self):
+        """Issue #60: ``SUPPORTED_PROVIDERS`` 外の litellm_provider (bedrock 等) は None。
+
+        ``_BUILDER_DISPATCH`` に builder が無い provider は除外する。
+        """
+        info = {
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "mode": "chat",
+            "litellm_provider": "bedrock_converse",
+        }
         assert _format_litellm_metadata("anthropic.claude-3-5-sonnet", info) is None
+        # litellm_provider field 欠落も None
+        info_no_provider = {"supports_vision": True, "supports_function_calling": True, "mode": "chat"}
+        assert _format_litellm_metadata("any-bare-id", info_no_provider) is None
 
 
 @pytest.mark.unit
@@ -180,20 +221,55 @@ class TestCanonicalizeLitellmId:
         )
         assert _canonicalize_litellm_id("openrouter/z-ai/glm-4.7") == "openrouter/z-ai/glm-4.7"
 
-    def test_claude_bare_normalized(self):
-        """bare `claude-*` は `anthropic/<bare>` に補完される。"""
-        assert _canonicalize_litellm_id("claude-opus-4-6") == "anthropic/claude-opus-4-6"
-        assert _canonicalize_litellm_id("claude-3-5-sonnet-20241022") == (
+    def test_anthropic_bare_normalized_via_info(self):
+        """Issue #60: bare ``claude-*`` は ``info['litellm_provider']='anthropic'`` で正規化される。
+
+        本テストは LiteLLM upstream DB 状態に依存しないよう info 引数で明示する。
+        """
+        info = {"litellm_provider": "anthropic"}
+        assert _canonicalize_litellm_id("claude-opus-4-6", info=info) == "anthropic/claude-opus-4-6"
+        assert _canonicalize_litellm_id("claude-3-5-sonnet-20241022", info=info) == (
             "anthropic/claude-3-5-sonnet-20241022"
         )
-        assert _canonicalize_litellm_id("claude-haiku-4-5") == "anthropic/claude-haiku-4-5"
 
-    def test_non_claude_bare_returns_none(self):
-        """`claude-` 以外の bare 名は対応外として None。"""
-        assert _canonicalize_litellm_id("gpt-4o") is None
-        # Bedrock 形式: ドット区切りで `claude-` で始まらない
-        assert _canonicalize_litellm_id("anthropic.claude-3-5-sonnet") is None
-        assert _canonicalize_litellm_id("invalid_id_no_slash") is None
+    def test_openai_bare_normalized_via_info(self):
+        """Issue #60: bare ``gpt-*`` / ``o*`` 系 OpenAI モデルは ``openai/<bare>`` に補完される。"""
+        info = {"litellm_provider": "openai"}
+        assert _canonicalize_litellm_id("gpt-4o", info=info) == "openai/gpt-4o"
+        assert _canonicalize_litellm_id("o3", info=info) == "openai/o3"
+
+    def test_gemini_bare_normalized_via_info(self):
+        """Issue #60: bare ``gemini-*`` モデルは ``gemini/<bare>`` に補完される。
+
+        ``_BUILDER_DISPATCH`` には ``gemini`` も ``google`` も登録済 (alias)。
+        """
+        info = {"litellm_provider": "gemini"}
+        assert _canonicalize_litellm_id("gemini-1.5-flash", info=info) == "gemini/gemini-1.5-flash"
+
+    def test_unsupported_litellm_provider_returns_none(self):
+        """Issue #60: ``SUPPORTED_PROVIDERS`` 外の litellm_provider は None。
+
+        ``_BUILDER_DISPATCH`` に builder が無い provider (bedrock 系等) は除外。
+        """
+        info_bedrock = {"litellm_provider": "bedrock_converse"}
+        assert _canonicalize_litellm_id("anthropic.claude-3-5-sonnet", info=info_bedrock) is None
+        info_vertex = {"litellm_provider": "vertex_ai-language-models"}
+        assert _canonicalize_litellm_id("any-bare-id", info=info_vertex) is None
+
+    def test_missing_litellm_provider_returns_none(self):
+        """Issue #60: info に ``litellm_provider`` field が無い場合は None。"""
+        info_empty = {"supports_vision": True}
+        assert _canonicalize_litellm_id("any-bare-id", info=info_empty) is None
+        # 空文字や None も None
+        info_blank = {"litellm_provider": ""}
+        assert _canonicalize_litellm_id("any-bare-id", info=info_blank) is None
+        info_none = {"litellm_provider": None}
+        assert _canonicalize_litellm_id("any-bare-id", info=info_none) is None
+
+    def test_unknown_bare_id_returns_none_via_db(self):
+        """Issue #60: LiteLLM DB に存在しない bare ID は info=None でも None。"""
+        # info を渡さなければ litellm.model_cost を lookup、存在しなければ None
+        assert _canonicalize_litellm_id("definitely_not_a_real_litellm_model_id_xyz") is None
 
     def test_empty_string_returns_none(self):
         """空文字も None。"""
@@ -209,11 +285,20 @@ class TestIsAllowedProviderBareName:
         assert is_allowed_provider("claude-opus-4-6") is True
         assert is_allowed_provider("claude-haiku-4-5") is True
 
-    def test_non_claude_bare_rejected(self):
-        """claude- 以外の bare 名は除外維持。"""
-        assert is_allowed_provider("gpt-4o") is False
-        # Bedrock 形式の bare 名 (claude- で始まらない) は除外
+    def test_openai_bare_allowed(self):
+        """Issue #60: OpenAI bare 名 (gpt-4o 等) も SUPPORTED_PROVIDERS 経由で通過。
+
+        旧実装 (Issue #52) では ``claude-*`` のみ補完していたため False だった。
+        """
+        assert is_allowed_provider("gpt-4o") is True
+
+    def test_unsupported_provider_bare_rejected(self):
+        """Issue #60: ``SUPPORTED_PROVIDERS`` 外の litellm_provider (bedrock 等) は除外。"""
+        # `anthropic.claude-3-5-sonnet` は LiteLLM DB に `bedrock_converse` で存在するが
+        # `_BUILDER_DISPATCH` に builder 無し → 除外
         assert is_allowed_provider("anthropic.claude-3-5-sonnet") is False
+        # LiteLLM DB に存在しない bare ID も除外
+        assert is_allowed_provider("invalid_id_no_slash") is False
 
     def test_slash_id_unchanged(self):
         """slash 入り ID の判定は Phase 1.9 と変わらず。"""


### PR DESCRIPTION
## Summary

Issue #60 対応: bare ID の provider 判定を LiteLLM `litellm_provider` field SSoT 方式に置換。LoRAIro [#253](https://github.com/NEXTAltair/LoRAIro/issues/253) 連動の根本対応。

## 背景

旧実装 (Issue #52 / ADR 0023 Phase 1.10) は以下のように Anthropic bare 名のみハードコード補完していました:

\`\`\`python
_ANTHROPIC_BARE_PREFIXES: tuple[str, ...] = (\"claude-\",)

def _canonicalize_litellm_id(model_id):
    if \"/\" in model_id: return model_id
    if model_id.startswith(_ANTHROPIC_BARE_PREFIXES):
        return f\"anthropic/{model_id}\"
    return None    # ← gpt-4o / gemini-1.5-pro 等は全部ここで除外
\`\`\`

LiteLLM 同梱 DB は OpenAI / Gemini vision モデルを bare 形式 (\`gpt-4o\`, \`gpt-5.2\`, \`o3\`, \`gemini-1.5-pro\` 等) で格納していますが、\`claude-*\` prefix のみ補完していたため、それ以外の supported provider の bare ID は全部 None で除外されていました。

## 修正方針

LiteLLM 同梱 DB の各 entry が持つ \`litellm_provider\` field を SSoT として provider を判定する方式に置換:

\`\`\`python
def _canonicalize_litellm_id(model_id, info=None):
    if \"/\" in model_id:
        return model_id
    if info is None:
        info = litellm.model_cost.get(model_id)
    if info is None:
        return None
    provider = info.get(\"litellm_provider\")
    if not provider or provider not in SUPPORTED_PROVIDERS:
        return None
    return f\"{provider}/{model_id}\"
\`\`\`

## 変更内容

- \`_ANTHROPIC_BARE_PREFIXES\` 定数を削除
- \`_canonicalize_litellm_id()\` を \`litellm_provider\` field SSoT 方式に置換
- \`is_allowed_provider()\` / \`_format_litellm_metadata()\` / \`_collect_models()\` に \`info\` optional 引数追加 (重複 lookup 回避)
- テスト更新: 新規 7 件追加、既存 3 件を新仕様に合わせて修正 (info 引数明示渡しで LiteLLM upstream DB 依存を排除)

## 検証結果

### `discover_available_vision_models()` の件数変化

| | 修正前 | 修正後 | 差分 |
|---|---|---|---|
| 合計 | 90 | **163** | **+73** |
| OpenAI | 0 | **71** | **+71** |
| Gemini | 28 | 28 | 0 |
| Anthropic | 20 | 20 | 0 |
| Openrouter | 44 | 44 | 0 |

OpenAI direct route の vision モデル 71 件 (`gpt-4o`, `gpt-5.2`, `o3`, etc.) が新たに registry に流れるようになります。

### Test

- \`pytest -m unit\`: 321 passed / 9 skipped (既存 skipped、regression なし)
- 新規テスト 7 件: OpenAI / Anthropic / Gemini bare の正規化 / unsupported provider / info 引数欠落 / unknown bare ID 等
- 既存テスト 3 件 (旧 \`claude-*\` 限定挙動前提) を新仕様に追従

### 品質チェック

- \`ruff check\` (修正 file): clean
- mypy 2 errors は既存 main にも存在 (本 PR で悪化なし、行番号変動のみ)

## 利点

- 新モデル名規則 (\`gpt-5\`, \`o6\`, etc.) に追従不要
- 新 provider 追加時は \`_BUILDER_DISPATCH\` 更新 1 行で完了 (canonicalize は変更不要)
- ADR 0023 Phase 1 方針「LiteLLM 同梱 DB を runtime SSoT として直接参照する」と完全に整合

## 関連

- Issue [#60](https://github.com/NEXTAltair/image-annotator-lib/issues/60) — 本 PR の対象 Issue
- Issue #52 — 旧 \`_canonicalize_litellm_id()\` 導入の元 Issue (Phase 1.10)
- ADR 0023 Phase 1 — WebAPI inference boundary 設計
- LoRAIro [#253](https://github.com/NEXTAltair/LoRAIro/issues/253) — silent 0 件問題、本 PR で根本対応 (LoRAIro 側 follow-up で submodule pin 更新)
- LoRAIro PR [#256](https://github.com/NEXTAltair/LoRAIro/pull/256) — UX hint + DEBUG diagnostic (merged)
- LoRAIro PR [#257](https://github.com/NEXTAltair/LoRAIro/pull/257) — Linux SIGSEGV 解消 (merged)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)