### PR TITLE
feat: generalize ONNX tagger loading

### DIFF
--- a/config/annotator_config-sample.toml
+++ b/config/annotator_config-sample.toml
@@ -107,6 +107,14 @@ estimated_size_gb = 0.047
 type = "tagger"
 capabilities = ["ratings"]
 
+[anime_rating_caformer_s36_plus]
+model_path = "deepghs/anime_rating"
+model_variant = "caformer_s36_plus"
+class = "AnimeRatingAnnotator"
+estimated_size_gb = 0.52
+type = "tagger"
+capabilities = ["ratings"]
+
 [wd-convnext-tagger-v3]
 model_path = "SmilingWolf/wd-convnext-tagger-v3"
 class = "WDTagger"

--- a/config/annotator_config.toml
+++ b/config/annotator_config.toml
@@ -98,6 +98,14 @@ estimated_size_gb = 0.047
 type = "tagger"
 capabilities = ["ratings"]
 
+[anime_rating_caformer_s36_plus]
+model_path = "deepghs/anime_rating"
+model_variant = "caformer_s36_plus"
+class = "AnimeRatingAnnotator"
+estimated_size_gb = 0.52
+type = "tagger"
+capabilities = ["ratings"]
+
 [wd-convnext-tagger-v3]
 model_path = "SmilingWolf/wd-convnext-tagger-v3"
 class = "WDTagger"

--- a/src/image_annotator_lib/core/base/onnx.py
+++ b/src/image_annotator_lib/core/base/onnx.py
@@ -1,7 +1,7 @@
 """ONNX Runtime を使用するモデル用の基底クラス。"""
 
 from abc import abstractmethod
-from typing import Any, Self, cast
+from typing import Any, ClassVar, Self, cast
 
 import numpy as np
 from PIL import Image
@@ -16,6 +16,10 @@ from .annotator import BaseAnnotator
 
 class ONNXBaseAnnotator(BaseAnnotator):
     """ONNX Runtime を使用するモデル用の基底クラス。"""
+
+    onnx_model_filename: ClassVar[str] = "model.onnx"
+    onnx_metadata_filename: ClassVar[str | None] = "selected_tags.csv"
+    onnx_metadata_extension: ClassVar[str | None] = ".csv"
 
     def __init__(self, model_name: str):
         super().__init__(model_name=model_name)
@@ -37,7 +41,14 @@ class ONNXBaseAnnotator(BaseAnnotator):
             if self.model_path is None:
                 raise ValueError(f"モデル '{self.model_name}' の model_path が設定されていません。")
             logger.info(f"Loading/Restoring ONNX components: model='{self.model_path}'")
-            self.components = ModelLoad.load_onnx_components(self.model_name, self.model_path, self.device)
+            self.components = ModelLoad.load_onnx_components(
+                self.model_name,
+                self.model_path,
+                self.device,
+                model_filename=self.onnx_model_filename,
+                metadata_filename=self.onnx_metadata_filename,
+                metadata_extension=self.onnx_metadata_extension,
+            )
             self._load_tags()
             self._analyze_model_input_format()
 

--- a/src/image_annotator_lib/core/loaders/onnx_loader.py
+++ b/src/image_annotator_lib/core/loaders/onnx_loader.py
@@ -22,22 +22,33 @@ from .loader_base import LoaderBase
 class ONNXLoader(LoaderBase):
     """ONNX モデルのローダー。"""
 
-    def _resolve_model_path_internal(self, model_path: str) -> tuple[Path | None, Path | None]:
-        """ONNX モデルパスと関連 CSV パスを解決する。"""
+    def _resolve_model_path_internal(
+        self,
+        model_path: str,
+        model_filename: str = utils.WD_MODEL_FILENAME,
+        metadata_filename: str | None = utils.WD_LABEL_FILENAME,
+        metadata_extension: str | None = ".csv",
+    ) -> tuple[Path | None, Path | None]:
+        """ONNX モデルパスと関連 metadata パスを解決する。"""
         try:
-            csv_path, model_repo_or_path_obj = utils.download_onnx_tagger_model(model_path)
+            metadata_path, model_repo_or_path_obj = utils.download_onnx_model_files(
+                model_path,
+                model_filename=model_filename,
+                metadata_filename=metadata_filename,
+                metadata_extension=metadata_extension,
+            )
             if model_repo_or_path_obj is None:
                 logger.error(f"ONNX モデルパス/リポジトリ解決失敗: {model_path}")
                 return None, None
             logger.debug(f"ONNXモデルパス解決: {model_repo_or_path_obj}")
-            return csv_path, model_repo_or_path_obj
+            return metadata_path, model_repo_or_path_obj
         except Exception as e:
             logger.error(f"ONNXモデルパス解決中にエラー ({model_path}): {e}", exc_info=True)
             return None, None
 
     def _calculate_specific_size(self, model_path: str, **kwargs: Any) -> float:
         """解決された ONNX ファイルサイズに基づいてサイズを計算する (乗数付き)。"""
-        _, resolved_path = self._resolve_model_path_internal(model_path)
+        _, resolved_path = self._resolve_model_path_internal(model_path, **kwargs)
         if resolved_path and resolved_path.is_file():
             return LoaderBase._calculate_file_size_mb(resolved_path) * 1.5
         elif resolved_path and resolved_path.is_dir():
@@ -52,11 +63,11 @@ class ONNXLoader(LoaderBase):
 
     @override
     def _load_components_internal(self, model_path: str, **kwargs: Any) -> ONNXComponents:
-        """ONNX InferenceSession をロードし CSV パスを解決する。"""
+        """ONNX InferenceSession をロードし metadata パスを解決する。"""
         import onnxruntime as ort
 
-        csv_path, resolved_model_path = self._resolve_model_path_internal(model_path)
-        if resolved_model_path is None or csv_path is None:
+        metadata_path, resolved_model_path = self._resolve_model_path_internal(model_path, **kwargs)
+        if resolved_model_path is None or metadata_path is None:
             raise FileNotFoundError(f"ONNXモデルパス解決失敗: {model_path}")
 
         logger.debug("ONNXキャッシュクリア試行...")
@@ -81,4 +92,4 @@ class ONNXLoader(LoaderBase):
         session = ort.InferenceSession(str(resolved_model_path), providers=providers)
         logger.info(f"ONNXモデル '{self.model_name}' ロード成功。")
 
-        return {"session": session, "csv_path": csv_path}
+        return {"session": session, "csv_path": metadata_path, "metadata_path": metadata_path}

--- a/src/image_annotator_lib/core/model_factory.py
+++ b/src/image_annotator_lib/core/model_factory.py
@@ -164,10 +164,22 @@ class ModelLoad:
         return cast(TransformersPipelineComponents | None, result)
 
     @staticmethod
-    def load_onnx_components(model_name: str, model_path: str, device: str) -> ONNXComponents | None:
+    def load_onnx_components(
+        model_name: str,
+        model_path: str,
+        device: str,
+        model_filename: str = "model.onnx",
+        metadata_filename: str | None = "selected_tags.csv",
+        metadata_extension: str | None = ".csv",
+    ) -> ONNXComponents | None:
         """ONNX モデルコンポーネントをロードする。"""
         loader = ONNXLoader(model_name, device)
-        result = loader.load_components(model_path)
+        result = loader.load_components(
+            model_path,
+            model_filename=model_filename,
+            metadata_filename=metadata_filename,
+            metadata_extension=metadata_extension,
+        )
         return cast(ONNXComponents | None, result)
 
     @staticmethod

--- a/src/image_annotator_lib/core/types.py
+++ b/src/image_annotator_lib/core/types.py
@@ -34,6 +34,7 @@ class TransformersPipelineComponents(TypedDict):
 class ONNXComponents(TypedDict):
     session: ort.InferenceSession
     csv_path: Path
