### PR TITLE
fix(LoRAIro#267): AutoModelForVision2Seq を AutoModelForImageTextToText に移行

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "Pillow>=10.0.0",
     "toml",
     "tensorflow>=2.19.0;platform_system!='Darwin'", # Use newer version from scorer
-    "transformers>=4.27.4",
+    "transformers>=4.50.0",
     "tf-keras>=2.19.0",
     "accelerate>=0.26.0",
     "diffusers>=0.24.0",

--- a/src/image_annotator_lib/core/loaders/transformers_loader.py
+++ b/src/image_annotator_lib/core/loaders/transformers_loader.py
@@ -1,6 +1,6 @@
 """Hugging Face Transformers モデルローダー。
 
-AutoModelForVision2Seq と Pipeline の2つのローダーを提供する。
+AutoModelForImageTextToText と Pipeline の2つのローダーを提供する。
 
 Dependencies:
     - transformers: Hugging Face Transformers ライブラリ (遅延import)
@@ -24,18 +24,18 @@ if __name__ != "__main__":
 
 
 class TransformersLoader(LoaderBase):
-    """Hugging Face Transformers モデル (AutoModelForVision2Seq) のローダー。"""
+    """Hugging Face Transformers モデル (AutoModelForImageTextToText) のローダー。"""
 
     def _calculate_specific_size(self, model_path: str, **kwargs: Any) -> float:
         """CPU 上でモデルを一時ロードしてサイズを計算する。"""
         import torch.nn
-        from transformers.models.auto.modeling_auto import AutoModelForVision2Seq
+        from transformers.models.auto.modeling_auto import AutoModelForImageTextToText
 
         logger.debug(f"一時ロードによる Transformer サイズ計算開始: {model_path}")
         calculated_size_mb = 0.0
         temp_model = None
         try:
-            temp_model = AutoModelForVision2Seq.from_pretrained(model_path).to("cpu")
+            temp_model = AutoModelForImageTextToText.from_pretrained(model_path).to("cpu")
             if isinstance(temp_model, torch.nn.Module):
                 calculated_size_mb = LoaderBase._calculate_transformer_size_mb(temp_model)
         except Exception as e:
@@ -50,11 +50,11 @@ class TransformersLoader(LoaderBase):
     @override
     def _load_components_internal(self, model_path: str, **kwargs: Any) -> TransformersComponents:
         """モデルとプロセッサをロードする。"""
-        from transformers.models.auto.modeling_auto import AutoModelForVision2Seq
+        from transformers.models.auto.modeling_auto import AutoModelForImageTextToText
         from transformers.models.auto.processing_auto import AutoProcessor
 
         processor = AutoProcessor.from_pretrained(model_path)
-        model = AutoModelForVision2Seq.from_pretrained(model_path).to(self.device)
+        model = AutoModelForImageTextToText.from_pretrained(model_path).to(self.device)
         return {"model": model, "processor": processor}
 
 

--- a/tests/features/step_definitions/model_factory_steps.py
+++ b/tests/features/step_definitions/model_factory_steps.py
@@ -30,7 +30,7 @@ def mock_transformers_loader(mock_model_instance):
     """Mock Transformers model loader."""
     # Mock the actual transformers imports used in _TransformersLoader
     with (
-        patch("transformers.models.auto.modeling_auto.AutoModelForVision2Seq") as mock_auto_model,
+        patch("transformers.models.auto.modeling_auto.AutoModelForImageTextToText") as mock_auto_model,
         patch("transformers.models.auto.processing_auto.AutoProcessor") as mock_auto_processor,
     ):
         # Configure mocks


### PR DESCRIPTION
## Summary

transformers v4.50+ で `AutoModelForVision2Seq` が `AutoModelForImageTextToText` に統合・改名された。LoRAIro の `.venv` (transformers 4.57.1) では `transformers.models.auto.modeling_auto` から `AutoModelForVision2Seq` を直接 import できず、BLIP / BLIP2 / GIT / ToriiGate annotator が ImportError で動作不能だった。

## Changes

- `core/loaders/transformers_loader.py`: `AutoModelForVision2Seq` を `AutoModelForImageTextToText` に rename (lazy import を維持)
- `tests/features/step_definitions/model_factory_steps.py:33`: BDD test の patch path も同期して更新
- `pyproject.toml`: `transformers>=4.27.4` → `transformers>=4.50.0` に引き上げ

`AutoModelForImageTextToText` は BLIP / BLIP2 / GIT / Qwen2-VL (ToriiGate 基盤) を含む 70 モデルを網羅する後継クラス (`MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES` で確認済)。

## Test plan

- [x] BDD: `test_model_factory_v2.py` 7 scenarios 全 PASS (修正前は 5 failed)
- [x] CI-equivalent filter: 631 passed, 18 skipped (既存 skip)
- [x] 直接 import: `from transformers.models.auto.modeling_auto import AutoModelForImageTextToText` 成功

Refs: LoRAIro#267

🤖 Generated with [Claude Code](https://claude.com/claude-code)