### PR TITLE
docs: record onnx tagger model selection

### DIFF
--- a/docs/decisions/0003-rating-model-output-contract.md
+++ b/docs/decisions/0003-rating-model-output-contract.md
@@ -177,6 +177,7 @@ WDTagger 系のように category probability を持つモデルでは、full di
 ## Related
 
 - ADR 0002: Score Model Output Contract
+- ADR 0004: ONNX Tagger Loader and Model Selection
 - Model specs: `docs/model-specs/rating-model-candidates.md`
 - NEXTAltair/image-annotator-lib#79
 - NEXTAltair/image-annotator-lib#80

--- a/docs/decisions/0004-onnx-tagger-loader-and-model-selection.md
+++ b/docs/decisions/0004-onnx-tagger-loader-and-model-selection.md
@@ -1,0 +1,127 @@
+# ADR 0004: ONNX Tagger Loader and Model Selection
+
+- **日付**: 2026-05-21
+- **ステータス**: Accepted
+
+## Context
+
+ADR 0003 で `ratings` field と model-native label contract を定義し、最初の rating-only
+adapter として `deepghs/anime_rating` を追加した。次の候補として、rating だけでなく
+general / character tags も返せる Camie 系モデルを検討した。
+
+既存の WDTagger 系 adapter は、Hugging Face repo から `model.onnx` と `selected_tags.csv`
+を取得し、`ONNXBaseAnnotator` / `ONNXLoader` 経由で推論する。Camie 系モデルも ONNX だが、
+metadata は CSV ではなく JSON であり、ファイル名も `model_initial.onnx` /
+`model_initial_metadata.json` のように異なる。そのため、既存の `download_onnx_tagger_model()`
+は実質 WDTagger 専用になっている。
+
+また、モデル選択では以下の制約がある。
+
+- GUI のモデル選択肢を増やしすぎると使い勝手が悪くなる。
+- rating では精度を重視する。
+- モデル重みは同梱しない。
+- GPL-3.0 モデルを扱う場合でも、GPL 実装コードのコピーやモデル同梱は避ける。
+- LoRAIro canonical rating への mapping は consumer 側で行う。
+
+## Decision
+
+1. ONNX tagger の取得処理を WDTagger 専用から汎用化する。
+2. `ONNXLoader` / `ModelLoad.load_onnx_components()` は、ONNX model filename と metadata
+   filename を optional parameter として受け取れるようにする。
+3. `ONNXBaseAnnotator` は class variable または hook で model/metadata filename を宣言する。
+4. WDTagger 系は既存互換の default として `model.onnx` / `selected_tags.csv` を使う。
+5. Camie 系は WDTagger と同じ「モデル同梱なし、Hugging Face から ONNX と metadata を取得し、
+   adapter が metadata から label/category を復元する」方式で採用する。
+6. Camie の初期対応は `rating`, `general`, `character` のみに限定する。
+   `artist`, `copyright`, `meta`, `year` は初期出力に含めない。
+7. Camie 公式推論コードや `dghs-imgutils` の実装はコピーしない。公開仕様と metadata 形式に基づき、
+   image-annotator-lib 側で adapter を独自実装する。
+8. Camie model license が GPL-3.0 であることを docs / model specs に明記する。
+9. Camie 以外の追加 rating model として `deepghs/anime_rating` の `caformer_s36_plus`
+   variant を採用する。これは既存 `AnimeRatingAnnotator` と同じ ONNX 実装で扱う。
+
+## Model Selection
+
+標準 rating-only path は `deepghs/anime_rating` 系を維持する。
+
+- `mobilenetv3_sce_dist`: 高速・大量処理用。
+- `caformer_s36_plus`: 精度優先用。`anime_rating` の公開指標上、最も高い accuracy を持つため
+  採用する。
+
+Camie 系は rating-only model ではなく、WDTagger 後継候補に近い large ONNX tagger として扱う。
+rating も返せるが、主な採用理由は `rating`, `general`, `character` をまとめて高品質に返せる点である。
+
+その他の追加候補は現時点では採用しない。
+
+- `deepghs/eattach_sankaku_rating`: `anime_rating` と同じ `sankaku3` で用途が重なり、公開指標上の
+  優位性も弱い。
+- `ggg4mless/RateBooru_Efficient`: MIT だが TensorFlow/Keras 依存が増え、既存候補との差別化が弱い。
+- binary NSFW classifier: rating 保存モデルではなく、routing / filtering signal として別 issue で扱う。
+
+詳細な model card links、metrics、license は
+`docs/model-specs/rating-model-candidates.md` に記録する。
+
+## Rationale
+
+### なぜ loader を汎用化するか
+
+`download_onnx_tagger_model()` は `model.onnx` と CSV metadata を前提にしており、WDTagger 以外の
+ONNX tagger を追加するたびに専用 loader を増やすと重複が増える。model filename と metadata
+filename を adapter 側で宣言できるようにすれば、WDTagger 互換を保ったまま JSON metadata 型の
+tagger も同じロード経路に乗せられる。
+
+### なぜ Camie を WDTagger と同じ実装形態で採用するか
+
+Camie は GPL-3.0 model だが、モデル重みや metadata を package に同梱せず、GPL 実装コードも
+コピーしない。WDTagger と同様に外部 repo の ONNX model を利用者環境で取得し、image-annotator-lib
+側の独自 adapter が推論結果を解釈する形にする。この実装形態であれば、モデル自体の license は
+明示しつつ、library 側のコードを GPL 由来コードに強く依存させない。
+
+### なぜ Camie を rating-only ではなく large tagger として扱うか
+
+Camie は約 70,000 tag の multi-label classifier であり、rating だけを返す軽量モデルではない。
+rating 精度だけを目的に標準モデルを増やすより、WDTagger 系の代替・補完として `rating` /
+`general` / `character` を返す大型 tagger と位置づける方が利用者にとって分かりやすい。
+
+### なぜ出力カテゴリを絞るか
+
+Camie docs では `rating`, `general`, `character` は有用だが、`year`, `meta`, `artist`,
+`copyright` は精度が限定的とされている。初期対応で低精度カテゴリまで返すと、利用者が tag 品質を
+誤解しやすくなるため、初期出力は高品質なカテゴリに絞る。
+
+### なぜ `anime_rating_caformer_s36_plus` を採用するか
+
+`anime_rating_mobilenetv3_sce_dist` は高速・軽量で大量処理に向くが、rating では精度を重視する。
+同じ `deepghs/anime_rating` repo 内で公開されている `caformer_s36_plus` は、model card 上の
+accuracy が最も高い。license も同じ MIT で、出力 scheme も `sankaku3` のままなので、既存
+`AnimeRatingAnnotator` に variant 設定を追加するだけで扱える。GUI では高速枠と精度優先枠を
+用途で分けられる。
+
+## Consequences
+
+### 良い点
+
+- ONNX tagger 追加時の loader 重複が減る。
+- WDTagger の既存挙動を保ったまま Camie 系に対応できる。
+- GUI の標準選択肢を rating-only と large tagger の用途別に整理できる。
+- Camie の GPL-3.0 model license を明示しつつ、モデル同梱や GPL コードコピーを避けられる。
+
+### 悪い点・トレードオフ
+
+- `ModelLoad.load_onnx_components()` / `ONNXLoader` の引数が増える。
+- `ONNXComponents` は `csv_path` 前提から `metadata_path` 前提へ移行する必要がある。
+- Camie は重いため、runtime validation や GUI default には向かない。
+- GPL-3.0 model を扱う以上、利用者向け docs で license 注意書きが必要になる。
+
+### 実装ルール
+
+- 既存互換のため、移行期間は `ONNXComponents` に `metadata_path` と `csv_path` の両方を持たせてよい。
+- 新規 ONNX tagger は `metadata_path` を参照する。
+- Camie adapter は公式推論コードをコピーせず、独自実装する。
+- Camie adapter は `TaskCapability.TAGS` と `TaskCapability.RATINGS` を宣言し、rating label を
+  `tags` に混ぜない。
+
+## Related
+
+- ADR 0003: Rating Model Output Contract
+- Model specs: `docs/model-specs/rating-model-candidates.md`

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -7,6 +7,7 @@ image-annotator-lib の重要な設計判断を記録するドキュメント群
 | [0001](0001-runtime-validation-test-lanes.md) | Runtime Validation Test Lanes | 2026-05-17 | Accepted |
 | [0002](0002-score-model-output-contract.md) | Score Model Output Contract | 2026-05-17 | Accepted |
 | [0003](0003-rating-model-output-contract.md) | Rating Model Output Contract | 2026-05-21 | Accepted |
