### PR TITLE
fix: lazy load TensorFlow annotator dependency

### DIFF
--- a/src/image_annotator_lib/core/base/tensorflow.py
+++ b/src/image_annotator_lib/core/base/tensorflow.py
@@ -1,12 +1,16 @@
 """TensorFlow モデルを使用するモデル用の基底クラス。"""
 
+from __future__ import annotations
+
 from abc import abstractmethod
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
-import tensorflow as tf
 from PIL import Image
+
+if TYPE_CHECKING:
+    import tensorflow as tf
 
 # --- ローカルインポート ---
 from ...exceptions.errors import ModelLoadError, OutOfMemoryError
@@ -26,9 +30,12 @@ class TensorflowBaseAnnotator(BaseAnnotator):
         # device 判定はローカル ML 系 base class の責務 (Issue #35 で BaseAnnotator から移譲)
         from ..utils import determine_effective_device
 
+        try:
+            import tensorflow as tf
+        except ImportError as e:
+            raise ImportError("TensorFlow がインストールされていません。") from e
+
         self.device = determine_effective_device(self._config.device, self.model_name)
-        if tf is None:
-            raise ImportError("TensorFlow がインストールされていません。")
         try:
             gpus = tf.config.list_physical_devices("GPU")
             if gpus:
@@ -52,7 +59,7 @@ class TensorflowBaseAnnotator(BaseAnnotator):
         # components の型ヒントを具体的に指定
         self.components: TensorFlowComponents | None = None
 
-    def __enter__(self) -> "TensorflowBaseAnnotator":
+    def __enter__(self) -> TensorflowBaseAnnotator:
         """TensorFlow モデルコンポーネントをロードします。状態管理は ModelLoad に委譲します。"""
         logger.debug(f"Entering context for TensorFlow model '{self.model_name}'")
         try:
@@ -95,8 +102,9 @@ class TensorflowBaseAnnotator(BaseAnnotator):
                 )
                 self.components = cast(TensorFlowComponents, released_components)
                 logger.debug("TensorFlow Keras セッションクリアを試行 (必要な場合)。")
-                if tf:
-                    tf.keras.backend.clear_session()
+                import tensorflow as tf
+
+                tf.keras.backend.clear_session()
             except Exception as e:
                 logger.exception(f"TensorFlow モデル '{self.model_name}' の解放中にエラー: {e}")
             finally:
@@ -139,6 +147,8 @@ class TensorflowBaseAnnotator(BaseAnnotator):
 
     def _run_inference_tf(self, processed: np.ndarray[Any, np.dtype[Any]]) -> tf.Tensor:
         """TensorFlow モデルでバッチ推論を実行します。"""
+        import tensorflow as tf
+
         if not self.components or "model" not in self.components or self.components["model"] is None:
             raise RuntimeError("TensorFlow モデルがロードされていません。")
         tf_model = self.components["model"]
@@ -187,7 +197,14 @@ class TensorflowBaseAnnotator(BaseAnnotator):
             return {"error": {}}  # エラーを示す辞書を返す
 
         # 生出力が NumPy 配列であることを確認し、適切な次元から予測値を取得
-        if isinstance(raw_output, tf.Tensor):  # TFテンソルの場合 NumPy に変換
+        if isinstance(raw_output, np.ndarray):
+            predictions = raw_output.astype(float)
+        else:
+            import tensorflow as tf
+
+            if not isinstance(raw_output, tf.Tensor):
+                logger.error(f"予期しない予測値型: {type(raw_output).__name__}")
+                return {"error": {}}
             try:
                 # raw_output が None でないことを確認 (tf_model呼び出しがNoneを返さない想定)
                 # tf_modelの呼び出し結果がNoneになるケースは現状考えにくいが、より安全にするならNoneチェック
@@ -198,8 +215,6 @@ class TensorflowBaseAnnotator(BaseAnnotator):
             except Exception as e:
                 logger.exception(f"TF テンソルの NumPy 変換中にエラー: {e}")
                 return {"error": {}}
-        elif isinstance(raw_output, np.ndarray):
-            predictions = raw_output.astype(float)
 
         # 予測値の次元をチェック
         if predictions.ndim == 2 and predictions.shape[0] == 1:

--- a/src/image_annotator_lib/model_class/tagger_tensorflow.py
+++ b/src/image_annotator_lib/model_class/tagger_tensorflow.py
@@ -1,9 +1,10 @@
 """TensorFlow を使用する Tagger モデルの実装。"""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import tensorflow as tf
 from PIL import Image
 
 from ..core.base import TensorflowBaseAnnotator
@@ -11,6 +12,9 @@ from ..core.config import config_registry
 from ..core.model_config import BaseModelConfig
 from ..core.types import TaskCapability, UnifiedAnnotationResult
 from ..core.utils import get_model_capabilities, logger
+
+if TYPE_CHECKING:
+    import tensorflow as tf
 
 
 class DeepDanbooruTagger(TensorflowBaseAnnotator):

--- a/tests/unit/test_import_smoke.py
+++ b/tests/unit/test_import_smoke.py
@@ -4,11 +4,6 @@ ADR 0001 amendment 2026-05-18 で「通常 CI に `import image_annotator_lib` s
 ことが明文化された。本 test は subprocess clean import で実行し、in-process の sys.modules
 汚染 (他 test が torch を import 済み等) で false negative になることを避ける。
 
-Note:
-    現状 `tensorflow` は `initialize_registry()` 経由で DeepDanbooru 系 TF tagger class
-    の登録時に eager load される。本 smoke test ではその 1 件を許容しつつ、torch /
-    torchvision / transformers / onnxruntime の 4 module の lazy 化を regression 防止する。
-    tensorflow の lazy 化は別 Issue で追跡 (NEXTAltair/image-annotator-lib 側で起票予定)。
 """
 
 import json
@@ -17,12 +12,8 @@ import sys
 
 import pytest
 
-_HEAVY_MODULES: tuple[str, ...] = ("torch", "torchvision", "transformers", "onnxruntime")
-"""eager load を禁止する heavy native dep の module 名集合 (4 件)。
-
-tensorflow は現状 registry 初期化で eager load されるため本 set から除外し、別 Issue
-で追跡する (本 PR の scope 外)。
-"""
+_HEAVY_MODULES: tuple[str, ...] = ("torch", "torchvision", "transformers", "onnxruntime", "tensorflow")
+"""eager load を禁止する heavy native dep の module 名集合。"""
 
 _SENTINEL = "IAMLIB_SMOKE_JSON:"
 


### PR DESCRIPTION
## Summary
- remove module-level TensorFlow imports from TensorFlow annotator code
- lazy import TensorFlow only when constructing/running/cleaning TensorFlow models
- re-enable TensorFlow in the import smoke heavy-module guard

Closes #73

## Tests
- uv run pytest tests/unit/test_import_smoke.py tests/unit/core/base/test_tensorflow.py tests/unit/model_class/test_tagger_tensorflow.py tests/unit/standard/core/test_registry.py
- uv run ruff check --ignore C901 src/image_annotator_lib/core/base/tensorflow.py src/image_annotator_lib/model_class/tagger_tensorflow.py tests/unit/test_import_smoke.py
- git diff --check

## Notes
- Full `uv run ruff check` still reports pre-existing repository lint outside this change, plus existing C901 complexity in TensorFlow methods.
