### PR TITLE
feat: expose model-native rating outputs

### DIFF
--- a/docs/decisions/0002-score-model-output-contract.md
+++ b/docs/decisions/0002-score-model-output-contract.md
@@ -218,6 +218,10 @@ arbitrary policy になるため、`SCORE_LABELS` を持たせず regression の
 | 全 scorer に `score_labels` を強制する | regression モデル (`ImprovedAesthetic` / `WaifuAesthetic`) は配布元が categorical label を提供しない。lib 側で閾値を arbitrary に決めることになる |
 | `score_labels` ではなく `ratings` という field 名を使う | `ratings` は別概念 (例: NSFW rating 等) と混同しやすい。本 ADR は scorer の categorical label に特化した名前 `score_labels` を採用 |
 
+ADR 0003 で `ratings` field を rating / NSFW classifier 用に定義した。本 ADR で却下したのは
+score-derived categorical label を `ratings` と呼ぶ案であり、rating model output contract とは
+矛盾しない。
+
 ## Consequences
 
 ### 良い点
@@ -249,6 +253,7 @@ arbitrary policy になるため、`SCORE_LABELS` を持たせず regression の
 - **Issue**: NEXTAltair/image-annotator-lib#66
 - **Preliminary investigation (code-level)**: NEXTAltair/image-annotator-lib#66 issue comment (reproduction + 行番号付き code inventory + 完了条件)
 - **Runtime validation ADR**: 0001
+- **Rating output ADR**: 0003
 - **LoRAIro ADR**: NEXTAltair/LoRAIro `docs/decisions/0026-on-demand-runtime-validation-strategy.md`
 - **Implementation reference**: `https://github.com/toshiaki1729/dataset-tag-editor-standalone`
 - **Model sources**:

