### PR TITLE
fix(#59 follow-up): test_run_inference を sys.modules 注入方式に修正

### DIFF
--- a/tests/unit/standard/core/base/test_transfomers.py
+++ b/tests/unit/standard/core/base/test_transfomers.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from PIL import Image
@@ -67,8 +67,15 @@ def test_preprocess_images_calls_processor():
 
 # --- _run_inference ---
 @pytest.mark.standard
-@patch("image_annotator_lib.core.base.transformers.torch")
-def test_run_inference_generate_and_logits(mock_torch):
+def test_run_inference_generate_and_logits(monkeypatch):
+    # Issue #59: torch を module-level から関数内 lazy import に移動したため、
+    # @patch("...transformers.torch") では module attribute を取得できない。
+    # sys.modules に MagicMock を注入し、関数内 `import torch` がそれを返すようにする。
+    import sys
+
+    mock_torch = MagicMock()
+    monkeypatch.setitem(sys.modules, "torch", mock_torch)
+
     # torch.tensorのモック
     mock_tensor = MagicMock()
     mock_torch.tensor.return_value = mock_tensor


### PR DESCRIPTION
## Summary

PR #62 で `core/base/transformers.py` の `import torch` を関数内 lazy import に移動した結果、`@patch("image_annotator_lib.core.base.transformers.torch")` が AttributeError で失敗するようになった test を sys.modules 注入方式に変更する。

## Background

LoRAIro PR #260 (submodule pin 更新) の CI で発覚。iam-lib リポジトリには PR-triggered CI が無いため、PR #62 では検出されなかった。

```
FAILED tests/unit/standard/core/base/test_transfomers.py::test_run_inference_generate_and_logits
AttributeError: <module 'image_annotator_lib.core.base.transformers' ...> does not have the attribute 'torch'
```

## Fix

`@patch("image_annotator_lib.core.base.transformers.torch")` は module attribute を patch するが、lazy import 後は attribute が存在しない。代わりに sys.modules に MagicMock を注入することで、関数内 `import torch` が mock を取得する。

```python
# Before
@patch("image_annotator_lib.core.base.transformers.torch")
def test_run_inference_generate_and_logits(mock_torch):
    ...

# After
def test_run_inference_generate_and_logits(monkeypatch):
    import sys
    mock_torch = MagicMock()
    monkeypatch.setitem(sys.modules, "torch", mock_torch)
    ...
```

## Verification

- 単体: `uv run pytest tests/unit/standard/core/base/test_transfomers.py` → **7 passed**
- CI-equivalent: `uv run pytest -m "not real_api and not heavy and not system_integration"` → **628 passed / 18 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)