### PR TITLE
fix(#59): module-level torch import を lazy 化して Linux SIGSEGV を解消

### DIFF
--- a/src/image_annotator_lib/core/base/clip.py
+++ b/src/image_annotator_lib/core/base/clip.py
@@ -1,10 +1,16 @@
 """CLIP モデルをベースとする Scorer 用の基底クラス。"""
 
-from abc import abstractmethod
-from typing import Any, Self, cast
+from __future__ import annotations
 
-import torch
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any, Self, cast
+
 from PIL import Image
+
+# Issue #59: module-level `import torch` は CUDA driver 不在 + triton 在り環境で
+# SIGSEGV を引き起こす。型ヒントは TYPE_CHECKING 内、runtime 利用箇所は関数内 import に分離する。
+if TYPE_CHECKING:
+    import torch
 
 # --- ローカルインポート ---
 from ...exceptions.errors import ModelLoadError, OutOfMemoryError
@@ -96,6 +102,8 @@ class ClipBaseAnnotator(BaseAnnotator):
 
     def _run_inference(self, processed: dict[str, torch.Tensor]) -> torch.Tensor:
         """CLIP モデルで画像特徴量を抽出し、分類器ヘッドでスコアを計算します。"""
+        import torch
+
         if (
             not self.components
             or "clip_model" not in self.components

--- a/src/image_annotator_lib/core/base/transformers.py
+++ b/src/image_annotator_lib/core/base/transformers.py
@@ -1,10 +1,16 @@
 """Transformers ライブラリを使用するモデル用の基底クラス。"""
 
-from typing import Any, cast
+from __future__ import annotations
 
-import torch
+from typing import TYPE_CHECKING, Any, cast
+
 from PIL import Image
-from transformers.models.clip import CLIPProcessor
+
+# Issue #59: module-level `import torch` / `from transformers.models.clip import CLIPProcessor` は
+# transformers が torch を eager に load するため CUDA driver 不在 + triton 在り環境で SIGSEGV を
+# 引き起こす。型ヒントは TYPE_CHECKING 内、runtime 利用箇所は関数内 import に分離する。
+if TYPE_CHECKING:
+    import torch
 
 # --- ローカルインポート ---
 from ...exceptions.errors import ConfigurationError, ModelLoadError, OutOfMemoryError
@@ -36,7 +42,7 @@ class TransformersBaseAnnotator(BaseAnnotator):
         # model_path の型を保証 (LocalMLModelConfig では str を期待)
         self.model_path = str(self.model_path) if isinstance(self.model_path, str) else ""
 
-    def __enter__(self) -> "TransformersBaseAnnotator":
+    def __enter__(self) -> TransformersBaseAnnotator:
         """
         モデルの状態に基づいて、必要な場合のみロードまたは復元
         メモリ不足エラーをハンドリングし、VRAM使用量をログに出力
@@ -121,6 +127,8 @@ class TransformersBaseAnnotator(BaseAnnotator):
 
     def _run_inference(self, processed: list[dict[str, torch.Tensor]]) -> list[torch.Tensor]:
         """前処理済みバッチで推論を実行します (Transformers用)。"""
+        import torch
+
         if not self.components or "model" not in self.components or self.components["model"] is None:
             raise RuntimeError("Transformer モデルがロードされていません。")
         model: Any = self.components["model"]
@@ -167,7 +175,9 @@ class TransformersBaseAnnotator(BaseAnnotator):
         Returns:
             list[UnifiedAnnotationResult]: 統一フォーマットのアノテーション結果リスト
         """
-        # 関数レベルでインポート（循環インポート回避）
+        # 関数レベルでインポート (循環インポート回避 + Issue #59 torch eager load 回避)
+        from transformers.models.clip import CLIPProcessor
+
         from ..types import TaskCapability, UnifiedAnnotationResult
         from ..utils import get_model_capabilities
 

--- a/src/image_annotator_lib/core/loaders/clip_loader.py
+++ b/src/image_annotator_lib/core/loaders/clip_loader.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
     from transformers.models.clip import CLIPModel, CLIPProcessor
 
 from ...exceptions.errors import ModelLoadError
-from ..classifier import Classifier
 
 
 class CLIPLoader(LoaderBase):
@@ -94,6 +93,8 @@ class CLIPLoader(LoaderBase):
     ) -> nn.Module:
         """分類器ヘッドモジュールを作成し、重みをロードしてデバイスに移動する。"""
         import torch.nn as nn
+
+        from ..classifier import Classifier
 
         activation_map: dict[str, type[nn.Module]] = {
             "ReLU": nn.ReLU,

--- a/src/image_annotator_lib/model_class/tagger_transformers.py
+++ b/src/image_annotator_lib/model_class/tagger_transformers.py
@@ -1,7 +1,13 @@
-from typing import Any
+from __future__ import annotations
 
-import torch
+from typing import TYPE_CHECKING, Any
+
 from PIL import Image
+
+# Issue #59: module-level `import torch` は CUDA driver 不在 + triton 在り環境で
+# SIGSEGV を引き起こす。型ヒントは TYPE_CHECKING 内、runtime 利用箇所は関数内 import に分離する。
+if TYPE_CHECKING:
+    import torch
 
 from ..core.base import TransformersBaseAnnotator
 from ..core.types import UnifiedAnnotationResult
@@ -59,6 +65,8 @@ class ToriiGateTagger(TransformersBaseAnnotator):
 
     def _run_inference(self, processed_images: list[dict[str, Any]]) -> list[torch.Tensor]:
         """モデル推論を実行します。生成されたIDを返します。"""
+        import torch
+
         results = []
         # generateメソッドの一般的な引数やモデルのforwardメソッドの引数を想定
         KNOWN_ARGS = {
@@ -94,9 +102,9 @@ class ToriiGateTagger(TransformersBaseAnnotator):
         capabilities = get_model_capabilities(self.model_name)
         results: list[UnifiedAnnotationResult] = []
         for token_ids in token_ids_list:
-            generated_text = self.components["processor"].batch_decode(
-                token_ids, skip_special_tokens=True
-            )[0]
+            generated_text = self.components["processor"].batch_decode(token_ids, skip_special_tokens=True)[
+                0
+            ]
             if "Assistant: " in generated_text:
                 caption = generated_text.split("Assistant: ")[1]
             else:

--- a/tests/unit/core/test_lazy_torch_import.py
+++ b/tests/unit/core/test_lazy_torch_import.py
@@ -1,0 +1,53 @@
+"""Issue #59 regression: `import image_annotator_lib` must not eager-load torch."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.mark.unit
+def test_import_does_not_eager_load_torch() -> None:
+    """`import image_annotator_lib` で torch / torchvision が load されないことを検証する。
+
+    Linux + triton package 在り + CUDA driver 不在環境では `torch._dynamo` →
+    `triton.knobs` の C extension create_module が SIGSEGV を起こす。
+    本 test は fresh interpreter 内で `import image_annotator_lib` 実行直後の
+    `sys.modules` を検査し、torch / torchvision package が含まれないことを確認する。
+
+    subprocess を使う理由: 同一 pytest session 内で既に他テストが torch を
+    import 済みだと `sys.modules` に残留して検出不能になるため、独立した
+    Python interpreter で fresh state を保証する。
+    """
+    script = textwrap.dedent(
+        """
+        import sys
+        import image_annotator_lib  # noqa: F401
+
+        loaded = sorted(
+            m for m in sys.modules
+            if m == "torch" or m.startswith("torch.")
+            or m == "torchvision" or m.startswith("torchvision.")
+        )
+        if loaded:
+            for m in loaded:
+                print(f"LEAK: {m}", file=sys.stderr)
+            sys.exit(1)
+        sys.exit(0)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"torch/torchvision eager-loaded at `import image_annotator_lib`:\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Linux + triton 在り + CUDA driver 不在環境で `import image_annotator_lib` 単体が `torch._dynamo` → `triton.knobs` の C extension create で SIGSEGV する問題を、**4 ファイルの module-level `import torch` 排除**で恒久解消する。

## Before / After

### Before (SIGSEGV trigger 経路)

**Trigger A — eager 静的経路:**
\`\`\`
__init__.py:23 from .core.model_factory import ModelLoad
└─ core/loaders/__init__.py from .clip_loader import CLIPLoader
   └─ core/loaders/clip_loader.py:24 from ..classifier import Classifier ← module-level
      └─ core/classifier.py:7-8 import torch, torch.nn as nn          ← **SIGSEGV trigger #1**
\`\`\`

**Trigger B — dynamic registry scan:**
\`\`\`
__init__.py:63 initialize_registry()
└─ register_annotators() → _gather_available_classes("model_class")
   └─ importlib.import_module("...model_class.tagger_transformers")
      └─ model_class/tagger_transformers.py:3 import torch              ← **SIGSEGV trigger #2**
         └─ (from ..core.base import TransformersBaseAnnotator)
            └─ core/base/transformers.py:5 import torch                  ← **SIGSEGV trigger #3**
            └─ core/base/transformers.py:7 from transformers.models.clip ← **SIGSEGV trigger #3b**
                                            import CLIPProcessor          (transformers が torch を eager load)
            (scorer_clip.py 経由で core/base/clip.py:6 も同様)             ← **SIGSEGV trigger #4**
\`\`\`

### After

`import image_annotator_lib` 単体で `sys.modules` に torch / torchvision が **0 件** であることを subprocess 経由 regression test で保証。

## 修正ファイル

| ファイル | 変更 |
|---|---|
| `core/loaders/clip_loader.py` | `from ..classifier import Classifier` を `_create_and_load_classifier_head()` メソッド冒頭に移動 |
| `core/base/transformers.py` | `import torch` + `from transformers.models.clip import CLIPProcessor` を TYPE_CHECKING + 関数内 import に分離 (`_run_inference` / `_format_predictions`) |
| `core/base/clip.py` | `import torch` を TYPE_CHECKING + 関数内 import (`_run_inference`) に分離 |
| `model_class/tagger_transformers.py` | `import torch` を TYPE_CHECKING + 関数内 import (`_run_inference`) に分離 |

各ファイルは `from __future__ import annotations` を追加して type hints を文字列化 (runtime evaluation を回避)。既存 lazy import パターン (`core/utils.py:254`, `core/loaders/loader_base.py:28` 等) を踏襲。

## Regression test

`tests/unit/core/test_lazy_torch_import.py` を新規追加。subprocess 内で `import image_annotator_lib` 実行後の `sys.modules` を検査し、torch / torchvision package が含まれないことを assert。同一 pytest session 内の他テストによる `sys.modules` 汚染を回避するため fresh interpreter を使用する。

## 検証結果

- iam-lib unit tests: **322 passed / 9 skipped** (regression なし)
- ruff/mypy: pre-existing 警告のみ。本 PR で新規 lint/type issue は **0 件** 追加
- LoRAIro venv 経由 `import image_annotator_lib` で **torch=0 / torchvision=0**
- `PYTHONFAULTHANDLER=1 python -X faulthandler -c "import image_annotator_lib"` で exit 0 完走
- `lorairo-cli models list --type webapi` の registry 初期化が正常完了

## LoRAIro 側との関係性

LoRAIro PR #257 (`[tool.uv] exclude-dependencies = ["triton"]`) は workspace 側の **defense-in-depth として維持**。本 PR は lib 側 source-level 恒久対応であり、PR #257 を revert する pending Issue は別途検討可能 (本 PR では触らない)。

## Test plan

- [x] iam-lib 独立 venv (Python 3.12) で `uv run pytest tests/unit/ -m unit` pass
- [x] `uv run pytest tests/unit/core/test_lazy_torch_import.py -v` pass
- [x] `uv run ruff check` / `uv run mypy src/` で新規 issue 追加なし
- [x] LoRAIro venv 経由 `import image_annotator_lib` smoke test

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)