### PR TITLE
fix(#69): logger.error f-string + exc_info=True で KeyError leak (LoRAIro #275)

### DIFF
--- a/src/image_annotator_lib/core/provider_manager.py
+++ b/src/image_annotator_lib/core/provider_manager.py
@@ -129,10 +129,16 @@ class ProviderManager:
                     # ADR 0023 Phase 1.8 (Issue #46): transport retry 枯渇時は
                     # tenacity が httpx 例外を reraise する (RetryConfig(reraise=True))。
                     # 既存の str(exc) 文字列伝搬経路でそのまま LoRAIro 側に流れる。
-                    logger.error(
+                    #
+                    # Issue #69 / LoRAIro #275: `logger.error(message, exc_info=True)` は
+                    # loguru 内部で `message.format(*args, **kwargs)` を呼ぶため、f-string
+                    # 結果に str(exc) 由来の `{'type': ...}` dict 表現が含まれると
+                    # placeholder と誤認識され `KeyError("'type'")` が leak する。
+                    # `.opt(exception=exc).error(message)` パターンに変更して loguru の
+                    # message 再フォーマットを回避する。
+                    logger.opt(exception=exc).error(
                         f"WebAPI 推論失敗: model={model_name}, "
-                        f"litellm_model_id={litellm_model_id}, error={exc}",
-                        exc_info=True,
+                        f"litellm_model_id={litellm_model_id}, error={exc}"
                     )
                     results[phash] = to_annotation_result(None, phash, error=str(exc))
             return results

--- a/tests/unit/core/test_provider_manager_logger_keyerror.py
+++ b/tests/unit/core/test_provider_manager_logger_keyerror.py
@@ -1,0 +1,77 @@
+"""Issue #69 / LoRAIro #275: logger.error f-string + exc_info=True で str(exc) に
+dict 表現が含まれると loguru が format placeholder と解釈し KeyError を leak する。
+
+Regression test for the loguru f-string formatting bug discovered in
+`provider_manager.py:run_inference_with_model_async`.
+
+問題:
+    `logger.error(f"WebAPI 推論失敗: ...error={exc}", exc_info=True)` で `str(exc)` が
+    Python dict 表現 (`{'type': 'error', ...}`) を含むと、loguru の内部 record 構築で
+    message を再フォーマットし、`{'type'}` を positional/keyword placeholder と解釈して
+    `KeyError("'type'")` を raise する。
+
+検証経路:
+    `ProviderManager.run_inference_with_model` 経由で `_test_agent` 注入し、agent.run()
+    で ModelHTTPError 相当の例外を raise させる。修正前は KeyError がそのまま leak、
+    修正後は例外を swallow して result.error にオリジナル `str(exc)` を格納する。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image
+
+from image_annotator_lib.core.provider_manager import ProviderManager
+
+
+class _FakeModelHTTPError(Exception):
+    """`pydantic_ai.exceptions.ModelHTTPError` 相当の str() を返す例外。
+
+    body 属性は省略 (logger.error 経路の再現に str() のみが必要)。
+    実 ModelHTTPError は body を Python dict として保持し、`__str__` で `f"...body: {body}"`
+    を返すため、最終的に str(exc) に `{'type': 'error', ...}` が含まれる。本テストでは
+    その str() 結果を直接模倣する。
+    """
+
+    def __str__(self) -> str:
+        return (
+            "status_code: 400, model_name: claude-haiku-4-5, "
+            "body: {'type': 'error', 'error': {'type': 'invalid_request_error', "
+            "'message': 'foo'}, 'request_id': 'req_xyz'}"
+        )
+
+
+@pytest.mark.unit
+def test_logger_error_does_not_leak_keyerror_when_exception_str_contains_dict() -> None:
+    """Regression test for iam-lib #69 / LoRAIro #275.
+
+    `logger.error(f"...{exc}", exc_info=True)` で str(exc) に dict 表現が含まれても
+    `KeyError("'type'")` が leak せず、result.error に str(exc) がそのまま格納される
+    ことを確認する。
+    """
+    fake_agent = MagicMock()
+    fake_agent.run = AsyncMock(side_effect=_FakeModelHTTPError())
+
+    image = Image.new("RGB", (8, 8), color="white")
+
+    # 修正前: provider_manager.py:132 の logger.error で KeyError("'type'") が raise され、
+    # この呼び出し全体が KeyError で例外伝搬する (本 assert 行までも到達しない)。
+    # 修正後: 例外は内部で swallow され、result に error メッセージが入る。
+    results = ProviderManager.run_inference_with_model(
+        model_name="test-webapi",
+        images_list=[image],
+        litellm_model_id="anthropic/claude-haiku-4-5",
+        api_keys={"anthropic": "fake-key"},
+        _test_agent=fake_agent,
+    )
+
+    assert len(results) == 1
+    result = next(iter(results.values()))
+    error_msg = result["error"]
+    # str(exc) がそのまま error に流れること (KeyError の "'type'" ではない)
+    assert error_msg is not None
+    assert "status_code: 400" in error_msg
+    assert "claude-haiku-4-5" in error_msg
+    assert error_msg != "'type'"


### PR DESCRIPTION
## Summary

- `provider_manager.py:132` の `logger.error(f"...error={exc}", exc_info=True)` で str(exc) に Python dict 表現 (`{'type': 'error', ...}`) が含まれると、loguru が `message.format(*args, **kwargs)` を内部で呼び `{'type'}` を placeholder と誤認識して `KeyError("'type'")` を raise する root cause を修正
- `.opt(exception=exc).error(message)` パターンに変更して loguru の message 再フォーマットを回避
- 新規 regression test 追加 (`test_provider_manager_logger_keyerror.py`)

## Root cause

LoRAIro #275 (anthropic/claude-haiku-4-5 で `KeyError: 'type'`) の根本原因は **iam-lib 側 loguru 使用パターンのバグ** であり、Anthropic API / pydantic-ai 側の問題ではない。`ModelHTTPError.__str__()` は `f'status_code: ..., body: {body}'` を返し、body が Python dict のとき str(exc) に `{'type': 'error', ...}` を含む。`logger.error(message, exc_info=True)` の loguru 内部実装が `message.format()` を呼ぶため、f-string 結果に含まれる `{'type'}` を positional/keyword placeholder と解釈し `KeyError` を raise する。

最小再現:
```python
from loguru import logger
class FakeExc(Exception):
    def __str__(self):
        return "body: {'type': 'error', 'message': 'foo'}"
try:
    raise FakeExc()
except FakeExc as exc:
    logger.error(f"failed: error={exc}", exc_info=True)  # → KeyError("'type'")
```

## Fix

```python
# Before
logger.error(
    f"WebAPI 推論失敗: model={model_name}, "
    f"litellm_model_id={litellm_model_id}, error={exc}",
    exc_info=True,
)
# After
logger.opt(exception=exc).error(
    f"WebAPI 推論失敗: model={model_name}, "
    f"litellm_model_id={litellm_model_id}, error={exc}"
)
```

`.opt(exception=...)` パターンは loguru の message 再フォーマット経路を回避する。

## Test plan

- [x] **RED**: 新規 unit test `test_logger_error_does_not_leak_keyerror_when_exception_str_contains_dict` を作成
  - `MagicMock` + `AsyncMock(side_effect=FakeModelHTTPError())` で agent.run() を制御
  - 修正前: `KeyError("'type'")` が leak (test fail を確認)
- [x] **GREEN**: 修正適用後、test pass
- [x] **CI-equivalent filter** (`-m "not real_api and not heavy and not system_integration"`): 635 passed, 18 skipped, regression なし
- [x] **実 API E2E**: LoRAIro 側で claude-haiku-4-5 を annotate() し、修正後は credit balance エラーメッセージが正しく propagate することを確認
- [x] **LoRAIro CI-equivalent filter**: 2260 passed, 2 skipped, regression なし (submodule working tree に同 fix 適用済)

## Scope

iam-lib 全体に同パターンの logger 呼び出しが多数存在 (`api.py`, `core/config.py`, `core/model_factory.py`, `core/registry.py` 等)。本 PR は Issue #275 直接修正のため `provider_manager.py:132` のみに限定。**他箇所の集中修正は本 PR merge 後に別 issue で扱う** (scope creep 防止)。

## Related

- Closes #69
- Fixes downstream: NEXTAltair/LoRAIro#275
- 関連 ADR (LoRAIro): docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md
- LoRAIro 側 submodule pin update は本 PR merge 後の別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)