+    metadata_path: Path
 
 
 class TensorFlowComponents(TypedDict):
@@ -205,9 +206,7 @@ AnnotationResultV2 = (
     WebApiAnnotationResult | TaggerAnnotationResult | ScorerAnnotationResult | CaptionerAnnotationResult
 )
 
-
 # --- capability-based統一バリデーションスキーマ (Plan対応) ---
-
 
 class TaskCapability(str, Enum):
     """サポートするタスク能力(ADR 0002: SCORE_LABELS 追加)。"""

--- a/src/image_annotator_lib/core/utils.py
+++ b/src/image_annotator_lib/core/utils.py
@@ -26,6 +26,7 @@ __all__ = [
     "calculate_phash",
     "convert_unix_to_iso8601",
     "determine_effective_device",
+    "download_onnx_model_files",
     "download_onnx_tagger_model",
     "extract_zip",
     "get_file_path",
@@ -218,25 +219,44 @@ def load_file(path_or_url: str) -> Path:
         ) from e
 
 
-def download_onnx_tagger_model(model_repo: str) -> tuple[Path, Path]:
-    """WD-Taggerのモデルをダウンロードする"""
+def download_onnx_model_files(
+    model_repo: str,
+    model_filename: str = WD_MODEL_FILENAME,
+    metadata_filename: str | None = WD_LABEL_FILENAME,
+    metadata_extension: str | None = ".csv",
+) -> tuple[Path | None, Path]:
+    """ONNXモデルと関連metadataファイルをHugging Face Hubからダウンロードする。"""
     # リポジトリ内のファイル一覧を取得
     repo_files = huggingface_hub.list_repo_files(model_repo)
 
-    # CSVファイルを検索(最初に見つかったものを使用)
-    csv_filename = next((f for f in repo_files if f.endswith(".csv")), WD_LABEL_FILENAME)
-
-    csv_path = huggingface_hub.hf_hub_download(
-        model_repo,
-        csv_filename,
-    )
+    metadata_path: str | None = None
+    if metadata_filename:
+        resolved_metadata_filename = metadata_filename
+        if metadata_filename not in repo_files and metadata_extension:
+            resolved_metadata_filename = next(
+                (f for f in repo_files if f.endswith(metadata_extension)), metadata_filename
+            )
+        metadata_path = huggingface_hub.hf_hub_download(model_repo, resolved_metadata_filename)
 
     model_path = huggingface_hub.hf_hub_download(
         model_repo,
-        WD_MODEL_FILENAME,
+        model_filename,
     )
 
-    return Path(csv_path), Path(model_path)
+    return Path(metadata_path) if metadata_path else None, Path(model_path)
+
+
+def download_onnx_tagger_model(model_repo: str) -> tuple[Path, Path]:
+    """WD-Taggerのモデルをダウンロードする。"""
+    metadata_path, model_path = download_onnx_model_files(
+        model_repo,
+        model_filename=WD_MODEL_FILENAME,
+        metadata_filename=WD_LABEL_FILENAME,
+        metadata_extension=".csv",
+    )
+    if metadata_path is None:
+        raise FileNotFoundError(f"ONNX tagger metadata not found: {model_repo}")
+    return metadata_path, model_path
 
 
 def determine_effective_device(requested_device: str, model_name: str | None = None) -> str:

--- a/src/image_annotator_lib/model_class/tagger_onnx.py
+++ b/src/image_annotator_lib/model_class/tagger_onnx.py
@@ -46,11 +46,18 @@ class WDTagger(ONNXBaseAnnotator):
 
     def _load_tags(self) -> None:
         """タグ情報 (語彙) をロードし、カテゴリごとのインデックスを設定します。"""
-        if "csv_path" not in self.components or not self.components["csv_path"]:
-            logger.error("タグ情報ファイルパス (csv_path) が components に設定されていません。")
+        metadata_path = (
+            self.components.get("metadata_path") or self.components.get("csv_path")
+            if self.components
+            else None
+        )
+        if not metadata_path:
+            logger.error(
+                "タグ情報ファイルパス (metadata_path/csv_path) が components に設定されていません。"
+            )
             raise FileNotFoundError("タグ情報ファイルパスが見つかりません。")
 