+| [0004](0004-onnx-tagger-loader-and-model-selection.md) | ONNX Tagger Loader and Model Selection | 2026-05-21 | Accepted |
 
 ## ADR テンプレート
 

--- a/docs/model-specs/rating-model-candidates.md
+++ b/docs/model-specs/rating-model-candidates.md
@@ -3,7 +3,7 @@
 This document records model-specific facts for rating-capable annotators. The output contract is
 defined in ADR 0003; LoRAIro-specific mapping is intentionally out of scope for image-annotator-lib.
 
-## Adopted First: `deepghs/anime_rating`
+## Adopted Rating-Only Models: `deepghs/anime_rating`
 
 - Model card: https://huggingface.co/deepghs/anime_rating
 - Reference docs: https://dghs-imgutils.deepghs.org/main/api_doc/validate/rating.html
@@ -11,10 +11,13 @@ defined in ADR 0003; LoRAIro-specific mapping is intentionally out of scope for 
 - Format: ONNX
 - Source scheme: `sankaku3`
 - Labels: `safe`, `r15`, `r18`
-- Default variant: `mobilenetv3_sce_dist`
-- Default variant files:
+- Fast/default variant: `mobilenetv3_sce_dist`
+- Accuracy-first variant: `caformer_s36_plus`
+- Variant files:
   - `mobilenetv3_sce_dist/model.onnx`
   - `mobilenetv3_sce_dist/meta.json`
