### PR TITLE
feat: add anime rating annotator

### DIFF
--- a/config/annotator_config-sample.toml
+++ b/config/annotator_config-sample.toml
@@ -99,6 +99,14 @@ model_path = "SmilingWolf/wd-vit-tagger-v3"
 class = "WDTagger"
 estimated_size_gb = 0.529
 
+[anime_rating_mobilenetv3_sce_dist]
+model_path = "deepghs/anime_rating"
+model_variant = "mobilenetv3_sce_dist"
+class = "AnimeRatingAnnotator"
+estimated_size_gb = 0.047
+type = "tagger"
+capabilities = ["ratings"]
+
 [wd-convnext-tagger-v3]
 model_path = "SmilingWolf/wd-convnext-tagger-v3"
 class = "WDTagger"

--- a/config/annotator_config.toml
+++ b/config/annotator_config.toml
@@ -90,6 +90,14 @@ class = "WDTagger"
 estimated_size_gb = 0.529
 type = "tagger"
 
+[anime_rating_mobilenetv3_sce_dist]
+model_path = "deepghs/anime_rating"
+model_variant = "mobilenetv3_sce_dist"
+class = "AnimeRatingAnnotator"
+estimated_size_gb = 0.047
+type = "tagger"
+capabilities = ["ratings"]
+
 [wd-convnext-tagger-v3]
 model_path = "SmilingWolf/wd-convnext-tagger-v3"
 class = "WDTagger"

--- a/docs/decisions/0003-rating-model-output-contract.md
+++ b/docs/decisions/0003-rating-model-output-contract.md
@@ -177,6 +177,7 @@ WDTagger 系のように category probability を持つモデルでは、full di
 ## Related
 
 - ADR 0002: Score Model Output Contract
+- Model specs: `docs/model-specs/rating-model-candidates.md`
 - NEXTAltair/image-annotator-lib#79
 - NEXTAltair/image-annotator-lib#80
 - NEXTAltair/image-annotator-lib#81

--- a/docs/model-specs/rating-model-candidates.md
+++ b/docs/model-specs/rating-model-candidates.md
@@ -1,0 +1,35 @@
+# Rating Model Candidates
+
+This document records model-specific facts for rating-capable annotators. The output contract is
+defined in ADR 0003; LoRAIro-specific mapping is intentionally out of scope for image-annotator-lib.
+
+## Adopted First: `deepghs/anime_rating`
+
+- Model card: https://huggingface.co/deepghs/anime_rating
+- Reference docs: https://dghs-imgutils.deepghs.org/main/api_doc/validate/rating.html
+- License: MIT
+- Format: ONNX
+- Source scheme: `sankaku3`
+- Labels: `safe`, `r15`, `r18`
+- Default variant: `mobilenetv3_sce_dist`
+- Default variant files:
+  - `mobilenetv3_sce_dist/model.onnx`
+  - `mobilenetv3_sce_dist/meta.json`
+- `meta.json` label order: `safe`, `r15`, `r18`
+- Model card metrics:
+  - `caformer_s36_plus`: 74.26% accuracy, 22.10G FLOPs
+  - `mobilenetv3_sce_dist`: 69.49% accuracy, 0.63G FLOPs
+- Notes:
+  - The model card and imgutils docs state that boundaries between `safe`, `r15`, and `r18`
+    are unclear, and the model should be treated as a rough estimate.
+  - Use `mobilenetv3_sce_dist` first because it is small enough for routine local validation.
+  - LoRAIro maps these labels downstream; the library returns only model-native labels.
+
+## Deferred
+
+| Model | Scheme | Status | Reason |
+|---|---|---|---|
+| `deepghs/eattach_sankaku_rating` | `sankaku3` | Deferred | Similar labels; compare after `anime_rating` adapter proves the path. |
+| `Camais03/camie-tagger-v2` | `danbooru4` | Deferred | Multi-label tagger, likely heavier than rating-only model. |
+| `ggg4mless/RateBooru_Efficient` | `danbooru3` | Low priority | TensorFlow/Keras dependency and weaker public metrics. |
+| Binary NSFW classifiers | `binary_nsfw` | Deferred | Routing/filter signal rather than fine-grained rating. |