--- a/docs/decisions/0003-rating-model-output-contract.md
+++ b/docs/decisions/0003-rating-model-output-contract.md
@@ -1,0 +1,185 @@
+# ADR 0003: Rating Model Output Contract
+
+- **日付**: 2026-05-21
+- **ステータス**: Accepted
+
+## Context
+
+WaifuDiffusion Tagger 系モデルは、content tag だけでなく `general` / `sensitive` /
+`questionable` / `explicit` のような rating category も出力する。さらに、rating / NSFW 判定に
+使える新規候補モデルとして以下がある。
+
+- `deepghs/anime_rating`
+- `deepghs/eattach_sankaku_rating`
+- `Camais03/camie-tagger-v2`
+- `ggg4mless/RateBooru_Efficient`
+- binary NSFW / explicit-content classifier
+
+これらの label scheme はモデルごとに異なる。LoRAIro は `PG` / `PG-13` / `R` / `X` / `XXX`
+という canonical rating を持つが、それは consumer 固有の policy であり、image-annotator-lib の
+共通 contract ではない。
+
+ADR 0002 は score-derived categorical label を `score_labels` として定義し、model-specific key
+や scale を無理に正規化しない方針を採った。rating model output も同じく、まず配布元・モデル
+固有の label を保持する必要がある。
+
+## Decision
+
+1. 新規 capability `TaskCapability.RATINGS` を定義する。
+2. `UnifiedAnnotationResult` に `ratings: list[RatingPrediction] | None` を追加する。
+3. `ratings` は model-native な top prediction を返す。LoRAIro canonical rating へ変換しない。
+4. full distribution が必要な場合は `raw_output` に保持する。`ratings` は downstream が扱いやすい
+   summary field とする。
+5. rating 対応を実装した model adapter だけが `TaskCapability.RATINGS` を宣言する。rating 能力の
+   ないモデルに `ratings` は期待しない。
+
+### RatingPrediction
+
+`RatingPrediction` は以下の情報を持つ。
+
+| field | 型 | 意味 |
+|---|---|---|
+| `raw_label` | `str` | モデルが返した rating label。例: `general`, `questionable`, `r15`, `NSFW` |
+| `confidence_score` | `float | None` | `raw_label` の confidence。取得できないモデルでは `None` |
+| `source_scheme` | `str` | label scheme id。例: `danbooru4`, `e6213`, `sankaku3`, `binary_nsfw` |
+
+`normalized_rating` / `canonical_rating` / `lorairo_rating` のような consumer policy field は持たせない。
+
+### Source schemes
+
+初期対応の scheme id は以下とする。
+
+| `source_scheme` | labels | 想定モデル |
+|---|---|---|
+| `danbooru4` | `general`, `sensitive`, `questionable`, `explicit` | WaifuDiffusion Tagger / `Camais03/camie-tagger-v2` |
+| `danbooru3` | `general`, `questionable`, `explicit` | `ggg4mless/RateBooru_Efficient` 等 |
+| `e6213` | `safe`, `questionable`, `explicit` | Z3D E621Tagger 系 |
+| `sankaku3` | `safe`, `r15`, `r18` | `deepghs/anime_rating`, `deepghs/eattach_sankaku_rating` |
+| `binary_nsfw` | `SFW`, `NSFW` | generic NSFW classifier |
+| `explicit_content` | model-specific explicit-content labels | generic explicit-content classifier |
+
+binary NSFW 候補モデルの model card:
+
+- `AdamCodd/vit-base-nsfw-detector`: https://huggingface.co/AdamCodd/vit-base-nsfw-detector
+  - 二値: `sfw` / `nsfw`
+  - 実写・3D・drawings を含む約 25,000 images で fine-tune。model card では generated image では
+    性能が下がると明記されている。
+- `AdamCodd/vit-nsfw-stable-diffusion`: https://huggingface.co/AdamCodd/vit-nsfw-stable-diffusion
+  - 二値: `sfw` / `nsfw`
+  - Stable Diffusion 生成画像向け。access gate と非商用系 license 条件があるため採用前確認が必要。
+- `Falconsai/nsfw_image_detection`: https://huggingface.co/Falconsai/nsfw_image_detection
+  - 二値: `normal` / `nsfw`
+  - NSFW image classification 用の ViT fine-tune。
+- `CaveduckAI/nsfw-classifier`: https://huggingface.co/CaveduckAI/nsfw-classifier
+  - 二値: `SFW` / `NSFW`
+  - ConvNeXt 系。model card に validation accuracy と label id が明記されている。
+
+これらは rating を細分化するモデルではなく、`binary_nsfw` scheme の routing / filtering signal として
+扱う。Civitai 5段階などへの変換は consumer 側の責務であり、library では行わない。
+
+### Existing WDTagger behavior
+
+WDTagger / Z3D E621Tagger など、既に rating category を内部出力しているモデルは、
+content tags とは別に `ratings` を返す。rating category を `tags` に混ぜない。
+
+既存実装で full category distribution を `raw_output` に保持している場合、それは維持する。
+`ratings` には top-1 を入れる。
+
+top-1 は confidence が最大の label とする。confidence が取得できないモデルでは adapter が最も
+妥当な 1 件を返し、`confidence_score=None` とする。推定値を `1.0` や `0.0` で埋めない。
+
+`raw_label` は `source_scheme` 内の公式表記に寄せる。例えば provider や model が `Safe` /
+`SAFE` / `safe` のように表記揺れする場合、adapter 内で `safe` に揃える。ただし LoRAIro
+canonical rating には変換しない。
+
+### WebAPI models
+
+WebAPI 経由で rating を依頼する場合も、library は prompt / provider の model-native label を
+`raw_label` として返す。LoRAIro canonical rating への mapping は行わない。
+
+ただし WebAPI rating は初期実装の範囲外とし、別 issue で扱う。
+
+## Rationale
+
+### なぜ LoRAIro rating に変換しないか
+
+`PG` / `PG-13` / `R` / `X` / `XXX` は LoRAIro の保存・検索・除外判定用の policy であり、
+汎用 library が固定すべき意味ではない。同じ `r15` を `PG-13` と見るか `R` と見るかは
+consumer の運用方針で変わる。
+
+### なぜ `tags` に入れないか
+
+`tags` は画像内容を表す content tag 用である。rating label を `tags` に混ぜると、下流が
+`1girl` / `outdoor` と `questionable` / `explicit` を同じ種類の検索・export 対象として扱って
+しまう。rating は専用 field と capability で分離する。
+
+### なぜ `ratings` field を追加するか
+
+`ratings` を専用 field として追加することで、モデルが rating を返すことを明示できる。
+既存の `tags` や `score_labels` に混ぜるより意味が分かれ、ライブラリ利用側も
+`result.ratings` だけを見れば rating 保存・routing 処理へ渡せる。
+
+`raw_output` だけに rating を置く案では、利用側が model id ごとに
+`raw_output["category_scores"]["ratings"]` や `raw_output["labels"]` のような
+model-specific な構造を解析する必要がある。専用 field を持たせれば、その解析責務を
+各 model adapter 内に閉じ込められる。
+
+また、`TaskCapability.RATINGS` と `ratings` field を対応させることで、`ratings` を返すモデルは
+capability に `RATINGS` を宣言しなければならない、という既存の出力検証パターンに乗せられる。
+これにより「rating を返しているのに capability に出ていない」「rating capability なのに
+`tags` に混ぜている」といった contract 不整合をテストで検出できる。
+
+### なぜ top-1 field と raw_output を分けるか
+
+多くの consumer は保存・filter 用に最終 label だけを必要とする。一方で、threshold 調整や UI
+表示では full distribution が必要になる。`ratings` は安定 contract として top-1 を提供し、
+詳細は model-specific `raw_output` に保持する。
+
+WDTagger 系のように category probability を持つモデルでは、full distribution は
+`raw_output["category_scores"]["ratings"]` に保持する。二値 NSFW classifier など別形式のモデルでも、
+`raw_output` に model-native な全出力を残す。
+
+### 却下した選択肢
+
+| 案 | 却下理由 |
+|---|---|
+| library が `PG` / `R` 等へ変換する | consumer 固有 policy を library に固定してしまう |
+| rating label を `tags` に混ぜる | content tag と safety/rating label が区別不能になる |
+| binary NSFW 用の専用 field を作る | binary NSFW は rating / routing signal の一種であり、field を増やすと consumer contract が分散する |
+| full distribution を `ratings` に全展開する | stable summary field と model-specific raw output の境界が曖昧になる |
+
+## Consequences
+
+### 良い点
+
+- model-native label と confidence を失わない。
+- LoRAIro 以外の consumer が自分の policy で mapping できる。
+- WDTagger 系の rating category を content tags から分離できる。
+- ADR 0002 と同様に、library はモデル出力の意味を保持し、正規化 policy を consumer に任せる。
+
+### 悪い点・トレードオフ
+
+- downstream consumer は `source_scheme` + `raw_label` の mapping を自前で持つ必要がある。
+- `source_scheme` の命名を増やすときは、モデル追加 issue / PR で label 一覧を明示する必要がある。
+- full distribution は `raw_output` の model-specific 形式を参照するため、横断的な UI には追加設計が必要。
+
+### 運用ルール
+
+- `TaskCapability.RATINGS` を宣言したモデルは `ratings is not None` を返す。
+- rating 能力がないモデルは `TaskCapability.RATINGS` を宣言しない。利用側も `ratings` を期待しない。
+- rating 抽出実装が入っていないモデルに capability だけを先に足さない。
+- `ratings` を返すモデルは、`tags` に rating category を混ぜない。
+- `raw_label` は配布元の label spelling を原則保持する。ただし provider が空白・大小文字を揺らす場合は
+  model adapter 内で scheme ごとに定義した spelling に寄せる。
+- `source_scheme` は model id ではなく label scheme id とする。同じ scheme を複数モデルで共有してよい。
+- LoRAIro canonical rating への mapping は image-annotator-lib では実装しない。
+
+## Related
+
+- ADR 0002: Score Model Output Contract
+- NEXTAltair/image-annotator-lib#79
+- NEXTAltair/image-annotator-lib#80
+- NEXTAltair/image-annotator-lib#81
+- NEXTAltair/image-annotator-lib#82
+- NEXTAltair/LoRAIro#333
+- LoRAIro ADR 0031: Model-Native Rating Mapping and Storage

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -6,6 +6,7 @@ image-annotator-lib の重要な設計判断を記録するドキュメント群
 |-----|---------|------|-----------|
 | [0001](0001-runtime-validation-test-lanes.md) | Runtime Validation Test Lanes | 2026-05-17 | Accepted |
 | [0002](0002-score-model-output-contract.md) | Score Model Output Contract | 2026-05-17 | Accepted |