+  - `caformer_s36_plus/model.onnx`
+  - `caformer_s36_plus/meta.json`
 - `meta.json` label order: `safe`, `r15`, `r18`
 - Model card metrics:
   - `caformer_s36_plus`: 74.26% accuracy, 22.10G FLOPs
@@ -22,14 +25,40 @@ defined in ADR 0003; LoRAIro-specific mapping is intentionally out of scope for 
 - Notes:
   - The model card and imgutils docs state that boundaries between `safe`, `r15`, and `r18`
     are unclear, and the model should be treated as a rough estimate.
-  - Use `mobilenetv3_sce_dist` first because it is small enough for routine local validation.
+  - Use `mobilenetv3_sce_dist` when speed and batch throughput matter.
+  - Use `caformer_s36_plus` when rating accuracy is more important than runtime cost.
   - LoRAIro maps these labels downstream; the library returns only model-native labels.
+
+## Adopted as Large Tagger Candidate: `Camais03/camie-tagger`
+
+- Model card: https://huggingface.co/Camais03/camie-tagger
+- ONNX optimized export: https://huggingface.co/deepghs/camie_tagger_onnx
+- Reference docs: https://dghs-imgutils.deepghs.org/main/api_doc/tagging/camie.html
+- License: GPL-3.0
+- Format: ONNX / PyTorch
+- Source scheme: `danbooru4`
+- Labels: `general`, `sensitive`, `questionable`, `explicit` for rating
+- Files in original repo:
+  - `model_initial.onnx`
+  - `model_initial_metadata.json`
+- Objective indicators:
+  - Hugging Face likes: about 66 on the original repo when reviewed.
+  - Original ONNX size: about 856 MB for `model_initial.onnx`.
+  - DeepGHS ONNX export reports 70,527 classes.
+  - DeepGHS ONNX export reports F1 micro/macro around 0.584/0.383 for `initial` and
+    0.589/0.387 for `refined`.
+- Notes:
+  - Treat Camie as a large tagger, not as a rating-only model.
+  - Initial adapter output should be limited to `rating`, `general`, and `character`.
+  - `artist`, `copyright`, `meta`, and `year` are not default outputs because the reference docs
+    describe those categories as limited accuracy.
+  - Do not copy GPL implementation code or bundle model files. Use the same external ONNX download
+    style as WDTagger.
 
 ## Deferred
 
 | Model | Scheme | Status | Reason |
 |---|---|---|---|
-| `deepghs/eattach_sankaku_rating` | `sankaku3` | Deferred | Similar labels; compare after `anime_rating` adapter proves the path. |
-| `Camais03/camie-tagger-v2` | `danbooru4` | Deferred | Multi-label tagger, likely heavier than rating-only model. |
+| `deepghs/eattach_sankaku_rating` | `sankaku3` | Rejected for now | Similar labels to `anime_rating`; weaker objective case than `anime_rating` variants. |
 | `ggg4mless/RateBooru_Efficient` | `danbooru3` | Low priority | TensorFlow/Keras dependency and weaker public metrics. |
 | Binary NSFW classifiers | `binary_nsfw` | Deferred | Routing/filter signal rather than fine-grained rating. |


### PR DESCRIPTION
## Summary
- add ADR 0004 for ONNX tagger loader generalization and model selection
- record Camie adoption constraints: external ONNX download, no model bundling, no GPL code copy, rating/general/character only
- mark anime_rating caformer_s36_plus as the accuracy-first rating variant
- document rejected/deferred non-Camie candidates

## Tests
- git diff --check