--- a/src/image_annotator_lib/core/model_config.py
+++ b/src/image_annotator_lib/core/model_config.py
@@ -81,6 +81,7 @@ class LocalMLModelConfig(BaseModelConfig):
     final_activation_type: str | None = Field(default=None, description="最終層活性化関数(一部モデルのみ)")
     batch_size: int = Field(default=1, gt=0, description="バッチサイズ")
     gpu_memory_limit_gb: float | None = Field(default=None, gt=0, description="GPU メモリ上限 (GB)")
+    model_variant: str | None = Field(default=None, description="同一リポジトリ内のモデルvariant名")
 
     @field_validator("model_path")
     @classmethod

--- a/src/image_annotator_lib/model_class/rating_onnx.py
+++ b/src/image_annotator_lib/model_class/rating_onnx.py
@@ -1,0 +1,159 @@
+"""Rating-only ONNX annotators."""
+
+import json
+from pathlib import Path
+from typing import Any, ClassVar, Self, cast
+
+import numpy as np
+from PIL import Image
+
+from ..core.base import BaseAnnotator
+from ..core.config import config_registry
+from ..core.types import RatingPrediction, TaskCapability, UnifiedAnnotationResult
+from ..core.utils import determine_effective_device, logger
+
+
+class AnimeRatingAnnotator(BaseAnnotator):
+    """deepghs/anime_rating ONNX annotator.
+
+    Returns model-native Sankaku-style labels: safe, r15, r18.
+    """
+
+    rating_source_scheme: ClassVar[str] = "sankaku3"
+    default_model_variant: ClassVar[str] = "mobilenetv3_sce_dist"
+    default_labels: ClassVar[list[str]] = ["safe", "r15", "r18"]
+    input_size: ClassVar[int] = 384
+    image_mean: ClassVar[np.ndarray] = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+    image_std: ClassVar[np.ndarray] = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+
+    def __init__(self, model_name: str):
+        super().__init__(model_name=model_name)
+        self.device = determine_effective_device(self._config.device, self.model_name)
+        self.model_variant = config_registry.get(
+            self.model_name, "model_variant", self.default_model_variant
+        )
+        self.components: dict[str, Any] | None = None
+        self.labels = list(self.default_labels)
+
+    def __enter__(self) -> Self:
+        if self.model_path is None:
+            raise ValueError(f"モデル '{self.model_name}' の model_path が設定されていません。")
+
+        import onnxruntime as ort
+
+        model_path, meta_path = self._resolve_model_files(self.model_path, self.model_variant)
+        providers = (
+            ["CUDAExecutionProvider", "CPUExecutionProvider"]
+            if self.device == "cuda" and "CUDAExecutionProvider" in ort.get_available_providers()
+            else ["CPUExecutionProvider"]
+        )
+        logger.info(f"Anime rating ONNX model '{self.model_name}' loading: {model_path}")
+        session = ort.InferenceSession(str(model_path), providers=providers)
+        self.labels = self._load_labels(meta_path)
+        self.components = {
+            "session": session,
+            "model_path": model_path,
+            "meta_path": meta_path,
+        }
+        return self
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any
+    ) -> None:
+        logger.debug(f"Exiting context for anime rating model '{self.model_name}'")
+        self.components = None
+        if exc_type:
+            logger.error(f"Anime rating model '{self.model_name}' context error: {exc_val}")
+
+    @staticmethod
+    def _resolve_model_files(model_path: str, model_variant: str) -> tuple[Path, Path]:
+        local_path = Path(model_path)
+        if local_path.exists():
+            if local_path.is_dir() and (local_path / "model.onnx").exists():
+                base_path = local_path
+            else:
+                base_path = local_path / model_variant if local_path.is_dir() else local_path.parent
+            return base_path / "model.onnx", base_path / "meta.json"
+
+        from huggingface_hub import hf_hub_download
+
+        model_file = hf_hub_download(model_path, f"{model_variant}/model.onnx")
+        meta_file = hf_hub_download(model_path, f"{model_variant}/meta.json")
+        return Path(model_file), Path(meta_file)
+
+    def _load_labels(self, meta_path: Path) -> list[str]:
+        try:
+            labels = json.loads(meta_path.read_text(encoding="utf-8")).get("labels")
+        except FileNotFoundError:
+            logger.warning(f"Anime rating meta file not found: {meta_path}; fallback labels used")
+            return list(self.default_labels)
+
+        if not isinstance(labels, list) or not all(isinstance(label, str) for label in labels):
+            logger.warning(f"Invalid anime rating labels in {meta_path}; fallback labels used")
+            return list(self.default_labels)
+        return [label.strip().lower().replace(" ", "_") for label in labels]
+
+    def _preprocess_images(self, images: list[Image.Image]) -> np.ndarray:
+        processed = []
+        for image in images:
+            rgb = image.convert("RGB").resize((self.input_size, self.input_size), Image.Resampling.BICUBIC)
+            array = np.asarray(rgb, dtype=np.float32) / 255.0
+            array = (array - self.image_mean) / self.image_std
+            processed.append(np.transpose(array, (2, 0, 1)))
+        return np.stack(processed, axis=0).astype(np.float32)
+
+    def _run_inference(self, processed: np.ndarray) -> np.ndarray:
+        if not self.components or "session" not in self.components:
+            raise RuntimeError("Anime rating ONNX session is not loaded")
+        session = self.components["session"]
+        input_name = session.get_inputs()[0].name
+        output_name = session.get_outputs()[0].name
+        return cast(np.ndarray, session.run([output_name], {input_name: processed})[0])
+
+    def _format_predictions(self, raw_outputs: np.ndarray) -> list[UnifiedAnnotationResult]:
+        from ..core.utils import get_model_capabilities
+
+        capabilities = get_model_capabilities(self.model_name)
+        probabilities = self._ensure_probabilities(raw_outputs.astype(np.float32))
+        results = []
+        for scores in probabilities:
+            score_map = {label: float(score) for label, score in zip(self.labels, scores, strict=True)}
+            raw_label, confidence = max(score_map.items(), key=lambda item: item[1])
+            results.append(
+                UnifiedAnnotationResult(
+                    model_name=self.model_name,
+                    capabilities=capabilities,
+                    tags=None,
+                    captions=None,
+                    scores=None,
+                    score_labels=None,
+                    ratings=[
+                        RatingPrediction(
+                            raw_label=raw_label,
+                            confidence_score=float(confidence),
+                            source_scheme=self.rating_source_scheme,
+                        )
+                    ]
+                    if TaskCapability.RATINGS in capabilities
+                    else None,
+                    framework="onnx",
+                    raw_output={"ratings": score_map},
+                )
+            )
+        return results
+
+    @staticmethod
+    def _ensure_probabilities(raw_outputs: np.ndarray) -> np.ndarray:
+        if raw_outputs.ndim == 1:
+            raw_outputs = raw_outputs.reshape(1, -1)
+        row_sums = raw_outputs.sum(axis=1)
+        if (
+            np.all(raw_outputs >= 0.0)
+            and np.all(raw_outputs <= 1.0)
+            and np.allclose(row_sums, 1.0, atol=1e-3)
+        ):
+            return raw_outputs
+
+        shifted = raw_outputs - np.max(raw_outputs, axis=1, keepdims=True)
+        exp = np.exp(shifted)
+        return exp / exp.sum(axis=1, keepdims=True)

