### PR TITLE
feat: expose WebAPI rating outputs

### DIFF
--- a/src/image_annotator_lib/core/annotation_runner.py
+++ b/src/image_annotator_lib/core/annotation_runner.py
@@ -30,7 +30,7 @@ from .registry import (
     initialize_registry,
 )
 from .types import PHashAnnotationResults, UnifiedAnnotationResult
-from .utils import calculate_phash, logger
+from .utils import calculate_phash, get_model_capabilities, logger
 from .webapi_annotator import WebApiAnnotator
 
 _MODEL_INSTANCE_REGISTRY: dict[str, Any] = {}
@@ -100,6 +100,7 @@ def _create_annotator_instance(model_name: str, api_keys: dict[str, str] | None 
                 litellm_model_id=litellm_model_id,
                 api_keys=api_keys,
                 model_name=actual_model_name,
+                capabilities=get_model_capabilities(actual_model_name),
             )
 
         # registry 登録 ローカル ML モデル: 直接インスタンス化

--- a/src/image_annotator_lib/core/output_normalization.py
+++ b/src/image_annotator_lib/core/output_normalization.py
@@ -19,19 +19,27 @@ ADR 0023 Issue #47: PydanticAI `Agent.output_type` に渡す callable として
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from pydantic import ValidationError
 from pydantic_ai import ModelRetry
 
-from .types import AnnotationSchema, RatingPrediction
+from .types import AnnotationSchema, RatingPrediction, TaskCapability
 
 _WEBAPI_RATING_SOURCE_SCHEME = "prompt_defined"
+_DEFAULT_REQUIRED_CAPABILITIES = frozenset(
+    {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
+)
 
 
-def _normalize_string_items(value: Any, *, field_name: str, split_commas: bool) -> list[str]:
+def _normalize_string_items(
+    value: Any, *, field_name: str, split_commas: bool, required: bool
+) -> list[str]:
     """Normalize tag/caption values allowed by ADR 0023."""
     if value is None:
+        if required:
+            raise ModelRetry(f"`{field_name}` is required")
         return []
     if isinstance(value, str):
         raw_items = value.split(",") if split_commas and "," in value else [value]
@@ -50,9 +58,11 @@ def _normalize_string_items(value: Any, *, field_name: str, split_commas: bool) 
     return normalized
 
 
-def _normalize_score(value: Any) -> float | None:
+def _normalize_score(value: Any, *, required: bool) -> float | None:
     """Normalize numeric score values allowed by ADR 0023."""
     if value is None:
+        if required:
+            raise ModelRetry("`score` is required")
         return None
     if isinstance(value, bool):
         raise ModelRetry("`score` must be a number")
@@ -111,7 +121,9 @@ def _normalize_rating_item(value: Any, *, confidence: Any = None) -> RatingPredi
     )
 
 
-def _normalize_ratings(rating: Any, ratings: Any, rating_confidence: Any) -> list[RatingPrediction]:
+def _normalize_ratings(
+    rating: Any, ratings: Any, rating_confidence: Any, *, required: bool
+) -> list[RatingPrediction]:
     """Normalize single or list-shaped rating outputs."""
     normalized: list[RatingPrediction] = []
 
@@ -120,6 +132,8 @@ def _normalize_ratings(rating: Any, ratings: Any, rating_confidence: Any) -> lis
         normalized.append(single)
 
     if ratings is None:
+        if required and not normalized:
+            raise ModelRetry("`rating` or `ratings` is required")
         return normalized
     if not isinstance(ratings, list):
         raise ModelRetry("`ratings` must be a list")
@@ -128,6 +142,8 @@ def _normalize_ratings(rating: Any, ratings: Any, rating_confidence: Any) -> lis
         prediction = _normalize_rating_item(item)
         if prediction is not None:
             normalized.append(prediction)
+    if required and not normalized:
+        raise ModelRetry("`rating` or `ratings` is required")
     return normalized
 
 