-        csv_path = self.components["csv_path"]
+        csv_path = metadata_path
         try:
             # ラベルファイルをpolarsで読み込み
             tags_df = pl.read_csv(csv_path)
@@ -124,11 +131,18 @@ class Z3D_E621Tagger(ONNXBaseAnnotator):
 
     def _load_tags(self) -> None:
         """Z3D_E621用のタグ情報 (語彙) をロードします。"""
-        if "csv_path" not in self.components or not self.components["csv_path"]:
-            logger.error("タグ情報ファイルパス (csv_path) が components に設定されていません。")
+        metadata_path = (
+            self.components.get("metadata_path") or self.components.get("csv_path")
+            if self.components
+            else None
+        )
+        if not metadata_path:
+            logger.error(
+                "タグ情報ファイルパス (metadata_path/csv_path) が components に設定されていません。"
+            )
             raise FileNotFoundError("タグ情報ファイルパスが見つかりません。")
 
-        csv_path = self.components["csv_path"]
+        csv_path = metadata_path
         try:
             # CSVファイルの読み込みとタグ取得
             tags_df = pl.read_csv(csv_path)

--- a/src/image_annotator_lib/resources/system/annotator_config.toml
+++ b/src/image_annotator_lib/resources/system/annotator_config.toml
@@ -71,6 +71,14 @@ estimated_size_gb = 0.047
 type = "tagger"
 capabilities = ["ratings"]
 
+[anime_rating_caformer_s36_plus]
+model_path = "deepghs/anime_rating"
+model_variant = "caformer_s36_plus"
+class = "AnimeRatingAnnotator"
+estimated_size_gb = 0.52
+type = "tagger"
+capabilities = ["ratings"]
+
 [wd-v1-4-convnext-tagger-v2]
 model_path = "SmilingWolf/wd-v1-4-convnext-tagger-v2"
 class = "WDTagger"

