### PR TITLE
fix: stop event-loop probe leaking into error cause chain (LoRAIro #302)

### DIFF
--- a/src/image_annotator_lib/core/provider_manager.py
+++ b/src/image_annotator_lib/core/provider_manager.py
@@ -196,6 +196,27 @@ class ProviderManager:
             if http_client is not None:
                 await http_client.aclose()
 
+    @staticmethod
+    def _running_loop_active() -> bool:
+        """現在のスレッドで asyncio event loop が稼働中かを返す (LoRAIro #302)。
+
+        ``asyncio.get_running_loop()`` は loop が無いと ``RuntimeError`` を raise する。
+        この probe の ``RuntimeError`` を ``except`` 内に閉じ込めず bool へ変換することで、
+        後続の ``asyncio.run()`` を ``except`` ブロック **外** で実行できる。``except``
+        ブロック内で ``asyncio.run()`` を呼ぶと、その動的範囲で coroutine 内に raise
+        される素の例外 (`__cause__` 無し) の ``__context__`` に probe の
+        ``RuntimeError("no running event loop")`` が連鎖し、診断 chain
+        (``_format_exception_chain``) に偽の根本原因として混入する。
+
+        Returns:
+            event loop が稼働中なら ``True``、無ければ ``False``。
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        return True
+
     @classmethod
     def run_inference_with_model(
         cls,
@@ -212,23 +233,24 @@ class ProviderManager:
         Running asyncio loop の中で呼ばれた場合は `InferenceError` を raise する
         (thread fallback はしない)。
         """
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return asyncio.run(
-                cls.run_inference_with_model_async(
-                    model_name=model_name,
-                    images_list=images_list,
-                    litellm_model_id=litellm_model_id,
-                    api_keys=api_keys,
-                    config=config,
-                    _test_agent=_test_agent,
-                )
+        if cls._running_loop_active():
+            raise InferenceError(
+                "ProviderManager.run_inference_with_model() called from a running event loop. "
+                "Use run_inference_with_model_async() in async context.",
+                litellm_model_id=litellm_model_id,
             )
-        raise InferenceError(
-            "ProviderManager.run_inference_with_model() called from a running event loop. "
-            "Use run_inference_with_model_async() in async context.",
-            litellm_model_id=litellm_model_id,
+        # LoRAIro #302: asyncio.run() は except ブロック **外** で実行する。loop 検出 probe の
+        # RuntimeError を _running_loop_active() 内で消費済みのため、coroutine 内例外の
+        # __context__ に "no running event loop" が連鎖しない。
+        return asyncio.run(
+            cls.run_inference_with_model_async(
+                model_name=model_name,
+                images_list=images_list,
+                litellm_model_id=litellm_model_id,
+                api_keys=api_keys,
+                config=config,
+                _test_agent=_test_agent,
+            )
         )
 
     @classmethod

--- a/tests/unit/core/test_provider_manager_event_loop_context.py
+++ b/tests/unit/core/test_provider_manager_event_loop_context.py
@@ -1,0 +1,100 @@
+"""LoRAIro #302: sync wrapper の event loop probe が診断 chain を汚さないことの検証。
+
+``ProviderManager.run_inference_with_model`` は running loop 検出に
+``asyncio.get_running_loop()`` を使う。旧実装はこの probe の ``RuntimeError`` を
+``except`` ブロックで受け、その **中** で ``asyncio.run()`` を呼んでいた。すると
+coroutine 内で raise される素の例外 (`__cause__` 無し) の ``__context__`` に probe の
+``RuntimeError("no running event loop")`` が連鎖し、``_format_exception_chain`` が
+生成する診断文字列に偽の根本原因として混入していた (LoRAIro #274 の実機検証で発覚)。
+
+修正後は probe を ``_running_loop_active()`` helper に分離し ``RuntimeError`` を
+完全に消費してから ``asyncio.run()`` を ``except`` ブロック外で実行する。本モジュールは
+その回帰防止と probe helper / running-loop ガードの挙動を検証する。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from PIL import Image
+
+from image_annotator_lib.core.provider_manager import ProviderManager
+from image_annotator_lib.exceptions.errors import InferenceError
+
+
+class _FakeRateLimitError(Exception):
+    """429 retry 枯渇後に transport が reraise する ``httpx.HTTPStatusError`` 相当。
+
+    ``raise_for_status()`` の ``from`` 無し raise と同じく ``__cause__`` を持たない素の
+    例外。診断 chain walker (`_format_exception_chain`) が ``__cause__`` 経路で止まれず
+    ``__context__`` 経路へ落ちる条件を再現する。
+    """
+
+
+class _FailingAgent:
+    """``run()`` が ``__cause__`` 無しの素の例外を fresh raise する最小 Agent スタブ。
+
+    ``AsyncMock(side_effect=instance)`` ではなく実 ``async def`` 内の fresh ``raise`` を
+    使うことで、``__context__`` 連鎖を確実に再現する。
+    """
+
+    async def run(self, *_args: object, **_kwargs: object) -> object:
+        raise _FakeRateLimitError("Client error '429 Too Many Requests'")
+
+
+@pytest.mark.unit
+class TestSyncWrapperEventLoopContext:
+    """``run_inference_with_model`` の sync wrapper が偽の ``__context__`` を残さない。"""
+
+    def test_sync_wrapper_error_does_not_leak_no_running_event_loop(self) -> None:
+        """sync wrapper 経由の error 文字列に probe の RuntimeError が混入しない (#302)。"""
+        image = Image.new("RGB", (8, 8), color="white")
+
+        results = ProviderManager.run_inference_with_model(
+            model_name="test-webapi",
+            images_list=[image],
+            litellm_model_id="openai/gpt-4o-mini",
+            api_keys={"openai": "fake-key"},
+            _test_agent=_FailingAgent(),
+        )
+
+        assert len(results) == 1
+        error_msg = results[next(iter(results))]["error"]
+        assert error_msg is not None
+        # 真の原因 (429) は診断 chain に保持される
+        assert "429" in error_msg
+        # probe RuntimeError の __context__ 漏れが混入しない
+        assert "no running event loop" not in error_msg
+
+    def test_sync_wrapper_from_running_loop_raises_inference_error(self) -> None:
+        """running loop 内からの呼び出しは従来通り ``InferenceError`` を raise する。"""
+
+        async def _call_from_loop() -> None:
+            ProviderManager.run_inference_with_model(
+                model_name="test-webapi",
+                images_list=[Image.new("RGB", (8, 8), color="white")],
+                litellm_model_id="openai/gpt-4o-mini",
+                api_keys={"openai": "fake-key"},
+                _test_agent=_FailingAgent(),
+            )
+
+        with pytest.raises(InferenceError):
+            asyncio.run(_call_from_loop())
+
+
+@pytest.mark.unit
+class TestRunningLoopActive:
+    """``_running_loop_active()`` probe helper の挙動。"""
+
+    def test_running_loop_active_false_outside_loop(self) -> None:
+        """event loop が無いスレッドでは ``False`` を返す。"""
+        assert ProviderManager._running_loop_active() is False
+
+    def test_running_loop_active_true_inside_asyncio_run(self) -> None:
+        """``asyncio.run`` の coroutine 内では ``True`` を返す。"""
+
+        async def _check() -> bool:
+            return ProviderManager._running_loop_active()
+
+        assert asyncio.run(_check()) is True


### PR DESCRIPTION
## 概要

WebAPI 推論失敗ログの cause chain 末尾に `RuntimeError: no running event loop` が
混入する問題を修正する (LoRAIro #302)。

LoRAIro #274 の実機 runtime validation で、`openai/gpt-4o-mini` の 429 失敗時の
診断 chain 末尾にこの `RuntimeError` が現れ、当初は「429 retry / async ライフ
サイクルのコード欠陥」と推定されていた。調査の結果、**機能バグではなく診断
ノイズ**と確定した。

## 根本原因

`ProviderManager.run_inference_with_model` (sync wrapper) は running loop 検出に
`asyncio.get_running_loop()` を使う。旧実装:

```python
try:
    asyncio.get_running_loop()        # loop が無いと RuntimeError("no running event loop")
except RuntimeError:
    return asyncio.run(...)            # ← except ブロック内
```

`asyncio.run()` が `except RuntimeError` ブロック **内** で呼ばれているため、その
動的範囲で coroutine 内に raise される素の例外 (`__cause__` 無し) が `__context__`
に probe の `RuntimeError` を継承する。429 path の `HTTPStatusError`
(`raise_for_status()` の `from` 無し raise) がこれに該当し、`_format_exception_chain`
の診断文字列に偽の根本原因として現れていた。

### 再現実験

```
CASE A (asyncio.run を except 内で呼ぶ = 旧コード):
  ValueError: real-error-from-coroutine <- caused by RuntimeError: no running event loop
CASE B (asyncio.run を except 外で呼ぶ):
  ValueError: real-error-from-coroutine            ← 漏れなし
```

`get_running_loop()` を呼ぶ箇所は WebAPI 経路全体でこの probe 1 箇所のみ。
`AsyncTenacityTransport` / `wait_retry_after` / tenacity async sleep / httpx には
`no running event loop` を raise する経路は無い。429 失敗自体は probe 構造と無関係に発生する。

## 修正

probe を `_running_loop_active() -> bool` helper に分離し、`RuntimeError` を完全に
消費してから `asyncio.run()` を `except` ブロック **外** で実行する。running loop 内
呼び出し時の `InferenceError` 挙動は不変。

## test

新規 `tests/unit/core/test_provider_manager_event_loop_context.py`:

- sync wrapper 経由の error 文字列に `no running event loop` が混入せず真の原因
  (429) が保持されること (回帰防止)
- `_running_loop_active()` の loop 内外判定
- running loop 内呼び出しが従来通り `InferenceError` を raise すること

### 検証

CI-equivalent filter で全 pass:

```
pytest -m "not downloads_and_runs_model and not calls_real_webapi"
→ 649 passed, 18 skipped (既存 dead-test skip)
```

## 関連

- LoRAIro #302 (本 issue)
- 発端: LoRAIro #274 (WebAPI Connection error、診断 patch でこの artifact を surface)
- 関連: image-annotator-lib #46 (HTTP transport retry policy)
