### PR TITLE
fix: enrich WebAPI inference error with exception cause chain (LoRAIro #274)

### DIFF
--- a/src/image_annotator_lib/core/provider_manager.py
+++ b/src/image_annotator_lib/core/provider_manager.py
@@ -43,6 +43,48 @@ _OUTPUT_RETRIES = 1
 # Agent.run の user message として渡す短い指示。BASE_PROMPT は system_prompt 側で詳細を伝える。
 _USER_PROMPT_TEXT = "Analyze this image and provide annotations as specified."
 
+# LoRAIro #274: cause/context chain を辿る最大段数 (循環・過剰深さの安全弁)。
+_EXCEPTION_CHAIN_MAX_DEPTH = 5
+
+
+def _format_exception_chain(exc: BaseException, *, max_depth: int = _EXCEPTION_CHAIN_MAX_DEPTH) -> str:
+    """例外の cause/context chain を 1 行の診断文字列に整形する (LoRAIro #274)。
+
+    ``openai.APIConnectionError`` 等の SDK ラッパー例外は ``str(exc)`` が
+    ``"Connection error."`` のような短い定型文に潰れ、根本原因 (httpx の
+    ``ConnectTimeout`` / ``ConnectError`` 等) が ``AnnotationResult.error`` から
+    失われる。``__cause__`` / ``__context__`` を辿って各層の型名とメッセージを
+    連結し、原因特定に足る error 文字列を生成する。
+
+    Args:
+        exc: 整形対象の例外。
+        max_depth: 辿る chain の最大段数。
+
+    Returns:
+        ``"openai.APIConnectionError: Connection error. <- caused by httpx.ConnectError: ..."``
+        形式の 1 行文字列。chain が無ければ単層の ``"型名: message"``。
+    """
+    parts: list[str] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    depth = 0
+    while current is not None and id(current) not in seen and depth < max_depth:
+        seen.add(id(current))
+        cls = type(current)
+        qualified = (
+            cls.__name__ if cls.__module__ in ("builtins", "") else f"{cls.__module__}.{cls.__name__}"
+        )
+        message = str(current).strip() or "(no message)"
+        parts.append(f"{qualified}: {message}")
+        # __cause__ (明示的 raise from) を優先。無く __context__ が suppress されて
+        # いなければ暗黙の context を辿る。
+        next_exc = current.__cause__
+        if next_exc is None and not current.__suppress_context__:
+            next_exc = current.__context__
+        current = next_exc
+        depth += 1
+    return " <- caused by ".join(parts)
+
 
 class ProviderManager:
     """LiteLLM ID ベースで PydanticAI 推論を実行するクラスメソッド集。
@@ -130,6 +172,11 @@ class ProviderManager:
                     # tenacity が httpx 例外を reraise する (RetryConfig(reraise=True))。
                     # 既存の str(exc) 文字列伝搬経路でそのまま LoRAIro 側に流れる。
                     #
+                    # LoRAIro #274: openai.APIConnectionError 等は str(exc) が
+                    # "Connection error." に潰れ、根本原因 (httpx の ConnectTimeout 等)
+                    # が AnnotationResult.error から失われる。cause/context chain を
+                    # 辿った診断文字列を log・result.error の双方に伝搬する。
+                    error_detail = _format_exception_chain(exc)
                     # Issue #69 / LoRAIro #275: `logger.error(message, exc_info=True)` は
                     # loguru 内部で `message.format(*args, **kwargs)` を呼ぶため、f-string
                     # 結果に str(exc) 由来の `{'type': ...}` dict 表現が含まれると
@@ -138,9 +185,9 @@ class ProviderManager:
                     # message 再フォーマットを回避する。
                     logger.opt(exception=exc).error(
                         f"WebAPI 推論失敗: model={model_name}, "
-                        f"litellm_model_id={litellm_model_id}, error={exc}"
+                        f"litellm_model_id={litellm_model_id}, error={error_detail}"
                     )
-                    results[phash] = to_annotation_result(None, phash, error=str(exc))
+                    results[phash] = to_annotation_result(None, phash, error=error_detail)
             return results
         finally:
             if http_client is not None:

--- a/tests/unit/core/test_provider_manager_exception_chain.py
+++ b/tests/unit/core/test_provider_manager_exception_chain.py
@@ -1,0 +1,161 @@
+"""LoRAIro #274: WebAPI 推論失敗時の診断情報強化。
+
+``openai.APIConnectionError`` 等の SDK ラッパー例外は ``str(exc)`` が
+``"Connection error."`` に潰れ、根本原因 (httpx の ``ConnectTimeout`` /
+``ConnectError`` 等) が ``AnnotationResult.error`` から失われる。
+
+``provider_manager._format_exception_chain`` が cause/context chain を辿って
+原因特定に足る診断文字列を生成し、``run_inference_with_model`` の generic error
+経路が log・result.error の双方にそれを伝搬することを検証する。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image
+
+from image_annotator_lib.core.provider_manager import (
+    ProviderManager,
+    _format_exception_chain,
+)
+
+
+@pytest.mark.unit
+class TestFormatExceptionChain:
+    """``_format_exception_chain`` の chain 整形ロジック。"""
+
+    def test_single_exception_no_cause(self) -> None:
+        """cause/context が無い例外は単層の '型名: message' になる。"""
+        result = _format_exception_chain(ValueError("bad value"))
+        # builtins は module prefix を付けない
+        assert result == "ValueError: bad value"
+
+    def test_non_builtin_module_prefixed(self) -> None:
+        """builtins 以外の例外は module 修飾名が付く。"""
+
+        class _CustomError(Exception):
+            pass
+
+        result = _format_exception_chain(_CustomError("boom"))
+        assert result.endswith("_CustomError: boom")
+        # module prefix (テストモジュール名) が付与される
+        assert "." in result.split(":")[0]
+
+    def test_empty_message_placeholder(self) -> None:
+        """message が空の例外は '(no message)' に置換される。"""
+        result = _format_exception_chain(ValueError(""))
+        assert result == "ValueError: (no message)"
+
+    def test_explicit_cause_chain(self) -> None:
+        """raise X from Y は 'X <- caused by Y' で連結される。"""
+        try:
+            try:
+                raise ConnectionResetError("tcp reset")
+            except ConnectionResetError as inner:
+                raise RuntimeError("Connection error.") from inner
+        except RuntimeError as exc:
+            result = _format_exception_chain(exc)
+
+        assert result == "RuntimeError: Connection error. <- caused by ConnectionResetError: tcp reset"
+
+    def test_implicit_context_chain(self) -> None:
+        """except 中の暗黙 raise は __context__ 経由で辿られる。"""
+        try:
+            try:
+                raise ConnectionResetError("tcp reset")
+            except ConnectionResetError:
+                raise RuntimeError("Connection error.")  # noqa: B904
+        except RuntimeError as exc:
+            result = _format_exception_chain(exc)
+
+        assert "RuntimeError: Connection error." in result
+        assert "caused by ConnectionResetError: tcp reset" in result
+
+    def test_suppressed_context_not_walked(self) -> None:
+        """raise X from None は context を辿らない。"""
+        try:
+            try:
+                raise ConnectionResetError("tcp reset")
+            except ConnectionResetError:
+                raise RuntimeError("Connection error.") from None
+        except RuntimeError as exc:
+            result = _format_exception_chain(exc)
+
+        assert result == "RuntimeError: Connection error."
+        assert "tcp reset" not in result
+
+    def test_max_depth_caps_chain(self) -> None:
+        """max_depth で chain の段数が制限される。"""
+        exc = ValueError("level-0")
+        exc.__cause__ = ValueError("level-1")
+        exc.__cause__.__cause__ = ValueError("level-2")
+
+        result = _format_exception_chain(exc, max_depth=2)
+
+        assert "level-0" in result
+        assert "level-1" in result
+        assert "level-2" not in result
+
+    def test_cycle_is_safe(self) -> None:
+        """cause が循環していても無限ループしない。"""
+        exc_a = ValueError("a")
+        exc_b = ValueError("b")
+        exc_a.__cause__ = exc_b
+        exc_b.__cause__ = exc_a
+
+        result = _format_exception_chain(exc_a)
+
+        # 各例外は 1 回ずつだけ現れる
+        assert result.count("ValueError: a") == 1
+        assert result.count("ValueError: b") == 1
+
+
+@pytest.mark.unit
+def test_run_inference_error_propagates_exception_chain() -> None:
+    """LoRAIro #274 regression: generic error 経路で result.error に cause chain が乗る。
+
+    ``agent.run()`` が ``APIConnectionError`` 相当 (str() は "Connection error." に
+    潰れるが ``__cause__`` に httpx 例外相当を持つ) を raise した場合、
+    ``result["error"]`` が単なる "Connection error." ではなく根本原因を含む。
+    """
+
+    class _FakeAPIConnectionError(Exception):
+        """openai.APIConnectionError 相当 (str() が定型文に潰れる)。"""
+
+        def __str__(self) -> str:
+            return "Connection error."
+
+    def _raise_chained() -> None:
+        try:
+            raise ConnectionError("All connection attempts failed")
+        except ConnectionError as inner:
+            raise _FakeAPIConnectionError() from inner
+
+    try:
+        _raise_chained()
+    except _FakeAPIConnectionError as built:
+        chained_exc = built
+
+    fake_agent = MagicMock()
+    fake_agent.run = AsyncMock(side_effect=chained_exc)
+
+    image = Image.new("RGB", (8, 8), color="white")
+    results = ProviderManager.run_inference_with_model(
+        model_name="test-webapi",
+        images_list=[image],
+        litellm_model_id="openai/gpt-4o-mini",
+        api_keys={"openai": "fake-key"},
+        _test_agent=fake_agent,
+    )
+
+    assert len(results) == 1
+    error_msg = results[next(iter(results))]["error"]
+    assert error_msg is not None
+    # 定型文だけでなく根本原因 (inner ConnectionError) が含まれる
+    assert "Connection error." in error_msg
+    assert "caused by" in error_msg
+    assert "All connection attempts failed" in error_msg
+    # 単純な str(exc) ("Connection error.") ではない
+    assert error_msg != "Connection error."


### PR DESCRIPTION
## 背景

LoRAIro #274: `openai/gpt-4o-mini` の WebAPI annotation が `"Connection error."` で失敗する。`openai.APIConnectionError` 等の SDK ラッパー例外は `str(exc)` が定型文に潰れ、根本原因 (httpx の `ConnectTimeout` / `ConnectError` 等) が `AnnotationResult.error` から失われる。

オーナー予備調査では現環境で再現せず、最大の欠落は「`AnnotationResult.error` に inner cause が乗らない」点と特定された。本 PR はその診断強化 (LoRAIro #274 の段階対応: 診断 patch 先行) を行う。

## 変更内容

| 対象 | 変更 |
|---|---|
| `core/provider_manager.py` | `_format_exception_chain()` 追加 — `__cause__` / `__context__` chain を辿り、各層の型名 (module 修飾) + メッセージを連結した 1 行診断文字列を生成 |
| `core/provider_manager.py` | `run_inference_with_model_async` の generic error 経路で log / `result.error` の双方に chain 診断を伝搬 (旧: `str(exc)` 単独) |

`_format_exception_chain` の安全性:
- 循環 cause を `seen` set で検出して無限ループ回避
- `max_depth` (default 5) で段数 cap
- `raise X from None` の suppress context を尊重
- builtins は module prefix 省略

refusal 経路 (`SafetyRefusalError:` / `ContentPolicyRefusalError:` prefix) は LoRAIro `annotation_save_service` の decode 契約のため**不変**。generic error は LoRAIro 側で parse されないため文字列形式変更は後方互換。

## Verification

```
make test-iam-lib  (LoRAIro 経由、CI-equivalent filter)
# → 645 passed, 18 skipped, 9 deselected (新規 9 件: TestFormatExceptionChain 8 + integration 1)

ruff format / check
# → All checks passed
```

新規 unit test (`tests/unit/core/test_provider_manager_exception_chain.py`):
- chain 整形: 単層 / module 修飾 / 空メッセージ / explicit cause / implicit context / suppressed context / max_depth / 循環
- integration: `_test_agent` で `APIConnectionError` 相当 (str() が定型文に潰れ `__cause__` を持つ) を raise → `result["error"]` が根本原因を含む

## 関連

- LoRAIro #274 (発端 Issue、段階対応の診断 patch)
- ADR 0023 (PydanticAI / LiteLLM WebAPI Inference Boundary) — inference boundary 契約は不変
- 実機再現確認は本 PR merge 後、enrich されたログで別途実施 (LoRAIro #274 完了条件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