--- a/tests/unit/core/test_onnx_loader.py
+++ b/tests/unit/core/test_onnx_loader.py
@@ -1,0 +1,109 @@
+"""Unit tests for generalized ONNX loader file resolution."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from image_annotator_lib.core.loaders.onnx_loader import ONNXLoader
+from image_annotator_lib.core.model_factory import ModelLoad
+from image_annotator_lib.core.utils import download_onnx_model_files, download_onnx_tagger_model
+
+
+@pytest.mark.unit
+def test_download_onnx_model_files_uses_custom_filenames() -> None:
+    with (
+        patch(
+            "image_annotator_lib.core.utils.huggingface_hub.list_repo_files",
+            return_value=["model_initial.onnx", "model_initial_metadata.json"],
+        ),
+        patch(
+            "image_annotator_lib.core.utils.huggingface_hub.hf_hub_download",
+            side_effect=["/cache/model_initial_metadata.json", "/cache/model_initial.onnx"],
+        ) as mock_download,
+    ):
+        metadata_path, model_path = download_onnx_model_files(
+            "Camais03/camie-tagger",
+            model_filename="model_initial.onnx",
+            metadata_filename="model_initial_metadata.json",
+            metadata_extension=".json",
+        )
+
+    assert metadata_path == Path("/cache/model_initial_metadata.json")
+    assert model_path == Path("/cache/model_initial.onnx")
+    assert mock_download.call_args_list[0].args == (
+        "Camais03/camie-tagger",
+        "model_initial_metadata.json",
+    )
+    assert mock_download.call_args_list[1].args == ("Camais03/camie-tagger", "model_initial.onnx")
+
+
+@pytest.mark.unit
+def test_download_onnx_tagger_model_keeps_csv_fallback() -> None:
+    with (
+        patch(
+            "image_annotator_lib.core.utils.huggingface_hub.list_repo_files",
+            return_value=["model.onnx", "tags.csv"],
+        ),
+        patch(
+            "image_annotator_lib.core.utils.huggingface_hub.hf_hub_download",
+            side_effect=["/cache/tags.csv", "/cache/model.onnx"],
+        ) as mock_download,
+    ):
+        csv_path, model_path = download_onnx_tagger_model("SmilingWolf/example")
+
+    assert csv_path == Path("/cache/tags.csv")
+    assert model_path == Path("/cache/model.onnx")
+    assert mock_download.call_args_list[0].args == ("SmilingWolf/example", "tags.csv")
+    assert mock_download.call_args_list[1].args == ("SmilingWolf/example", "model.onnx")
+
+
+@pytest.mark.unit
+def test_onnx_loader_returns_metadata_and_csv_compatibility(tmp_path: Path) -> None:
+    metadata_path = tmp_path / "metadata.json"
+    model_path = tmp_path / "model.onnx"
+    metadata_path.write_text("{}", encoding="utf-8")
+    model_path.write_bytes(b"fake")
+    session = MagicMock()
+
+    with (
+        patch(
+            "image_annotator_lib.core.loaders.onnx_loader.utils.download_onnx_model_files",
+            return_value=(metadata_path, model_path),
+        ),
+        patch("onnxruntime.InferenceSession", return_value=session),
+    ):
+        components = ONNXLoader("test-model", "cpu")._load_components_internal(
+            "test/repo",
+            model_filename="model_initial.onnx",
+            metadata_filename="model_initial_metadata.json",
+            metadata_extension=".json",
+        )
+
+    assert components["session"] is session
+    assert components["metadata_path"] == metadata_path
+    assert components["csv_path"] == metadata_path
+
+
+@pytest.mark.unit
+def test_model_load_passes_onnx_filename_options() -> None:
+    with patch("image_annotator_lib.core.model_factory.ONNXLoader") as mock_loader_cls:
+        mock_loader = mock_loader_cls.return_value
+        mock_loader.load_components.return_value = {"session": MagicMock()}
+
+        result = ModelLoad.load_onnx_components(
+            "camie",
+            "Camais03/camie-tagger",
+            "cpu",
+            model_filename="model_initial.onnx",
+            metadata_filename="model_initial_metadata.json",
+            metadata_extension=".json",
+        )
+
+    assert result == {"session": mock_loader.load_components.return_value["session"]}
+    mock_loader.load_components.assert_called_once_with(
+        "Camais03/camie-tagger",
+        model_filename="model_initial.onnx",
+        metadata_filename="model_initial_metadata.json",
+        metadata_extension=".json",
+    )


### PR DESCRIPTION
## Summary
- generalize ONNX tagger file resolution so adapters can specify model and metadata filenames
- keep WDTagger/Z3D compatibility via csv_path while adding metadata_path
- add anime_rating_caformer_s36_plus as the accuracy-first rating variant

## Tests
- uv run ruff check src/image_annotator_lib/core/utils.py src/image_annotator_lib/core/loaders/onnx_loader.py src/image_annotator_lib/core/model_factory.py src/image_annotator_lib/core/base/onnx.py src/image_annotator_lib/core/types.py src/image_annotator_lib/model_class/tagger_onnx.py tests/unit/core/test_onnx_loader.py
- uv run ruff format --check src/image_annotator_lib/core/utils.py src/image_annotator_lib/core/loaders/onnx_loader.py src/image_annotator_lib/core/model_factory.py src/image_annotator_lib/core/base/onnx.py src/image_annotator_lib/core/types.py src/image_annotator_lib/model_class/tagger_onnx.py tests/unit/core/test_onnx_loader.py
- uv run pytest tests/unit/core/test_onnx_loader.py tests/unit/core/base/test_onnx.py tests/unit/model_class/test_tagger_onnx.py tests/unit/model_class/test_rating_onnx.py tests/unit/fast/test_list_annotator_info.py

Closes #88