@@ -168,10 +184,49 @@ def normalize_annotation_output(
     Returns:
         Validated `AnnotationSchema` with the normalized fields.
     """
-    normalized_tags = _normalize_string_items(tags, field_name="tags", split_commas=True)
-    normalized_captions = _normalize_string_items(captions, field_name="captions", split_commas=False)
-    normalized_score = _normalize_score(score)
-    normalized_ratings = _normalize_ratings(rating, ratings, rating_confidence)
+    return _normalize_annotation_output_for_capabilities(
+        tags=tags,
+        captions=captions,
+        score=score,
+        rating=rating,
+        rating_confidence=rating_confidence,
+        ratings=ratings,
+        required_capabilities=_DEFAULT_REQUIRED_CAPABILITIES,
+    )
+
+
+def _normalize_annotation_output_for_capabilities(
+    *,
+    tags: Any = None,
+    captions: Any = None,
+    score: Any = None,
+    rating: Any = None,
+    rating_confidence: Any = None,
+    ratings: Any = None,
+    required_capabilities: frozenset[TaskCapability],
+) -> AnnotationSchema:
+    normalized_tags = _normalize_string_items(
+        tags,
+        field_name="tags",
+        split_commas=True,
+        required=TaskCapability.TAGS in required_capabilities,
+    )
+    normalized_captions = _normalize_string_items(
+        captions,
+        field_name="captions",
+        split_commas=False,
+        required=TaskCapability.CAPTIONS in required_capabilities,
+    )
+    normalized_score = _normalize_score(
+        score,
+        required=TaskCapability.SCORES in required_capabilities,
+    )
+    normalized_ratings = _normalize_ratings(
+        rating,
+        ratings,
+        rating_confidence,
+        required=TaskCapability.RATINGS in required_capabilities,
+    )
 
     try:
         return AnnotationSchema(
@@ -184,4 +239,36 @@ def normalize_annotation_output(
         raise ModelRetry("annotation output does not match AnnotationSchema") from exc
 
 
-__all__ = ["normalize_annotation_output"]
+def build_annotation_output_normalizer(
+    capabilities: set[TaskCapability] | frozenset[TaskCapability] | None,
+) -> Callable[..., AnnotationSchema]:
+    """Build a WebAPI output normalizer that requires only requested capabilities."""
+    required_capabilities = (
+        frozenset(capabilities) if capabilities is not None else _DEFAULT_REQUIRED_CAPABILITIES
+    )
+
+    def normalize_output(
+        tags: Any = None,
+        captions: Any = None,
+        score: Any = None,
+        rating: Any = None,
+        rating_confidence: Any = None,
+        ratings: Any = None,
+    ) -> AnnotationSchema:
+        """Provide image annotation results."""
+        return _normalize_annotation_output_for_capabilities(
+            tags=tags,
+            captions=captions,
+            score=score,
+            rating=rating,
+            rating_confidence=rating_confidence,
+            ratings=ratings,
+            required_capabilities=required_capabilities,
+        )
+
+    normalize_output.__name__ = "normalize_annotation_output"
+    normalize_output.__doc__ = normalize_annotation_output.__doc__
+    return normalize_output
+
+
+__all__ = ["build_annotation_output_normalizer", "normalize_annotation_output"]

--- a/src/image_annotator_lib/core/output_normalization.py
+++ b/src/image_annotator_lib/core/output_normalization.py
@@ -9,9 +9,10 @@ ADR 0023 Issue #47: PydanticAI `Agent.output_type` に渡す callable として
 - `tags` の文字列 (カンマ区切りまたは単一) → `list[str]`
 - `captions` の文字列 (単一) → `list[str]`
 - `score` の数値文字列 → `float`
+- `rating` / `ratings` の文字列または dict → `RatingPrediction`
 - 各要素の trim、空文字除去
 
-補正不能 (None / dict / list 内非文字列 / 解釈不能 score 等) は `ModelRetry`
+補正不能 (非対応型 / list 内非文字列 / 解釈不能 score 等) は `ModelRetry`
 を raise し、PydanticAI `output_retries=1` に従って LLM 再生成へ流す。
 壊れた JSON 修復 / free text からの regex 復元 / provider 別 parser は実装しない。
 """
@@ -23,11 +24,15 @@ from typing import Any
 from pydantic import ValidationError
 from pydantic_ai import ModelRetry
 
-from .types import AnnotationSchema
+from .types import AnnotationSchema, RatingPrediction
+
+_WEBAPI_RATING_SOURCE_SCHEME = "prompt_defined"
 
 
 def _normalize_string_items(value: Any, *, field_name: str, split_commas: bool) -> list[str]:
     """Normalize tag/caption values allowed by ADR 0023."""
+    if value is None:
+        return []
     if isinstance(value, str):
         raw_items = value.split(",") if split_commas and "," in value else [value]
     elif isinstance(value, list):
@@ -45,8 +50,10 @@ def _normalize_string_items(value: Any, *, field_name: str, split_commas: bool) 
     return normalized
 
 
-def _normalize_score(value: Any) -> float:
+def _normalize_score(value: Any) -> float | None:
     """Normalize numeric score values allowed by ADR 0023."""
+    if value is None:
+        return None
     if isinstance(value, bool):
         raise ModelRetry("`score` must be a number")
     if isinstance(value, (int, float)):
@@ -59,7 +66,79 @@ def _normalize_score(value: Any) -> float:
     raise ModelRetry("`score` must be a number or numeric string")
 
 
-def normalize_annotation_output(tags: Any, captions: Any, score: Any) -> AnnotationSchema:
+def _normalize_confidence(value: Any, *, field_name: str) -> float | None:
+    """Normalize optional rating confidence values."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ModelRetry(f"`{field_name}` must be a number")
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError as exc:
+            raise ModelRetry(f"`{field_name}` must be a numeric string") from exc
+    raise ModelRetry(f"`{field_name}` must be a number or numeric string")
+
+
+def _normalize_rating_item(value: Any, *, confidence: Any = None) -> RatingPrediction | None:
+    """Normalize one model-native WebAPI rating prediction."""
+    raw_label: Any
+    raw_confidence = confidence
+
+    if value is None:
+        return None
+    if isinstance(value, str):
+        raw_label = value
+    elif isinstance(value, dict):
+        raw_label = value.get("raw_label", value.get("label", value.get("rating")))
+        raw_confidence = value.get("confidence_score", value.get("confidence", raw_confidence))
+    else:
+        raise ModelRetry("`rating` must be a string or object")
+
+    if not isinstance(raw_label, str):
+        raise ModelRetry("`rating` label must be a string")
+
+    label = raw_label.strip()
+    if not label:
+        return None
+
+    return RatingPrediction(
+        raw_label=label,
+        confidence_score=_normalize_confidence(raw_confidence, field_name="rating_confidence"),
+        source_scheme=_WEBAPI_RATING_SOURCE_SCHEME,
+    )
+
+
+def _normalize_ratings(rating: Any, ratings: Any, rating_confidence: Any) -> list[RatingPrediction]:
+    """Normalize single or list-shaped rating outputs."""
+    normalized: list[RatingPrediction] = []
+
+    single = _normalize_rating_item(rating, confidence=rating_confidence)
+    if single is not None:
+        normalized.append(single)
+
+    if ratings is None:
+        return normalized
+    if not isinstance(ratings, list):
+        raise ModelRetry("`ratings` must be a list")
+
+    for item in ratings:
+        prediction = _normalize_rating_item(item)
+        if prediction is not None:
+            normalized.append(prediction)
+    return normalized
+
+
+def normalize_annotation_output(
+    tags: Any = None,
+    captions: Any = None,
+    score: Any = None,
+    rating: Any = None,
+    rating_confidence: Any = None,
+    ratings: Any = None,
+) -> AnnotationSchema:
     """Provide image annotation results.
 
     Call this tool to return your image analysis as structured data.
@@ -78,6 +157,13 @@ def normalize_annotation_output(tags: Any, captions: Any, score: Any) -> Annotat
         score: Quality score. Preferred shape is a number (`AnnotationSchema`
             stores it as ``float``; the typical range used by `BASE_PROMPT` is
             1.00 - 10.00). A numeric string such as ``"7.25"`` is also accepted.
+        rating: Optional model-native content rating label when a rating task is
+            requested. This value is kept separate from tags and score labels.
+        rating_confidence: Optional confidence for `rating`. Omit it when the
+            model/provider does not provide confidence.
+        ratings: Optional list of rating objects. Each object may contain
+            ``raw_label`` or ``label`` and optional ``confidence_score`` or
+            ``confidence``.
 
     Returns:
         Validated `AnnotationSchema` with the normalized fields.
@@ -85,9 +171,15 @@ def normalize_annotation_output(tags: Any, captions: Any, score: Any) -> Annotat
     normalized_tags = _normalize_string_items(tags, field_name="tags", split_commas=True)
     normalized_captions = _normalize_string_items(captions, field_name="captions", split_commas=False)
     normalized_score = _normalize_score(score)
+    normalized_ratings = _normalize_ratings(rating, ratings, rating_confidence)
 
     try:
-        return AnnotationSchema(tags=normalized_tags, captions=normalized_captions, score=normalized_score)
+        return AnnotationSchema(
+            tags=normalized_tags,
+            captions=normalized_captions,
+            score=normalized_score,
+            ratings=normalized_ratings,
+        )
     except ValidationError as exc:
         raise ModelRetry("annotation output does not match AnnotationSchema") from exc
 

--- a/src/image_annotator_lib/core/output_normalization.py
+++ b/src/image_annotator_lib/core/output_normalization.py
@@ -19,6 +19,7 @@ ADR 0023 Issue #47: PydanticAI `Agent.output_type` に渡す callable として
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable
 from typing import Any
 
@@ -31,6 +32,19 @@ _WEBAPI_RATING_SOURCE_SCHEME = "prompt_defined"
 _DEFAULT_REQUIRED_CAPABILITIES = frozenset(
     {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
 )
+
+# core capability -> normalizer 引数名。rating 系引数 (rating / rating_confidence /
+# ratings) は best-effort 出力のため capability に関わらず常に optional 扱い。
+_CAPABILITY_TO_PARAM: dict[TaskCapability, str] = {
+    TaskCapability.TAGS: "tags",
+    TaskCapability.CAPTIONS: "captions",
+    TaskCapability.SCORES: "score",
+}
+# normalizer (PydanticAI output tool) の引数順。
+_NORMALIZER_PARAM_ORDER = ("tags", "captions", "score", "rating", "rating_confidence", "ratings")
+# `__signature__` 属性名。literal を直接 setattr すると flake8-bugbear B010 に
+# 抵触するため定数経由で渡す。
+_SIGNATURE_ATTR = "__signature__"
 
 
 def _normalize_string_items(value: Any, *, field_name: str, split_commas: bool) -> list[str]:
@@ -95,6 +109,22 @@ def _normalize_confidence(value: Any, *, field_name: str) -> float | None:
     raise ModelRetry(f"`{field_name}` must be a number or numeric string")
 
 
+def _first_non_none(mapping: dict[str, Any], *keys: str, default: Any = None) -> Any:
+    """`mapping` から最初に non-None 値を持つ key の値を返す。
+
+    `dict.get(key, fallback)` は key が存在し値が `None` の場合、その `None` を
+    「権威ある値」として返してしまい fallback key を拾えない。
+    ``{"raw_label": null, "label": "PG-13"}`` のような alias 混在 payload で
+    後続 alias を正しく拾うため、明示的に non-None を探索する
+    (PR #85 Codex review P2)。
+    """
+    for key in keys:
+        value = mapping.get(key)
+        if value is not None:
+            return value
+    return default
+
+
 def _normalize_rating_item(value: Any, *, confidence: Any = None) -> RatingPrediction | None:
     """Normalize one model-native WebAPI rating prediction."""
     raw_label: Any
@@ -105,8 +135,8 @@ def _normalize_rating_item(value: Any, *, confidence: Any = None) -> RatingPredi
     if isinstance(value, str):
         raw_label = value
     elif isinstance(value, dict):
-        raw_label = value.get("raw_label", value.get("label", value.get("rating")))
-        raw_confidence = value.get("confidence_score", value.get("confidence", raw_confidence))
+        raw_label = _first_non_none(value, "raw_label", "label", "rating")
+        raw_confidence = _first_non_none(value, "confidence_score", "confidence", default=raw_confidence)
     else:
         raise ModelRetry("`rating` must be a string or object")
 
@@ -127,9 +157,13 @@ def _normalize_rating_item(value: Any, *, confidence: Any = None) -> RatingPredi
 def _normalize_ratings(rating: Any, ratings: Any, rating_confidence: Any) -> list[RatingPrediction]:
     """Normalize single or list-shaped rating outputs.
 
-    呼び出し元が capability gate 済み (= RATINGS は要求されている) 前提。
-    rating が 1 件も得られなければ `ModelRetry` を上げる。RATINGS が要求されて
-    いない場合は呼び出し元が本関数を呼ばずに skip する。
+    WebAPI の rating は prompt 由来の best-effort 出力。RATINGS capability が
+    あっても rating が 1 件も得られなければ空リストを返す (`ModelRetry` は
+    上げない)。rating の欠落で tags / captions / score を含む正常な annotation
+    全体を retry / 失敗へ巻き込まないため (PR #85 Codex review P1)。
+
+    値の *形式* 不正 (非 list の ``ratings`` / 非 str・非 dict の要素) は
+    schema error として `ModelRetry` を上げ、1 回の再生成に委ねる。
     """
     normalized: list[RatingPrediction] = []
 
@@ -145,9 +179,40 @@ def _normalize_ratings(rating: Any, ratings: Any, rating_confidence: Any) -> lis
             if prediction is not None:
                 normalized.append(prediction)
 
-    if not normalized:
-        raise ModelRetry("`rating` or `ratings` is required")
     return normalized
+
+
+def _build_normalizer_signature(required_capabilities: frozenset[TaskCapability]) -> inspect.Signature:
+    """capability に応じた output tool schema 用の signature を構築する。
+
+    要求された core capability (tags / captions / score) の引数は **default を
+    持たない** = PydanticAI が生成する output tool schema 上で required field に
+    なる。rating 系引数は best-effort 出力のため常に optional。
+    全引数を keyword-only にすることで「required の後に optional」順序制約を
+    回避し、任意の capability 部分集合を表現できる (PR #85 Codex review P2)。
+    """
+    required_params = {param for cap, param in _CAPABILITY_TO_PARAM.items() if cap in required_capabilities}
+    parameters = [
+        inspect.Parameter(
+            name,
+            inspect.Parameter.KEYWORD_ONLY,
+            annotation=Any,
+            **({} if name in required_params else {"default": None}),
+        )
+        for name in _NORMALIZER_PARAM_ORDER
+    ]
+    return inspect.Signature(parameters, return_annotation=AnnotationSchema)
+
+
+def _apply_normalizer_signature(
+    func: Callable[..., AnnotationSchema], required_capabilities: frozenset[TaskCapability]
+) -> None:
+    """`func.__signature__` を capability ベースの signature で上書きする。
+
+    `__signature__` は関数の宣言済み属性ではないため、属性名を定数経由の
+    `setattr` で動的設定する (literal 属性名だと flake8-bugbear B010 に抵触)。
+    """
+    setattr(func, _SIGNATURE_ATTR, _build_normalizer_signature(required_capabilities))
 
 
 def normalize_annotation_output(
@@ -198,6 +263,12 @@ def normalize_annotation_output(
     )
 
 
+# PydanticAI が output tool schema を生成する際の signature を上書きする。
+# 関数本体は全引数に default を持つ permissive な実体だが、schema 上は core
+# field を required として申告する (PR #85 Codex review P2)。
+_apply_normalizer_signature(normalize_annotation_output, _DEFAULT_REQUIRED_CAPABILITIES)
+
+
 def _normalize_annotation_output_for_capabilities(
     *,
     tags: Any = None,
@@ -214,6 +285,9 @@ def _normalize_annotation_output_for_capabilities(
     モデルが付随的に出力した値が不正形でも `ModelRetry` を誘発せず、空 / None に
     落として無視する (PR #85 Codex review: 非要求 field の shape error で正常な
     要求 field 出力を巻き込まないため)。
+
+    rating は RATINGS capability があっても best-effort 扱い: 欠落しても
+    `ModelRetry` を上げず空リストにする (`_normalize_ratings` 参照)。
     """
     normalized_tags = (
         _normalize_string_items(tags, field_name="tags", split_commas=True)
@@ -272,6 +346,7 @@ def build_annotation_output_normalizer(
 
     normalize_output.__name__ = "normalize_annotation_output"
     normalize_output.__doc__ = normalize_annotation_output.__doc__
+    _apply_normalizer_signature(normalize_output, required_capabilities)
     return normalize_output
 
 

--- a/src/image_annotator_lib/core/output_normalization.py
+++ b/src/image_annotator_lib/core/output_normalization.py
@@ -33,14 +33,15 @@ _DEFAULT_REQUIRED_CAPABILITIES = frozenset(
 )
 
 
-def _normalize_string_items(
-    value: Any, *, field_name: str, split_commas: bool, required: bool
-) -> list[str]:
-    """Normalize tag/caption values allowed by ADR 0023."""
+def _normalize_string_items(value: Any, *, field_name: str, split_commas: bool) -> list[str]:
+    """Normalize tag/caption values allowed by ADR 0023.
+
+    呼び出し元が capability gate 済み (= この field は要求されている) 前提。
+    欠損 (`None`) も不正形も `ModelRetry` を上げる。要求されていない field は
+    呼び出し元が本関数を呼ばずに skip するため、不正形でも retry を誘発しない。
+    """
     if value is None:
-        if required:
-            raise ModelRetry(f"`{field_name}` is required")
-        return []
+        raise ModelRetry(f"`{field_name}` is required")
     if isinstance(value, str):
         raw_items = value.split(",") if split_commas and "," in value else [value]
     elif isinstance(value, list):
@@ -58,12 +59,14 @@ def _normalize_string_items(
     return normalized
 
 
-def _normalize_score(value: Any, *, required: bool) -> float | None:
-    """Normalize numeric score values allowed by ADR 0023."""
+def _normalize_score(value: Any) -> float:
+    """Normalize numeric score values allowed by ADR 0023.
+
+    呼び出し元が capability gate 済み (= score は要求されている) 前提。
+    欠損 (`None`) も不正形も `ModelRetry` を上げる。
+    """
     if value is None:
-        if required:
-            raise ModelRetry("`score` is required")
-        return None
+        raise ModelRetry("`score` is required")
     if isinstance(value, bool):
         raise ModelRetry("`score` must be a number")
     if isinstance(value, (int, float)):
@@ -121,28 +124,28 @@ def _normalize_rating_item(value: Any, *, confidence: Any = None) -> RatingPredi
     )
 
 
-def _normalize_ratings(
-    rating: Any, ratings: Any, rating_confidence: Any, *, required: bool
-) -> list[RatingPrediction]:
-    """Normalize single or list-shaped rating outputs."""
+def _normalize_ratings(rating: Any, ratings: Any, rating_confidence: Any) -> list[RatingPrediction]:
+    """Normalize single or list-shaped rating outputs.
+
+    呼び出し元が capability gate 済み (= RATINGS は要求されている) 前提。
+    rating が 1 件も得られなければ `ModelRetry` を上げる。RATINGS が要求されて
+    いない場合は呼び出し元が本関数を呼ばずに skip する。
+    """
     normalized: list[RatingPrediction] = []
 
     single = _normalize_rating_item(rating, confidence=rating_confidence)
     if single is not None:
         normalized.append(single)
 
-    if ratings is None:
-        if required and not normalized:
-            raise ModelRetry("`rating` or `ratings` is required")
-        return normalized
-    if not isinstance(ratings, list):
-        raise ModelRetry("`ratings` must be a list")
+    if ratings is not None:
+        if not isinstance(ratings, list):
+            raise ModelRetry("`ratings` must be a list")
+        for item in ratings:
+            prediction = _normalize_rating_item(item)
+            if prediction is not None:
+                normalized.append(prediction)
 
-    for item in ratings:
-        prediction = _normalize_rating_item(item)
-        if prediction is not None:
-            normalized.append(prediction)
-    if required and not normalized:
+    if not normalized:
         raise ModelRetry("`rating` or `ratings` is required")
     return normalized
 
@@ -205,27 +208,28 @@ def _normalize_annotation_output_for_capabilities(
     ratings: Any = None,
     required_capabilities: frozenset[TaskCapability],
 ) -> AnnotationSchema:
-    normalized_tags = _normalize_string_items(
-        tags,
-        field_name="tags",
-        split_commas=True,
-        required=TaskCapability.TAGS in required_capabilities,
+    """Normalize WebAPI output, validating only the requested capabilities.
+
+    要求された capability の field のみ正規化・検証する。要求されていない field は
+    モデルが付随的に出力した値が不正形でも `ModelRetry` を誘発せず、空 / None に
+    落として無視する (PR #85 Codex review: 非要求 field の shape error で正常な
+    要求 field 出力を巻き込まないため)。
+    """
+    normalized_tags = (
+        _normalize_string_items(tags, field_name="tags", split_commas=True)
+        if TaskCapability.TAGS in required_capabilities
+        else []
     )
-    normalized_captions = _normalize_string_items(
-        captions,
-        field_name="captions",
-        split_commas=False,
-        required=TaskCapability.CAPTIONS in required_capabilities,
+    normalized_captions = (
+        _normalize_string_items(captions, field_name="captions", split_commas=False)
+        if TaskCapability.CAPTIONS in required_capabilities
+        else []
     )
-    normalized_score = _normalize_score(
-        score,
-        required=TaskCapability.SCORES in required_capabilities,
-    )
-    normalized_ratings = _normalize_ratings(
-        rating,
-        ratings,
-        rating_confidence,
-        required=TaskCapability.RATINGS in required_capabilities,
+    normalized_score = _normalize_score(score) if TaskCapability.SCORES in required_capabilities else None
+    normalized_ratings = (
+        _normalize_ratings(rating, ratings, rating_confidence)
+        if TaskCapability.RATINGS in required_capabilities
+        else []
     )
 
     try:

--- a/src/image_annotator_lib/core/provider_manager.py
+++ b/src/image_annotator_lib/core/provider_manager.py
@@ -27,7 +27,7 @@ from ..model_class.annotator_webapi.webapi_shared import BASE_PROMPT
 from .http_retry import build_retry_http_client
 from .image_preprocess import preprocess_images_to_binary
 from .model_id import build_pydantic_model, resolve_model_ref
-from .output_normalization import normalize_annotation_output
+from .output_normalization import build_annotation_output_normalizer
 from .result_adapter import to_annotation_result
 from .types import AnnotationResult, TaskCapability
 from .utils import calculate_phash, logger
@@ -152,7 +152,7 @@ class ProviderManager:
                 model = build_pydantic_model(ref, api_key, config, http_client=http_client)
                 agent = Agent(
                     model=model,
-                    output_type=normalize_annotation_output,
+                    output_type=build_annotation_output_normalizer(capabilities),
                     system_prompt=_build_system_prompt(capabilities),
                     output_retries=_OUTPUT_RETRIES,
                 )

--- a/src/image_annotator_lib/core/provider_manager.py
+++ b/src/image_annotator_lib/core/provider_manager.py
@@ -29,7 +29,7 @@ from .image_preprocess import preprocess_images_to_binary
 from .model_id import build_pydantic_model, resolve_model_ref
 from .output_normalization import normalize_annotation_output
 from .result_adapter import to_annotation_result
-from .types import AnnotationResult
+from .types import AnnotationResult, TaskCapability
 from .utils import calculate_phash, logger
 
 # ADR 0023 retry policy:
@@ -45,6 +45,20 @@ _USER_PROMPT_TEXT = "Analyze this image and provide annotations as specified."
 
 # LoRAIro #274: cause/context chain を辿る最大段数 (循環・過剰深さの安全弁)。
 _EXCEPTION_CHAIN_MAX_DEPTH = 5
+
+
+def _build_system_prompt(capabilities: set[TaskCapability] | frozenset[TaskCapability] | None) -> str:
+    """Build the WebAPI system prompt for the requested task capabilities."""
+    if capabilities is None or TaskCapability.RATINGS not in capabilities:
+        return BASE_PROMPT
+
+    return (
+        BASE_PROMPT
+        + "\n\n"
+        + "Rating task: return any requested content rating as a model-native label in the "
+        + "`rating` or `ratings` output field. Do not include rating labels in `tags` or "
+        + "`score_labels`, and do not map them to LoRAIro canonical ratings."
+    )
 
 
 def _format_exception_chain(exc: BaseException, *, max_depth: int = _EXCEPTION_CHAIN_MAX_DEPTH) -> str:
@@ -103,6 +117,7 @@ class ProviderManager:
         litellm_model_id: str,
         api_keys: dict[str, str] | None = None,
         config: dict[str, Any] | None = None,
+        capabilities: set[TaskCapability] | frozenset[TaskCapability] | None = None,
         _test_agent: Agent | None = None,
     ) -> dict[str, AnnotationResult]:
         """非同期推論の中核実装。
@@ -113,6 +128,7 @@ class ProviderManager:
             litellm_model_id: LiteLLM 形式 ID (`openai/gpt-4o` 等)。
             api_keys: provider 名 (`openai` / `anthropic` / `google` / `openrouter`) 単位の API key dict。
             config: provider 固有の追加設定 (OpenRouter `referer` / `app_name` 等)。
+            capabilities: 呼び出し元 WebAPI annotator が明示したタスク能力。
             _test_agent: pytest fixture からの Agent 注入専用 (本番では None)。
 
         Returns:
@@ -137,7 +153,7 @@ class ProviderManager:
                 agent = Agent(
                     model=model,
                     output_type=normalize_annotation_output,
-                    system_prompt=BASE_PROMPT,
+                    system_prompt=_build_system_prompt(capabilities),
                     output_retries=_OUTPUT_RETRIES,
                 )
             except BaseException:
@@ -226,6 +242,7 @@ class ProviderManager:
         litellm_model_id: str,
         api_keys: dict[str, str] | None = None,
         config: dict[str, Any] | None = None,
+        capabilities: set[TaskCapability] | frozenset[TaskCapability] | None = None,
         _test_agent: Agent | None = None,
     ) -> dict[str, AnnotationResult]:
         """`run_inference_with_model_async()` の sync wrapper。
@@ -249,6 +266,7 @@ class ProviderManager:
                 litellm_model_id=litellm_model_id,
                 api_keys=api_keys,
                 config=config,
+                capabilities=capabilities,
                 _test_agent=_test_agent,
             )
         )

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -763,6 +763,11 @@ def _register_webapi_models_from_discovery() -> None:
                         model_info.get("estimated_size_gb"), model_id, "estimated_size_gb"
                     ),
                     "discontinued_at": None,
+                    # Issue #82: discovery 由来の WebAPI モデルは Vision LLM であり、
+                    # prompt 指示で tags/captions/scores に加え rating も出力できる。
+                    # `capabilities` を明示しないと `get_model_capabilities` の fallback で
+                    # RATINGS が欠落し、rating prompt / 正規化経路が production で到達不能になる。
+                    "capabilities": ["tags", "captions", "scores", "ratings"],
                     "type": "webapi",
                     "class": "WebApiAnnotator",
                 }

--- a/src/image_annotator_lib/core/result_adapter.py
+++ b/src/image_annotator_lib/core/result_adapter.py
@@ -49,6 +49,7 @@ def to_annotation_result(
         "tags": normalized_tags,
         "captions": normalized_captions,
         "score": schema_output.score,
+        "ratings": [rating.model_dump() for rating in schema_output.ratings],
     }
 
     return AnnotationResult(

--- a/src/image_annotator_lib/core/types.py
+++ b/src/image_annotator_lib/core/types.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 import datetime
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
@@ -101,12 +102,24 @@ LoaderComponents = (
 )
 
 
+class RatingPrediction(BaseModel):
+    """Model-native rating prediction.
+
+    LoRAIro などの consumer 固有 rating へは変換せず、モデルの label scheme を保持する。
+    """
+
+    raw_label: str
+    confidence_score: float | None = None
+    source_scheme: str
+
+
 class AnnotationSchema(BaseModel):
     """画像アノテーションAPI共通のレスポンススキーマ"""
 
-    tags: list[str]
-    captions: list[str]
-    score: float
+    tags: list[str] = Field(default_factory=list)
+    captions: list[str] = Field(default_factory=list)
+    score: float | None = None
+    ratings: list[RatingPrediction] = Field(default_factory=list)
 
 
 # --- 新バリデーションスキーマ (Pydantic V2) ---
@@ -188,17 +201,12 @@ class CaptionerAnnotationResult(BaseAnnotationResult):
 
 
 # Union型で型安全性確保
-AnnotationResultV2 = Union[
-    WebApiAnnotationResult,
-    TaggerAnnotationResult,
-    ScorerAnnotationResult,
-    CaptionerAnnotationResult,
-]
+AnnotationResultV2 = (
+    WebApiAnnotationResult | TaggerAnnotationResult | ScorerAnnotationResult | CaptionerAnnotationResult
+)
 
 
 # --- capability-based統一バリデーションスキーマ (Plan対応) ---
-
-from enum import Enum
 
 
 class TaskCapability(str, Enum):
@@ -209,17 +217,6 @@ class TaskCapability(str, Enum):
     SCORES = "scores"
     SCORE_LABELS = "score_labels"
     RATINGS = "ratings"
-
-
-class RatingPrediction(BaseModel):
-    """Model-native rating prediction.
-
-    LoRAIro などの consumer 固有 rating へは変換せず、モデルの label scheme を保持する。
-    """
-
-    raw_label: str
-    confidence_score: float | None = None
-    source_scheme: str
 
 
 class UnifiedAnnotationResult(BaseModel):

--- a/src/image_annotator_lib/core/utils.py
+++ b/src/image_annotator_lib/core/utils.py
@@ -320,8 +320,19 @@ def get_model_capabilities(model_name: str) -> set[Any]:
     from .registry import get_webapi_metadata
     from .types import TaskCapability
 
-    # 1. WebAPI モデルは Vision LLM として tags/captions/scores 全対応
-    if get_webapi_metadata(model_name) is not None:
+    # 1. WebAPI モデルは metadata に明示 capabilities があればそれを尊重し、
+    #    未指定なら Vision LLM として tags/captions/scores 全対応にフォールバックする。
+    webapi_metadata = get_webapi_metadata(model_name)
+    if webapi_metadata is not None:
+        capabilities_config = webapi_metadata.get("capabilities")
+        if capabilities_config:
+            capabilities = set()
+            for cap in capabilities_config:
+                try:
+                    capabilities.add(TaskCapability(cap))
+                except ValueError:
+                    logger.error(f"無効なcapability '{cap}' (model: {model_name})")
+            return capabilities
         return {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
 
     # 2. 設定ファイルからcapabilitiesを取得

--- a/src/image_annotator_lib/core/webapi_annotator.py
+++ b/src/image_annotator_lib/core/webapi_annotator.py
@@ -17,7 +17,7 @@ from PIL import Image
 
 from .base.annotator import BaseAnnotator
 from .provider_manager import ProviderManager
-from .types import AnnotationResult, TaskCapability, UnifiedAnnotationResult
+from .types import AnnotationResult, RatingPrediction, TaskCapability, UnifiedAnnotationResult
 from .utils import calculate_phash, logger
 
 
@@ -31,13 +31,14 @@ class WebApiAnnotator(BaseAnnotator):
     ADVERTISED_CAPABILITIES: frozenset[TaskCapability] = frozenset(
         {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
     )
-    """Phase 1 では `AnnotationSchema` (tags / captions / score) の 3 種を全申告する。"""
+    """Default WebAPI capabilities when no task-specific override is provided."""
 
     def __init__(
         self,
         litellm_model_id: str,
         api_keys: dict[str, str] | None = None,
         model_name: str | None = None,
+        capabilities: set[TaskCapability] | frozenset[TaskCapability] | list[str] | None = None,
     ) -> None:
         """`WebApiAnnotator` を初期化する。
 
@@ -47,6 +48,8 @@ class WebApiAnnotator(BaseAnnotator):
                 をキーとする API key dict。
             model_name: registry 登録済モデル名 (registry 経由の通常呼び出しで渡される)。
                 省略時は `litellm_model_id` をモデル名として扱う (テスト stub 等の特殊用途)。
+            capabilities: 明示タスク能力。`TaskCapability.RATINGS` が含まれる場合だけ
+                rating 出力を `UnifiedAnnotationResult.ratings` として公開する。
         """
         # ADR 0023 Phase 1 / Issue #35 / Issue #45:
         # - WebAPI モデルは registry 経由でのみインスタンス化される (Issue #45 で
@@ -60,10 +63,23 @@ class WebApiAnnotator(BaseAnnotator):
         self.model_name = model_name or litellm_model_id
         self.litellm_model_id = litellm_model_id
         self.api_keys = api_keys
+        self.capabilities = self._normalize_capabilities(capabilities)
         self._config = None
         self.model_path = None
         self.device = "api"
         self.components = None
+
+    @classmethod
+    def _normalize_capabilities(
+        cls, capabilities: set[TaskCapability] | frozenset[TaskCapability] | list[str] | None
+    ) -> frozenset[TaskCapability]:
+        if capabilities is None:
+            return cls.ADVERTISED_CAPABILITIES
+
+        normalized: set[TaskCapability] = set()
+        for capability in capabilities:
+            normalized.add(capability if isinstance(capability, TaskCapability) else TaskCapability(capability))
+        return frozenset(normalized) if normalized else cls.ADVERTISED_CAPABILITIES
 
     def __enter__(self) -> Self:
         return self
@@ -92,6 +108,7 @@ class WebApiAnnotator(BaseAnnotator):
             images_list=processed,
             litellm_model_id=self.litellm_model_id,
             api_keys=self.api_keys,
+            capabilities=self.capabilities,
         )
         ordered: list[AnnotationResult] = []
         for index, image in enumerate(processed):
@@ -118,7 +135,7 @@ class WebApiAnnotator(BaseAnnotator):
                 formatted.append(
                     UnifiedAnnotationResult(
                         model_name=self.model_name,
-                        capabilities=set(self.ADVERTISED_CAPABILITIES),
+                        capabilities=set(self.capabilities),
                         error=error,
                         framework="pydantic_ai",
                     )
@@ -129,25 +146,48 @@ class WebApiAnnotator(BaseAnnotator):
             raw_tags = formatted_output.get("tags") if isinstance(formatted_output, dict) else None
             raw_captions = formatted_output.get("captions") if isinstance(formatted_output, dict) else None
             raw_score = formatted_output.get("score") if isinstance(formatted_output, dict) else None
+            raw_ratings = formatted_output.get("ratings") if isinstance(formatted_output, dict) else None
 
             tags_value: list[str] | None = list(raw_tags) if raw_tags else None
             captions_value: list[str] | None = list(raw_captions) if raw_captions else None
             scores_value: dict[str, float] | None = (
                 {"overall": float(raw_score)} if raw_score is not None else None
             )
+            ratings_value = (
+                self._format_ratings(raw_ratings)
+                if TaskCapability.RATINGS in self.capabilities and raw_ratings
+                else None
+            )
 
             formatted.append(
                 UnifiedAnnotationResult(
                     model_name=self.model_name,
-                    capabilities=set(self.ADVERTISED_CAPABILITIES),
-                    tags=tags_value,
-                    captions=captions_value,
-                    scores=scores_value,
+                    capabilities=set(self.capabilities),
+                    tags=tags_value if TaskCapability.TAGS in self.capabilities else None,
+                    captions=captions_value if TaskCapability.CAPTIONS in self.capabilities else None,
+                    scores=scores_value if TaskCapability.SCORES in self.capabilities else None,
+                    ratings=ratings_value,
                     framework="pydantic_ai",
-                    raw_output={"litellm_model_id": self.litellm_model_id},
+                    raw_output={
+                        "litellm_model_id": self.litellm_model_id,
+                        "formatted_output": formatted_output,
+                    },
                 )
             )
         return formatted
+
+    @staticmethod
+    def _format_ratings(raw_ratings: Any) -> list[RatingPrediction] | None:
+        if not isinstance(raw_ratings, list):
+            return None
+
+        ratings: list[RatingPrediction] = []
+        for item in raw_ratings:
+            if isinstance(item, RatingPrediction):
+                ratings.append(item)
+            elif isinstance(item, dict):
+                ratings.append(RatingPrediction.model_validate(item))
+        return ratings or None
 
 
 __all__ = ["WebApiAnnotator"]

--- a/tests/unit/core/test_output_normalization.py
+++ b/tests/unit/core/test_output_normalization.py
@@ -39,6 +39,31 @@ class TestNormalizeAnnotationOutput:
         assert result.tags == ["cat", "dog"]
         assert result.captions == ["caption"]
 
+    def test_normalizes_single_rating_with_optional_confidence(self) -> None:
+        result = normalize_annotation_output(
+            tags=[],
+            captions=[],
+            score=None,
+            rating="  questionable  ",
+            rating_confidence="0.82",
+        )
+
+        assert result.ratings[0].raw_label == "questionable"
+        assert result.ratings[0].confidence_score == 0.82
+        assert result.ratings[0].source_scheme == "prompt_defined"
+
+    def test_normalizes_rating_objects_without_canonical_mapping(self) -> None:
+        result = normalize_annotation_output(
+            ratings=[
+                {"label": "PG-13", "confidence": 0.7},
+                {"raw_label": "mature"},
+            ]
+        )
+
+        assert [rating.raw_label for rating in result.ratings] == ["PG-13", "mature"]
+        assert result.ratings[0].confidence_score == 0.7
+        assert result.ratings[1].confidence_score is None
+
     @pytest.mark.parametrize(
         ("tags", "captions", "score"),
         [

--- a/tests/unit/core/test_output_normalization.py
+++ b/tests/unit/core/test_output_normalization.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import pytest
 from pydantic_ai import ModelRetry
 
-from image_annotator_lib.core.output_normalization import normalize_annotation_output
+from image_annotator_lib.core.output_normalization import (
+    build_annotation_output_normalizer,
+    normalize_annotation_output,
+)
+from image_annotator_lib.core.types import TaskCapability
 
 
 class TestNormalizeAnnotationOutput:
@@ -40,10 +44,9 @@ class TestNormalizeAnnotationOutput:
         assert result.captions == ["caption"]
 
     def test_normalizes_single_rating_with_optional_confidence(self) -> None:
-        result = normalize_annotation_output(
-            tags=[],
-            captions=[],
-            score=None,
+        normalizer = build_annotation_output_normalizer({TaskCapability.RATINGS})
+
+        result = normalizer(
             rating="  questionable  ",
             rating_confidence="0.82",
         )
@@ -53,7 +56,9 @@ class TestNormalizeAnnotationOutput:
         assert result.ratings[0].source_scheme == "prompt_defined"
 
     def test_normalizes_rating_objects_without_canonical_mapping(self) -> None:
-        result = normalize_annotation_output(
+        normalizer = build_annotation_output_normalizer({TaskCapability.RATINGS})
+
+        result = normalizer(
             ratings=[
                 {"label": "PG-13", "confidence": 0.7},
                 {"raw_label": "mature"},
@@ -80,3 +85,30 @@ class TestNormalizeAnnotationOutput:
     ) -> None:
         with pytest.raises(ModelRetry):
             normalize_annotation_output(tags=tags, captions=captions, score=score)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"captions": ["caption"], "score": 0.5},
+            {"tags": ["cat"], "score": 0.5},
+            {"tags": ["cat"], "captions": ["caption"]},
+        ],
+    )
+    def test_default_normalizer_retries_when_core_fields_are_missing(self, kwargs: dict[str, object]) -> None:
+        with pytest.raises(ModelRetry):
+            normalize_annotation_output(**kwargs)
+
+    def test_capability_normalizer_allows_unrequested_fields_to_be_missing(self) -> None:
+        normalizer = build_annotation_output_normalizer({TaskCapability.TAGS})
+
+        result = normalizer(tags="cat")
+
+        assert result.tags == ["cat"]
+        assert result.captions == []
+        assert result.score is None
+
+    def test_capability_normalizer_retries_when_rating_is_requested_but_missing(self) -> None:
+        normalizer = build_annotation_output_normalizer({TaskCapability.RATINGS})
+
+        with pytest.raises(ModelRetry):
+            normalizer()

--- a/tests/unit/core/test_output_normalization.py
+++ b/tests/unit/core/test_output_normalization.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 from pydantic_ai import ModelRetry
 
@@ -109,11 +111,66 @@ class TestNormalizeAnnotationOutput:
         assert result.captions == []
         assert result.score is None
 
-    def test_capability_normalizer_retries_when_rating_is_requested_but_missing(self) -> None:
+    def test_capability_normalizer_allows_rating_to_be_missing(self) -> None:
+        """RATINGS 要求時でも rating 欠落は best-effort 扱い: retry せず空リスト (Codex P1)。
+
+        rating はモデルの prompt 由来 best-effort 出力。欠落で tags/captions/score を
+        含む正常な annotation 全体を retry/失敗へ巻き込まない。
+        """
         normalizer = build_annotation_output_normalizer({TaskCapability.RATINGS})
 
-        with pytest.raises(ModelRetry):
-            normalizer()
+        result = normalizer()
+
+        assert result.ratings == []
+
+    def test_rating_object_falls_back_when_primary_alias_is_null(self) -> None:
+        """raw_label / confidence_score が present かつ null でも alias を拾う (Codex P2)。"""
+        normalizer = build_annotation_output_normalizer({TaskCapability.RATINGS})
+
+        result = normalizer(
+            ratings=[
+                {
+                    "raw_label": None,
+                    "label": "PG-13",
+                    "confidence_score": None,
+                    "confidence": 0.7,
+                }
+            ]
+        )
+
+        assert result.ratings[0].raw_label == "PG-13"
+        assert result.ratings[0].confidence_score == 0.7
+
+    def test_builder_marks_requested_core_fields_required_in_signature(self) -> None:
+        """build_annotation_output_normalizer は要求 core field を schema 上 required にする (Codex P2)。"""
+        normalizer = build_annotation_output_normalizer(
+            {
+                TaskCapability.TAGS,
+                TaskCapability.CAPTIONS,
+                TaskCapability.SCORES,
+                TaskCapability.RATINGS,
+            }
+        )
+
+        params = inspect.signature(normalizer).parameters
+
+        assert params["tags"].default is inspect.Parameter.empty
+        assert params["captions"].default is inspect.Parameter.empty
+        assert params["score"].default is inspect.Parameter.empty
+        # rating 系は best-effort のため常に optional。
+        assert params["rating"].default is None
+        assert params["rating_confidence"].default is None
+        assert params["ratings"].default is None
+
+    def test_builder_keeps_unrequested_core_fields_optional_in_signature(self) -> None:
+        """非要求 core field は schema 上 optional のまま (Codex P2)。"""
+        normalizer = build_annotation_output_normalizer({TaskCapability.TAGS})
+
+        params = inspect.signature(normalizer).parameters
+
+        assert params["tags"].default is inspect.Parameter.empty
+        assert params["captions"].default is None
+        assert params["score"].default is None
 
     def test_capability_normalizer_ignores_malformed_unrequested_core_fields(self) -> None:
         """RATINGS のみ要求時、付随的な不正形 core field は retry を誘発しない (Codex P2)。"""

--- a/tests/unit/core/test_output_normalization.py
+++ b/tests/unit/core/test_output_normalization.py
@@ -94,7 +94,9 @@ class TestNormalizeAnnotationOutput:
             {"tags": ["cat"], "captions": ["caption"]},
         ],
     )
-    def test_default_normalizer_retries_when_core_fields_are_missing(self, kwargs: dict[str, object]) -> None:
+    def test_default_normalizer_retries_when_core_fields_are_missing(
+        self, kwargs: dict[str, object]
+    ) -> None:
         with pytest.raises(ModelRetry):
             normalize_annotation_output(**kwargs)
 
@@ -112,3 +114,27 @@ class TestNormalizeAnnotationOutput:
 
         with pytest.raises(ModelRetry):
             normalizer()
+
+    def test_capability_normalizer_ignores_malformed_unrequested_core_fields(self) -> None:
+        """RATINGS のみ要求時、付随的な不正形 core field は retry を誘発しない (Codex P2)。"""
+        normalizer = build_annotation_output_normalizer({TaskCapability.RATINGS})
+
+        result = normalizer(rating="explicit", tags={"unexpected": 1}, score="not-a-number")
+
+        assert result.ratings[0].raw_label == "explicit"
+        assert result.tags == []
+        assert result.captions == []
+        assert result.score is None
+
+    def test_capability_normalizer_ignores_malformed_unrequested_rating_field(self) -> None:
+        """core capability のみ要求時、付随的な不正形 rating field は retry を誘発しない (Codex P1)。"""
+        normalizer = build_annotation_output_normalizer(
+            {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
+        )
+
+        result = normalizer(tags=["cat"], captions=["a cat"], score=0.8, ratings="explicit")
+
+        assert result.tags == ["cat"]
+        assert result.captions == ["a cat"]
+        assert result.score == 0.8
+        assert result.ratings == []

--- a/tests/unit/core/test_provider_manager_output_normalization.py
+++ b/tests/unit/core/test_provider_manager_output_normalization.py
@@ -38,4 +38,5 @@ def test_provider_manager_returns_normalized_annotation_result() -> None:
         "tags": ["cat", "dog"],
         "captions": ["a cat outside"],
         "score": 0.82,
+        "ratings": [],
     }

--- a/tests/unit/core/test_result_adapter.py
+++ b/tests/unit/core/test_result_adapter.py
@@ -21,6 +21,7 @@ class TestToAnnotationResult:
         assert formatted["tags"] == ["1girl", "blue eyes"]
         assert formatted["captions"] == ["a girl"]
         assert formatted["score"] == 8.5
+        assert formatted["ratings"] == []
 
     def test_error_path(self) -> None:
         result = to_annotation_result(None, phash="abc123", error="auth failure")
@@ -58,3 +59,31 @@ class TestToAnnotationResult:
         formatted = result["formatted_output"]
         assert isinstance(formatted, dict)
         assert formatted["score"] == 7.25
+
+    def test_ratings_passed_through_separately(self) -> None:
+        from image_annotator_lib.core.types import RatingPrediction
+
+        schema = AnnotationSchema(
+            tags=["solo"],
+            captions=[],
+            score=None,
+            ratings=[
+                RatingPrediction(
+                    raw_label="questionable",
+                    confidence_score=None,
+                    source_scheme="prompt_defined",
+                )
+            ],
+        )
+        result = to_annotation_result(schema, phash="abc")
+
+        assert result["tags"] == ["solo"]
+        formatted = result["formatted_output"]
+        assert isinstance(formatted, dict)
+        assert formatted["ratings"] == [
+            {
+                "raw_label": "questionable",
+                "confidence_score": None,
+                "source_scheme": "prompt_defined",
+            }
+        ]

--- a/tests/unit/core/test_webapi_annotator.py
+++ b/tests/unit/core/test_webapi_annotator.py
@@ -17,6 +17,7 @@ class TestWebApiAnnotatorBasics:
         assert TaskCapability.TAGS in caps
         assert TaskCapability.CAPTIONS in caps
         assert TaskCapability.SCORES in caps
+        assert TaskCapability.RATINGS not in caps
 
     def test_advertised_capabilities_is_frozenset(self) -> None:
         # registry.AnnotatorInfo.capabilities が frozenset 型を要求するため
@@ -35,6 +36,14 @@ class TestWebApiAnnotatorBasics:
         assert annotator.model_name == "my-registered-model"
         assert annotator.litellm_model_id == "openai/gpt-4o"
 
+    def test_init_accepts_explicit_rating_capability(self) -> None:
+        annotator = WebApiAnnotator(
+            litellm_model_id="openai/gpt-4o",
+            capabilities=[TaskCapability.RATINGS.value],
+        )
+
+        assert annotator.capabilities == frozenset({TaskCapability.RATINGS})
+
     def test_init_does_not_consult_config_registry(self) -> None:
         # BaseAnnotator.__init__ をスキップして config_registry に依存しないことを確認
         # (依存していると config_registry に entry の無い model_name で KeyError になるはず)
@@ -52,6 +61,78 @@ class TestWebApiAnnotatorBasics:
         with annotator as ctx:
             assert ctx is annotator
         # __exit__ で例外なく抜ける
+
+
+class TestWebApiAnnotatorRatings:
+    """Issue #82: WebAPI rating output is separate from tags and score labels."""
+
+    def test_format_predictions_emits_ratings_only_when_capability_declared(self) -> None:
+        annotator = WebApiAnnotator(
+            litellm_model_id="openai/gpt-4o",
+            capabilities={TaskCapability.TAGS, TaskCapability.RATINGS},
+        )
+
+        result = annotator._format_predictions(
+            [
+                {
+                    "phash": "abc",
+                    "tags": ["solo"],
+                    "formatted_output": {
+                        "tags": ["solo"],
+                        "captions": [],
+                        "score": None,
+                        "ratings": [
+                            {
+                                "raw_label": "questionable",
+                                "confidence_score": None,
+                                "source_scheme": "prompt_defined",
+                            }
+                        ],
+                    },
+                    "error": None,
+                }
+            ]
+        )[0]
+
+        assert result.capabilities == {TaskCapability.TAGS, TaskCapability.RATINGS}
+        assert result.tags == ["solo"]
+        assert result.score_labels is None
+        assert result.ratings is not None
+        assert result.ratings[0].raw_label == "questionable"
+        assert result.ratings[0].confidence_score is None
+        assert result.ratings[0].source_scheme == "prompt_defined"
+        assert result.raw_output is not None
+        assert result.raw_output["formatted_output"]["ratings"][0]["raw_label"] == "questionable"
+
+    def test_format_predictions_ignores_ratings_without_capability(self) -> None:
+        annotator = WebApiAnnotator(litellm_model_id="openai/gpt-4o")
+
+        result = annotator._format_predictions(
+            [
+                {
+                    "phash": "abc",
+                    "tags": ["solo"],
+                    "formatted_output": {
+                        "tags": ["solo"],
+                        "captions": [],
+                        "score": 8.0,
+                        "ratings": [
+                            {
+                                "raw_label": "explicit",
+                                "confidence_score": 0.9,
+                                "source_scheme": "prompt_defined",
+                            }
+                        ],
+                    },
+                    "error": None,
+                }
+            ]
+        )[0]
+
+        assert TaskCapability.RATINGS not in result.capabilities
+        assert result.ratings is None
+        assert result.tags == ["solo"]
+        assert result.score_labels is None
 
 
 class TestWebApiAnnotatorIssue35Regression:

--- a/tests/unit/standard/core/test_webapi_metadata_isolation.py
+++ b/tests/unit/standard/core/test_webapi_metadata_isolation.py
@@ -125,6 +125,31 @@ def test_get_webapi_metadata_returns_full_metadata(isolated_registry):
     assert metadata["supports_function_calling"] is True
     assert metadata["type"] == "webapi"
     assert metadata["class"] == "WebApiAnnotator"
+    # Issue #82: discovery metadata は rating を含む全 capability を明示する。
+    assert metadata["capabilities"] == ["tags", "captions", "scores", "ratings"]
+
+
+@pytest.mark.unit
+def test_discovered_webapi_model_advertises_rating_capability(isolated_registry):
+    """Issue #82: discovery 登録モデルは `get_model_capabilities` で RATINGS を含む。
+
+    discovery metadata が `capabilities` を明示しないと fallback で RATINGS が
+    欠落し、rating prompt / 正規化経路が `annotate()` から到達不能になる
+    (PR #85 Codex review P1)。
+    """
+    from image_annotator_lib.core.types import TaskCapability
+    from image_annotator_lib.core.utils import get_model_capabilities
+
+    with patch(_DISCOVERY_PATCH_TARGET, return_value=_DISCOVERY_RESULT):
+        _register_webapi_models_from_discovery()
+
+    caps = get_model_capabilities("google/gemini-2.5-pro")
+    assert caps == {
+        TaskCapability.TAGS,
+        TaskCapability.CAPTIONS,
+        TaskCapability.SCORES,
+        TaskCapability.RATINGS,
+    }
 
 
 @pytest.mark.unit

--- a/tests/unit/test_capability_utils.py
+++ b/tests/unit/test_capability_utils.py
@@ -105,3 +105,19 @@ class TestGetModelCapabilities:
         capabilities = get_model_capabilities("gpt-4o")
 
         assert capabilities == {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
+
+    @patch("image_annotator_lib.core.registry.get_webapi_metadata")
+    def test_get_model_capabilities_webapi_respects_explicit_ratings(
+        self, mock_get_webapi_metadata
+    ):
+        """Issue #82: WebAPI metadata can explicitly request rating capability."""
+        mock_get_webapi_metadata.return_value = {
+            "api_model_id": "openai/gpt-4o",
+            "provider": "openai",
+            "type": "webapi",
+            "capabilities": ["tags", "ratings"],
+        }
+
+        capabilities = get_model_capabilities("gpt-4o-rating")
+
+        assert capabilities == {TaskCapability.TAGS, TaskCapability.RATINGS}


### PR DESCRIPTION
## Summary
- add WebAPI rating output normalization into `RatingPrediction` records
- pass explicit WebAPI capabilities through runner/provider/annotator paths
- expose ratings only when `TaskCapability.RATINGS` is requested, keeping rating labels out of tags and score labels

Closes #82

## Tests
- uv run pytest tests/unit/core/test_output_normalization.py tests/unit/core/test_result_adapter.py tests/unit/core/test_webapi_annotator.py tests/unit/core/test_provider_manager_output_normalization.py tests/unit/test_capability_utils.py tests/unit/test_capability_validation.py tests/unit/test_unified_validation_schema.py tests/unit/core/test_annotation_runner.py tests/unit/fast/test_annotation_runner.py tests/unit/fast/test_list_annotator_info.py
- uv run ruff check src/image_annotator_lib/core/annotation_runner.py src/image_annotator_lib/core/output_normalization.py src/image_annotator_lib/core/provider_manager.py src/image_annotator_lib/core/result_adapter.py src/image_annotator_lib/core/types.py src/image_annotator_lib/core/utils.py src/image_annotator_lib/core/webapi_annotator.py tests/unit/core/test_output_normalization.py tests/unit/core/test_provider_manager_output_normalization.py tests/unit/core/test_result_adapter.py tests/unit/core/test_webapi_annotator.py tests/unit/test_capability_utils.py
- git diff --check

## Notes
- Real provider API validation was not run; this PR is covered by unit/fast tests for schema, adapter, and capability handling.