+| [0003](0003-rating-model-output-contract.md) | Rating Model Output Contract | 2026-05-21 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/image_annotator_lib/core/base/onnx.py
+++ b/src/image_annotator_lib/core/base/onnx.py
@@ -9,7 +9,7 @@ from PIL import Image
 # --- ローカルインポート ---
 from ...exceptions.errors import OutOfMemoryError
 from ..model_factory import ModelLoad
-from ..types import ONNXComponents, TaskCapability, UnifiedAnnotationResult
+from ..types import ONNXComponents, RatingPrediction, TaskCapability, UnifiedAnnotationResult
 from ..utils import logger
 from .annotator import BaseAnnotator
 
@@ -111,12 +111,15 @@ class ONNXBaseAnnotator(BaseAnnotator):
         # 閾値フィルタリング
         final_tags = self._filter_tags_by_threshold(category_scores, threshold)
 
+        ratings = self._extract_top_rating(category_scores, capabilities)
+
         return UnifiedAnnotationResult(
             model_name=self.model_name,
             capabilities=capabilities,
             tags=final_tags if TaskCapability.TAGS in capabilities else None,
             captions=None,
             scores=None,
+            ratings=ratings,
             framework="onnx",
             raw_output={
                 "predictions": predictions.tolist(),
@@ -216,6 +219,34 @@ class ONNXBaseAnnotator(BaseAnnotator):
 
         return category_scores
 
+    def _extract_top_rating(
+        self, category_scores: dict[str, dict[str, float]], capabilities: set[TaskCapability]
+    ) -> list[RatingPrediction] | None:
+        """Extract top-1 model-native rating prediction from category scores."""
+        if TaskCapability.RATINGS not in capabilities:
+            return None
+
+        rating_scores = category_scores.get("ratings")
+        if not rating_scores:
+            return None
+
+        raw_label, confidence = max(rating_scores.items(), key=lambda item: item[1])
+        source_scheme = getattr(self, "rating_source_scheme", "unknown")
+        return [
+            RatingPrediction(
+                raw_label=self._normalize_rating_label(raw_label),
+                confidence_score=float(confidence),
+                source_scheme=source_scheme,
+            )
+        ]
+
+    @staticmethod
+    def _normalize_rating_label(raw_label: str) -> str:
+        """Normalize adapter-local rating label spelling without consumer mapping."""
+        if ":" in raw_label:
+            raw_label = raw_label.split(":", 1)[1]
+        return raw_label.strip().lower().replace(" ", "_")
+
     @staticmethod
     def _filter_tags_by_threshold(
         category_scores: dict[str, dict[str, float]], threshold: float
@@ -230,7 +261,9 @@ class ONNXBaseAnnotator(BaseAnnotator):
             信頼度降順のタグ名リスト。
         """
         filtered_tags = []
-        for _category, tag_dict in category_scores.items():
+        for category, tag_dict in category_scores.items():
+            if category in {"rating", "ratings"}:
+                continue
             for tag, confidence in tag_dict.items():
                 if confidence >= threshold:
                     filtered_tags.append((tag, confidence))

--- a/src/image_annotator_lib/core/types.py
+++ b/src/image_annotator_lib/core/types.py
@@ -208,6 +208,18 @@ class TaskCapability(str, Enum):
     CAPTIONS = "captions"
     SCORES = "scores"
     SCORE_LABELS = "score_labels"
+    RATINGS = "ratings"
+
+
+class RatingPrediction(BaseModel):
+    """Model-native rating prediction.
+
+    LoRAIro などの consumer 固有 rating へは変換せず、モデルの label scheme を保持する。
+    """
+
+    raw_label: str
+    confidence_score: float | None = None
+    source_scheme: str
 
 
 class UnifiedAnnotationResult(BaseModel):
@@ -228,6 +240,8 @@ class UnifiedAnnotationResult(BaseModel):
     # ADR 0002: scorer 由来の categorical label (例: "very aesthetic", "aesthetic")。
     # content tag (WDTagger 等) と field レベルで分離。
     score_labels: list[str] | None = None
+    # ADR 0003: rating / NSFW classifier 由来の model-native rating。
+    ratings: list[RatingPrediction] | None = None
 
     # メタデータ(Optional)
     provider_name: str | None = None
@@ -275,6 +289,17 @@ class UnifiedAnnotationResult(BaseModel):
                 raise ValueError(
                     f"score_labels provided but SCORE_LABELS not in capabilities: {capabilities}"
                 )
+        return v
+
+    @field_validator("ratings")
+    @classmethod
+    def validate_ratings_capability(
+        cls, v: list[RatingPrediction] | None, info: ValidationInfo
+    ) -> list[RatingPrediction] | None:
+        if v is not None:
+            capabilities = info.data.get("capabilities", set())
+            if TaskCapability.RATINGS not in capabilities:
+                raise ValueError(f"ratings provided but RATINGS not in capabilities: {capabilities}")
         return v
 
     @model_validator(mode="after")

--- a/src/image_annotator_lib/model_class/tagger_onnx.py
+++ b/src/image_annotator_lib/model_class/tagger_onnx.py
@@ -24,6 +24,8 @@ class E621Categories:
 class WDTagger(ONNXBaseAnnotator):
     """WD Tagger (ONNX版)"""
 
+    rating_source_scheme = "danbooru4"
+
     def __init__(self, model_name: str):
         """WDTagger を初期化します。"""
         super().__init__(model_name=model_name)
@@ -95,6 +97,8 @@ class WDTagger(ONNXBaseAnnotator):
 class Z3D_E621Tagger(ONNXBaseAnnotator):
     """Z3D E621 Tagger (ONNX版)"""
 
+    rating_source_scheme = "e6213"
+
     def __init__(self, model_name: str):
         """Z3D_E621Tagger を初期化します。"""
         super().__init__(model_name=model_name)
@@ -108,7 +112,7 @@ class Z3D_E621Tagger(ONNXBaseAnnotator):
             "copyright": "copyright_indexes",
             "meta": "meta_indexes",  # meta, lore も追加
             "lore": "lore_indexes",
-            # rating は別途処理
+            "rating": "rating_indexes",
         }
         # レーティングタグ
         self._rating_tags = ["explicit", "questionable", "safe"]

--- a/src/image_annotator_lib/resources/system/annotator_config.toml
+++ b/src/image_annotator_lib/resources/system/annotator_config.toml
@@ -47,72 +47,84 @@ model_path = "deepghs/idolsankaku-eva02-large-tagger-v1"
 class = "WDTagger"
 estimated_size_gb = 1.695
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [idolsankaku-swinv2-tagger-v1]
 model_path = "deepghs/idolsankaku-swinv2-tagger-v1"
 class = "WDTagger"
 estimated_size_gb = 0.587
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [Z3D-E621-Convnext]
 model_path = "toynya/Z3D-E621-Convnext"
 class = "Z3D_E621Tagger"
 estimated_size_gb = 0.544
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [wd-v1-4-convnext-tagger-v2]
 model_path = "SmilingWolf/wd-v1-4-convnext-tagger-v2"
 class = "WDTagger"
 estimated_size_gb = 0.542
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [wd-v1-4-convnextv2-tagger-v2]
 model_path = "SmilingWolf/wd-v1-4-convnextv2-tagger-v2"
 class = "WDTagger"
 estimated_size_gb = 0.543
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [wd-v1-4-moat-tagger-v2]
 model_path = "SmilingWolf/wd-v1-4-moat-tagger-v2"
 class = "WDTagger"
 estimated_size_gb = 0.456
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [wd-v1-4-swinv2-tagger-v2]
 model_path = "SmilingWolf/wd-v1-4-swinv2-tagger-v2"
 class = "WDTagger"
 estimated_size_gb = 0.636
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [wd-vit-tagger-v3]
 model_path = "SmilingWolf/wd-vit-tagger-v3"
 class = "WDTagger"
 estimated_size_gb = 0.529
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [wd-convnext-tagger-v3]
 model_path = "SmilingWolf/wd-convnext-tagger-v3"
 class = "WDTagger"
 estimated_size_gb = 0.552
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [wd-swinv2-tagger-v3]
 model_path = "SmilingWolf/wd-swinv2-tagger-v3"
 class = "WDTagger"
 estimated_size_gb = 0.653
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [wd-vit-large-tagger-v3]
 model_path = "SmilingWolf/wd-vit-large-tagger-v3"
 class = "WDTagger"
 estimated_size_gb = 1.761
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [wd-eva02-large-tagger-v3]
 model_path = "SmilingWolf/wd-eva02-large-tagger-v3"
 class = "WDTagger"
 estimated_size_gb = 1.761
 type = "tagger"
+capabilities = ["tags", "ratings"]
 
 [BLIPLargeCaptioning]
 model_path = "Salesforce/blip-image-captioning-large"

--- a/tests/unit/model_class/test_tagger_onnx.py
+++ b/tests/unit/model_class/test_tagger_onnx.py
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 from PIL import Image
 
+from image_annotator_lib.core.types import TaskCapability
 from image_annotator_lib.model_class.tagger_onnx import WDTagger, Z3D_E621Tagger
 
 
@@ -77,7 +78,7 @@ def mock_csv_file(tmp_path):
 solo,0
 smile,0
 long_hair,0
-rating:safe,9
+rating:general,9
 rating:questionable,9
 rating:explicit,9
 character_name,4
@@ -116,10 +117,8 @@ def mock_capabilities():
 
     This avoids Pydantic validation issues with capabilities in config.
     """
-    from image_annotator_lib.core.types import TaskCapability
-
     with patch("image_annotator_lib.core.utils.get_model_capabilities") as mock:
-        mock.return_value = {TaskCapability.TAGS}
+        mock.return_value = {TaskCapability.TAGS, TaskCapability.RATINGS}
         yield mock
 
 
@@ -234,7 +233,8 @@ def test_onnx_tagger_inference(
             predictions[0, 0] = 0.95  # 1girl (general, above threshold)
             predictions[0, 1] = 0.85  # solo (general, above threshold)
             predictions[0, 2] = 0.30  # smile (general, below threshold 0.5)
-            predictions[0, 4] = 0.75  # rating:safe (rating)
+            predictions[0, 4] = 0.75  # rating:general (rating)
+            predictions[0, 5] = 0.82  # rating:questionable (rating)
             mock_onnx_session.run.return_value = [predictions]
 
             tagger = WDTagger(mock_wdtagger_config)
@@ -256,6 +256,13 @@ def test_onnx_tagger_inference(
                 result = formatted[0]
                 assert result.tags is not None
                 assert len(result.tags) >= 2  # At least 1girl and solo (above threshold)
+                assert "general" not in result.tags
+                assert "questionable" not in result.tags
+                assert result.ratings is not None
+                assert len(result.ratings) == 1
+                assert result.ratings[0].raw_label == "questionable"
+                assert result.ratings[0].confidence_score == pytest.approx(0.82)
+                assert result.ratings[0].source_scheme == "danbooru4"
                 assert result.framework == "onnx"
                 assert result.raw_output is not None
 
@@ -403,7 +410,7 @@ artist_name,1
 copyright_name,3
 character_name,4
 meta_tag,5
-rating:safe,9
+rating:general,9
 rating:questionable,9
 rating:explicit,9
 """
@@ -424,13 +431,13 @@ rating:explicit,9
                 assert len(tagger.all_tags) == 9
                 assert "general_tag_1" in tagger.all_tags
                 assert "character_name" in tagger.all_tags
-                assert "rating:safe" in tagger.all_tags
+                assert "rating:general" in tagger.all_tags
 
                 # Verify category indexes
                 assert 0 in tagger.general_indexes  # general_tag_1
                 assert 1 in tagger.general_indexes  # general_tag_2
                 assert 4 in tagger.character_indexes  # character_name
-                assert 6 in tagger.rating_indexes  # rating:safe
+                assert 6 in tagger.rating_indexes  # rating:general
 
 
 @pytest.mark.unit
@@ -581,7 +588,7 @@ def test_onnx_tagger_category_score_extraction(
                             0.75,  # general tag 2
                             0.65,  # general tag 3
                             0.55,  # general tag 4
-                            0.80,  # rating:safe (index 4 in CSV)
+                            0.80,  # rating:general (index 4 in CSV)
                             0.15,  # rating:questionable
                             0.05,  # rating:explicit
                             0.70,  # character_name
@@ -601,6 +608,11 @@ def test_onnx_tagger_category_score_extraction(
                 result = formatted[0]
                 assert result.tags is not None
                 assert result.raw_output is not None
+                assert result.ratings is not None
+                assert result.ratings[0].raw_label == "general"
+                assert result.ratings[0].confidence_score == pytest.approx(0.80)
+                assert result.ratings[0].source_scheme == "danbooru4"
+                assert "general" not in result.tags
                 assert result.framework == "onnx"
 
 
@@ -650,6 +662,7 @@ def test_z3d_e621_tagger_initialization(managed_config_registry, mock_onnx_sessi
                     "copyright",
                     "meta",
                     "lore",
+                    "rating",
                 }
                 assert set(tagger._category_attr_map.keys()) == expected_categories
 
@@ -659,3 +672,63 @@ def test_z3d_e621_tagger_initialization(managed_config_registry, mock_onnx_sessi
                 assert hasattr(tagger, "all_tags")
                 assert hasattr(tagger, "rating_indexes")
                 assert hasattr(tagger, "general_indexes")
+
+
+@pytest.mark.unit
+def test_z3d_e621_tagger_extracts_e621_rating(
+    managed_config_registry, mock_onnx_session, tmp_path, test_image
+):
+    """Test Z3D_E621Tagger emits model-native e621 rating separately from content tags."""
+    csv_path = tmp_path / "z3d_tags.csv"
+    csv_path.write_text(
+        "\n".join(
+            [
+                "name,category",
+                "tail,0",
+                "solo,0",
+                "safe,9",
+                "questionable,9",
+                "explicit,9",
+            ]
+        )
+    )
+    config = {
+        "class": "Z3D_E621Tagger",
+        "model_path": "/fake/model.onnx",
+        "device": "cpu",
+        "estimated_size_gb": 1.0,
+        "type": "tagger",
+        "capabilities": ["tags", "ratings"],
+    }
+    managed_config_registry.set("test_z3d_rating", config)
+
+    with patch("onnxruntime.InferenceSession", return_value=mock_onnx_session):
+        with patch("image_annotator_lib.core.model_factory.ModelLoad.load_onnx_components") as mock_load:
+            mock_load.return_value = {
+                "session": mock_onnx_session,
+                "csv_path": str(csv_path),
+                "model_path": "/fake/model.onnx",
+            }
+
+            predictions = np.array([[0.91, 0.88, 0.10, 0.20, 0.93]], dtype=np.float32)
+            mock_onnx_session.run.return_value = [predictions]
+
+            tagger = Z3D_E621Tagger("test_z3d_rating")
+
+            with tagger:
+                processed = tagger._preprocess_images([test_image])
+                raw_outputs = tagger._run_inference(processed)
+                formatted = tagger._format_predictions(raw_outputs)
+
+                result = formatted[0]
+                assert result.tags is not None
+                assert "tail" in result.tags
+                assert "solo" in result.tags
+                assert "explicit" not in result.tags
+                assert result.ratings is not None
+                assert len(result.ratings) == 1
+                assert result.ratings[0].raw_label == "explicit"
+                assert result.ratings[0].confidence_score == pytest.approx(0.93)
+                assert result.ratings[0].source_scheme == "e6213"
+                assert result.raw_output is not None
+                assert result.raw_output["category_scores"]["ratings"]["explicit"] == pytest.approx(0.93)

--- a/tests/unit/test_capability_validation.py
+++ b/tests/unit/test_capability_validation.py
@@ -5,7 +5,7 @@ Test capability-based validation for UnifiedAnnotationResult
 import pytest
 from pydantic import ValidationError
 
-from image_annotator_lib.core.types import TaskCapability, UnifiedAnnotationResult
+from image_annotator_lib.core.types import RatingPrediction, TaskCapability, UnifiedAnnotationResult
 
 
 class TestTaskCapability:
@@ -17,6 +17,7 @@ class TestTaskCapability:
         assert TaskCapability.CAPTIONS == "captions"
         assert TaskCapability.SCORES == "scores"
         assert TaskCapability.SCORE_LABELS == "score_labels"
+        assert TaskCapability.RATINGS == "ratings"
 
     def test_task_capability_creation(self):
         """Test TaskCapability creation from strings"""
@@ -24,6 +25,7 @@ class TestTaskCapability:
         assert TaskCapability("captions") == TaskCapability.CAPTIONS
         assert TaskCapability("scores") == TaskCapability.SCORES
         assert TaskCapability("score_labels") == TaskCapability.SCORE_LABELS
+        assert TaskCapability("ratings") == TaskCapability.RATINGS
 
     def test_invalid_capability(self):
         """Test that invalid capability values raise errors"""
@@ -121,6 +123,41 @@ class TestUnifiedAnnotationResult:
                 capabilities={TaskCapability.SCORES},
                 scores={"aesthetic": 0.5},
                 score_labels=["aesthetic"],
+            )
+
+    def test_valid_ratings_capability(self):
+        """Test valid ratings with RATINGS capability (ADR 0003)."""
+        result = UnifiedAnnotationResult(
+            model_name="wd-vit-tagger-v3",
+            capabilities={TaskCapability.TAGS, TaskCapability.RATINGS},
+            tags=["1girl"],
+            ratings=[
+                RatingPrediction(
+                    raw_label="questionable",
+                    confidence_score=0.82,
+                    source_scheme="danbooru4",
+                )
+            ],
+        )
+        assert result.ratings is not None
+        assert result.ratings[0].raw_label == "questionable"
+        assert result.ratings[0].confidence_score == 0.82
+        assert result.ratings[0].source_scheme == "danbooru4"
+
+    def test_invalid_ratings_without_capability(self):
+        """Test that ratings without RATINGS capability raises ValidationError (ADR 0003)."""
+        with pytest.raises(ValidationError, match="ratings provided but RATINGS not in capabilities"):
+            UnifiedAnnotationResult(
+                model_name="wd-vit-tagger-v3",
+                capabilities={TaskCapability.TAGS},
+                tags=["1girl"],
+                ratings=[
+                    RatingPrediction(
+                        raw_label="questionable",
+                        confidence_score=0.82,
+                        source_scheme="danbooru4",
+                    )
+                ],
             )
 
     def test_score_only_scorer_invariants(self):

--- a/tests/unit/test_unified_validation_schema.py
+++ b/tests/unit/test_unified_validation_schema.py
@@ -5,7 +5,7 @@ Test unified validation schema integration
 import pytest
 from pydantic import ValidationError
 
-from image_annotator_lib.core.types import TaskCapability, UnifiedAnnotationResult
+from image_annotator_lib.core.types import RatingPrediction, TaskCapability, UnifiedAnnotationResult
 
 
 class TestUnifiedValidationSchemaIntegration:
@@ -91,6 +91,14 @@ class TestUnifiedValidationSchemaIntegration:
         with pytest.raises(ValidationError, match="scores provided but SCORES not in capabilities"):
             UnifiedAnnotationResult(
                 model_name="test-captioner", capabilities={TaskCapability.CAPTIONS}, scores={"invalid": 0.5}
+            )
+
+        # Invalid ratings without RATINGS capability
+        with pytest.raises(ValidationError, match="ratings provided but RATINGS not in capabilities"):
+            UnifiedAnnotationResult(
+                model_name="test-tagger",
+                capabilities={TaskCapability.TAGS},
+                ratings=[RatingPrediction(raw_label="explicit", confidence_score=0.9, source_scheme="e6213")],
             )
 
     def test_error_handling_with_capabilities(self):


### PR DESCRIPTION
## Summary

- add TaskCapability.RATINGS and UnifiedAnnotationResult.ratings
- emit model-native top-1 rating predictions from existing WDTagger/Z3D ONNX outputs
- keep rating category scores in raw_output while excluding rating labels from content tags
- document the rating output contract in ADR 0003

## Tests

- uv run pytest tests/unit/test_capability_validation.py tests/unit/test_unified_validation_schema.py tests/unit/model_class/test_tagger_onnx.py
- uv run pytest tests/unit/test_capability_utils.py tests/unit/fast/test_list_annotator_info.py
- git diff --check
- uv run ruff check --select F821 src/image_annotator_lib/core/types.py src/image_annotator_lib/core/base/onnx.py src/image_annotator_lib/model_class/tagger_onnx.py tests/unit/test_capability_validation.py tests/unit/test_unified_validation_schema.py tests/unit/model_class/test_tagger_onnx.py

Closes #80
Related #79