--- a/src/image_annotator_lib/resources/system/annotator_config.toml
+++ b/src/image_annotator_lib/resources/system/annotator_config.toml
@@ -63,6 +63,14 @@ estimated_size_gb = 0.544
 type = "tagger"
 capabilities = ["tags", "ratings"]
 
+[anime_rating_mobilenetv3_sce_dist]
+model_path = "deepghs/anime_rating"
+model_variant = "mobilenetv3_sce_dist"
+class = "AnimeRatingAnnotator"
+estimated_size_gb = 0.047
+type = "tagger"
+capabilities = ["ratings"]
+
 [wd-v1-4-convnext-tagger-v2]
 model_path = "SmilingWolf/wd-v1-4-convnext-tagger-v2"
 class = "WDTagger"

--- a/tests/runtime_validation/test_real_model_runtime.py
+++ b/tests/runtime_validation/test_real_model_runtime.py
@@ -62,16 +62,41 @@ def test_real_model_runtime(model_name: str) -> None:
 
     assert len(result) == 1, f"expected 1 phash entry, got {len(result)}"
     for _phash, models in result.items():
-        assert model_name in models, (
-            f"{model_name} missing in result keys: {list(models.keys())}"
-        )
+        assert model_name in models, f"{model_name} missing in result keys: {list(models.keys())}"
         ann = models[model_name]
         assert ann.error is None, f"{model_name} returned error: {ann.error}"
-        output_present = bool(ann.tags) or bool(ann.captions) or bool(ann.scores) or bool(
-            ann.score_labels
+        output_present = (
+            bool(ann.tags)
+            or bool(ann.captions)
+            or bool(ann.scores)
+            or bool(ann.score_labels)
+            or bool(ann.ratings)
         )
         assert output_present, (
             f"{model_name}: all output fields empty "
             f"(tags={ann.tags!r}, captions={ann.captions!r}, "
-            f"scores={ann.scores!r}, score_labels={ann.score_labels!r})"
+            f"scores={ann.scores!r}, score_labels={ann.score_labels!r}, ratings={ann.ratings!r})"
         )
+
+
+@pytest.mark.downloads_and_runs_model
+def test_real_anime_rating_runtime() -> None:
+    """deepghs/anime_rating smoke test for model-native rating output."""
+    if not _RESOURCE_IMG.exists():
+        pytest.skip(f"resource image not found: {_RESOURCE_IMG}")
+
+    img = Image.open(_RESOURCE_IMG).convert("RGB")
+    model_name = "anime_rating_mobilenetv3_sce_dist"
+    result = annotate(images_list=[img], model_name_list=[model_name])
+
+    assert len(result) == 1, f"expected 1 phash entry, got {len(result)}"
+    for _phash, models in result.items():
+        ann = models[model_name]
+        assert ann.error is None, f"{model_name} returned error: {ann.error}"
+        assert ann.tags is None
+        assert ann.ratings is not None and len(ann.ratings) == 1
+        rating = ann.ratings[0]
+        assert rating.raw_label in {"safe", "r15", "r18"}
+        assert rating.source_scheme == "sankaku3"
+        assert rating.confidence_score is not None
+        assert 0.0 <= rating.confidence_score <= 1.0

--- a/tests/unit/model_class/test_rating_onnx.py
+++ b/tests/unit/model_class/test_rating_onnx.py
@@ -1,0 +1,114 @@
+"""Unit tests for rating-only ONNX annotators."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from image_annotator_lib.core.types import TaskCapability
+from image_annotator_lib.model_class.rating_onnx import AnimeRatingAnnotator
+
+
+@pytest.fixture
+def test_image() -> Image.Image:
+    return Image.new("RGB", (96, 128), color="white")
+
+
+@pytest.fixture
+def mock_session() -> MagicMock:
+    session = MagicMock()
+    mock_input = Mock()
+    mock_input.name = "input"
+    session.get_inputs.return_value = [mock_input]
+    mock_output = Mock()
+    mock_output.name = "output"
+    session.get_outputs.return_value = [mock_output]
+    session.run.return_value = [np.array([[0.05, 0.88, 0.07]], dtype=np.float32)]
+    return session
+
+
+@pytest.fixture
+def anime_rating_config(managed_config_registry, tmp_path: Path) -> str:
+    model_dir = tmp_path / "anime_rating" / "mobilenetv3_sce_dist"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.onnx").write_bytes(b"fake onnx")
+    (model_dir / "meta.json").write_text(
+        '{"labels": ["safe", "r15", "r18"], "name": "mobilenetv3_large_100"}',
+        encoding="utf-8",
+    )
+    managed_config_registry.set(
+        "test_anime_rating",
+        {
+            "class": "AnimeRatingAnnotator",
+            "model_path": str(tmp_path / "anime_rating"),
+            "model_variant": "mobilenetv3_sce_dist",
+            "device": "cpu",
+            "estimated_size_gb": 0.047,
+            "type": "tagger",
+            "capabilities": ["ratings"],
+        },
+    )
+    return "test_anime_rating"
+
+
+@pytest.mark.unit
+def test_anime_rating_outputs_sankaku3_rating(
+    anime_rating_config: str, mock_session: MagicMock, test_image: Image.Image
+) -> None:
+    with patch("onnxruntime.InferenceSession", return_value=mock_session):
+        annotator = AnimeRatingAnnotator(anime_rating_config)
+        with annotator:
+            processed = annotator._preprocess_images([test_image])
+            raw_outputs = annotator._run_inference(processed)
+            formatted = annotator._format_predictions(raw_outputs)
+
+    assert processed.shape == (1, 3, 384, 384)
+    assert processed.dtype == np.float32
+    assert len(formatted) == 1
+    result = formatted[0]
+    assert result.capabilities == {TaskCapability.RATINGS}
+    assert result.tags is None
+    assert result.ratings is not None
+    assert result.ratings[0].raw_label == "r15"
+    assert result.ratings[0].confidence_score == pytest.approx(0.88)
+    assert result.ratings[0].source_scheme == "sankaku3"
+    assert result.raw_output == {
+        "ratings": {"safe": pytest.approx(0.05), "r15": pytest.approx(0.88), "r18": pytest.approx(0.07)}
+    }
+
+
+@pytest.mark.unit
+def test_anime_rating_softmaxes_logits(anime_rating_config: str) -> None:
+    annotator = AnimeRatingAnnotator(anime_rating_config)
+    probabilities = annotator._ensure_probabilities(np.array([[1.0, 3.0, 2.0]], dtype=np.float32))
+
+    assert probabilities.shape == (1, 3)
+    assert probabilities.sum() == pytest.approx(1.0)
+    assert probabilities.argmax(axis=1).tolist() == [1]
+
+
+@pytest.mark.unit
+def test_anime_rating_falls_back_to_default_labels(anime_rating_config: str, tmp_path: Path) -> None:
+    annotator = AnimeRatingAnnotator(anime_rating_config)
+    labels = annotator._load_labels(tmp_path / "missing_meta.json")
+
+    assert labels == ["safe", "r15", "r18"]
+
+
+@pytest.mark.unit
+def test_anime_rating_resolves_local_variant_directory(tmp_path: Path) -> None:
+    variant_dir = tmp_path / "mobilenetv3_sce_dist"
+    variant_dir.mkdir()
+    model_file = variant_dir / "model.onnx"
+    meta_file = variant_dir / "meta.json"
+    model_file.write_bytes(b"fake onnx")
+    meta_file.write_text('{"labels": ["safe", "r15", "r18"]}', encoding="utf-8")
+
+    resolved_model, resolved_meta = AnimeRatingAnnotator._resolve_model_files(
+        str(variant_dir), "mobilenetv3_sce_dist"
+    )
+
+    assert resolved_model == model_file
+    assert resolved_meta == meta_file


### PR DESCRIPTION
## Summary
- add a rating-only ONNX annotator for deepghs/anime_rating mobilenetv3_sce_dist
- register anime_rating_mobilenetv3_sce_dist with ratings capability in runtime/sample/package configs
- document rating model candidate specs and add unit/runtime validation

## Tests
- uv run ruff check src/image_annotator_lib/model_class/rating_onnx.py src/image_annotator_lib/core/model_config.py tests/unit/model_class/test_rating_onnx.py tests/runtime_validation/test_real_model_runtime.py
- uv run ruff format --check src/image_annotator_lib/model_class/rating_onnx.py src/image_annotator_lib/core/model_config.py tests/unit/model_class/test_rating_onnx.py tests/runtime_validation/test_real_model_runtime.py
- uv run pytest tests/unit/model_class/test_rating_onnx.py tests/unit/test_capability_utils.py tests/unit/fast/test_list_annotator_info.py
- uv run pytest tests/runtime_validation/test_real_model_runtime.py::test_real_anime_rating_runtime -m downloads_and_runs_model

Closes #81