### PR TITLE
feat: add Camie ONNX tagger

### DIFF
--- a/config/annotator_config-sample.toml
+++ b/config/annotator_config-sample.toml
@@ -115,6 +115,14 @@ estimated_size_gb = 0.52
 type = "tagger"
 capabilities = ["ratings"]
 
+[camie_tagger_initial]
+model_path = "Camais03/camie-tagger"
+class = "CamieTagger"
+estimated_size_gb = 0.856
+type = "tagger"
+capabilities = ["tags", "ratings"]
+tag_threshold = 0.325
+
 [wd-convnext-tagger-v3]
 model_path = "SmilingWolf/wd-convnext-tagger-v3"
 class = "WDTagger"

--- a/config/annotator_config.toml
+++ b/config/annotator_config.toml
@@ -96,7 +96,7 @@ model_variant = "mobilenetv3_sce_dist"
 class = "AnimeRatingAnnotator"
 estimated_size_gb = 0.047
 type = "tagger"
-capabilities = ["ratings"]
+capabilities = [ "ratings",]
 
 [anime_rating_caformer_s36_plus]
 model_path = "deepghs/anime_rating"
@@ -104,14 +104,14 @@ model_variant = "caformer_s36_plus"
 class = "AnimeRatingAnnotator"
 estimated_size_gb = 0.52
 type = "tagger"
-capabilities = ["ratings"]
+capabilities = [ "ratings",]
 
 [camie_tagger_initial]
 model_path = "Camais03/camie-tagger"
 class = "CamieTagger"
 estimated_size_gb = 0.856
 type = "tagger"
-capabilities = ["tags", "ratings"]
+capabilities = [ "tags", "ratings",]
 tag_threshold = 0.325
 
 [wd-convnext-tagger-v3]

--- a/config/annotator_config.toml
+++ b/config/annotator_config.toml
@@ -106,6 +106,14 @@ estimated_size_gb = 0.52
 type = "tagger"
 capabilities = ["ratings"]
 
+[camie_tagger_initial]
+model_path = "Camais03/camie-tagger"
+class = "CamieTagger"
+estimated_size_gb = 0.856
+type = "tagger"
+capabilities = ["tags", "ratings"]
+tag_threshold = 0.325
+
 [wd-convnext-tagger-v3]
 model_path = "SmilingWolf/wd-convnext-tagger-v3"
 class = "WDTagger"

--- a/docs/model-specs/rating-model-candidates.md
+++ b/docs/model-specs/rating-model-candidates.md
@@ -41,6 +41,7 @@ defined in ADR 0003; LoRAIro-specific mapping is intentionally out of scope for 
 - Files in original repo:
   - `model_initial.onnx`
   - `model_initial_metadata.json`
+- Library model id: `camie_tagger_initial`
 - Objective indicators:
   - Hugging Face likes: about 66 on the original repo when reviewed.
   - Original ONNX size: about 856 MB for `model_initial.onnx`.

--- a/src/image_annotator_lib/core/base/onnx.py
+++ b/src/image_annotator_lib/core/base/onnx.py
@@ -93,6 +93,22 @@ class ONNXBaseAnnotator(BaseAnnotator):
                 logger.warning(f"インデックス {i} が範囲外です (タグ総数: {len(all_tags_list)})。")
         return category_tags
 
+    def _to_probabilities(
+        self, raw_output: np.ndarray[Any, np.dtype[Any]]
+    ) -> np.ndarray[Any, np.dtype[Any]]:
+        """ONNX生出力を確率値へ変換する。
+
+        確率を直接出力するモデル (WDTagger / Z3D 等) では恒等変換 (既定)。
+        logit を出力するモデル (CamieTagger 等) はサブクラスで sigmoid 等を適用する。
+
+        Args:
+            raw_output: ONNX推論の生出力配列。
+
+        Returns:
+            確率値の配列。
+        """
+        return raw_output
+
     def _format_predictions_single(
         self, raw_output: np.ndarray[Any, np.dtype[Any]]
     ) -> UnifiedAnnotationResult:
@@ -110,8 +126,10 @@ class ONNXBaseAnnotator(BaseAnnotator):
         all_tags_list = getattr(self, "all_tags", [])
         threshold = getattr(self, "tag_threshold", 0.35)
 
-        # バリデーション
-        predictions, error = self._validate_onnx_output(raw_output, all_tags_list, capabilities)
+        # バリデーション (生出力 → 確率変換を挟む)
+        predictions, error = self._validate_onnx_output(
+            self._to_probabilities(raw_output), all_tags_list, capabilities
+        )
         if error:
             return error
 

--- a/src/image_annotator_lib/core/model_config.py
+++ b/src/image_annotator_lib/core/model_config.py
@@ -82,6 +82,7 @@ class LocalMLModelConfig(BaseModelConfig):
     batch_size: int = Field(default=1, gt=0, description="バッチサイズ")
     gpu_memory_limit_gb: float | None = Field(default=None, gt=0, description="GPU メモリ上限 (GB)")
     model_variant: str | None = Field(default=None, description="同一リポジトリ内のモデルvariant名")
+    tag_threshold: float | None = Field(default=None, ge=0, le=1, description="タグ出力閾値")
 
     @field_validator("model_path")
     @classmethod

--- a/src/image_annotator_lib/model_class/tagger_onnx.py
+++ b/src/image_annotator_lib/model_class/tagger_onnx.py
@@ -10,7 +10,6 @@ from PIL import Image
 
 from ..core.base import ONNXBaseAnnotator
 from ..core.config import config_registry
-from ..core.types import TaskCapability, UnifiedAnnotationResult
 from ..core.utils import logger
 
 
@@ -237,7 +236,13 @@ class Z3D_E621Tagger(ONNXBaseAnnotator):
 
 
 class CamieTagger(ONNXBaseAnnotator):
-    """Camie Tagger (ONNX版)。"""
+    """Camie Tagger (ONNX版)。
+
+    ライブラリ側ではカテゴリ情報を削らない: rating を除く全カテゴリ
+    (general / character / copyright / artist / meta / year 等) を保持し、
+    タグと per-category スコア (``raw_output["category_scores"]``) を raw のまま
+    公開する。どのカテゴリをどう使うかは consumer (LoRAIro 等) 側で決める。
+    """
 
     onnx_model_filename: ClassVar[str] = "model_initial.onnx"
     onnx_metadata_filename: ClassVar[str] = "model_initial_metadata.json"
@@ -247,22 +252,21 @@ class CamieTagger(ONNXBaseAnnotator):
     def __init__(self, model_name: str):
         """CamieTagger を初期化します。"""
         super().__init__(model_name=model_name)
-        self._category_attr_map = {
-            "rating": "rating_indexes",
-            "general": "general_indexes",
-            "character": "character_indexes",
-        }
-        self._init_empty_indexes()
+        # _category_attr_map は metadata に現れるカテゴリから _load_tags で動的構築する。
+        self._category_attr_map: dict[str, str] = {}
         self.tag_threshold = config_registry.get(self.model_name, "tag_threshold", 0.325)
         logger.info(f"Camie tag threshold set to: {self.tag_threshold}")
 
     def _init_empty_indexes(self) -> None:
-        """初期出力対象カテゴリのインデックスリストを空で初期化します。"""
+        """カテゴリ別インデックスリストを空で初期化します。"""
         for attr_name in self._category_attr_map.values():
             setattr(self, attr_name, [])
 
     def _load_tags(self) -> None:
-        """Camie JSON metadataからタグ名と対象カテゴリのインデックスをロードします。"""
+        """Camie JSON metadata からタグ名と全カテゴリのインデックスをロードします。
+
+        rating を含む metadata 上の全カテゴリを動的に保持する (情報を削らない)。
+        """
         metadata_path = (
             self.components.get("metadata_path") or self.components.get("csv_path")
             if self.components
@@ -279,14 +283,21 @@ class CamieTagger(ONNXBaseAnnotator):
             raise ValueError("Camie metadata must contain idx_to_tag and tag_to_category dictionaries.")
 
         self.all_tags = [str(idx_to_tag[str(i)]) for i in range(len(idx_to_tag))]
+
+        # metadata に現れる全カテゴリから動的に attr マップを構築する (カテゴリを削らない)。
+        categories = {str(tag_to_category.get(tag)) for tag in self.all_tags}
+        categories.discard("None")
+        self._category_attr_map = {category: f"{category}_indexes" for category in sorted(categories)}
         self._init_empty_indexes()
         for index, tag_name in enumerate(self.all_tags):
-            category = tag_to_category.get(tag_name)
-            attr_name = self._category_attr_map.get(str(category))
+            attr_name = self._category_attr_map.get(str(tag_to_category.get(tag_name)))
             if attr_name:
                 getattr(self, attr_name).append(index)
 
-        logger.info(f"Camie metadata loaded: total_tags={len(self.all_tags)}")
+        logger.info(
+            f"Camie metadata loaded: total_tags={len(self.all_tags)}, "
+            f"categories={sorted(self._category_attr_map)}"
+        )
 
     def _preprocess_images(self, images: list[Image.Image]) -> list[np.ndarray[Any, np.dtype[np.float32]]]:
         """Camie公式ONNX経路に合わせ、黒padding + RGB + 0..1 NCHWで前処理します。"""
@@ -294,7 +305,7 @@ class CamieTagger(ONNXBaseAnnotator):
         image_size = target_size[0]
         results = []
         for image in images:
-            img_rgb = image.convert("RGB") if image.mode in {"RGBA", "P"} or image.mode != "RGB" else image
+            img_rgb = image if image.mode == "RGB" else image.convert("RGB")
             width, height = img_rgb.size
             aspect_ratio = width / height
             if aspect_ratio > 1:
@@ -312,37 +323,11 @@ class CamieTagger(ONNXBaseAnnotator):
             results.append(np.expand_dims(input_data, axis=0).astype(np.float32))
         return results
 
-    def _format_predictions_single(
+    def _to_probabilities(
         self, raw_output: np.ndarray[Any, np.dtype[Any]]
-    ) -> UnifiedAnnotationResult:
-        """Camie logitsにsigmoidを適用して統一結果へ整形します。"""
-        from ..core.utils import get_model_capabilities
-
-        capabilities = get_model_capabilities(self.model_name)
-        probabilities = self._sigmoid(raw_output.astype(np.float32))
-        predictions, error = self._validate_onnx_output(probabilities, self.all_tags, capabilities)
-        if error:
-            return error
-
-        tags_with_probs = list(zip(self.all_tags, predictions, strict=True))
-        category_scores = self._classify_tags_by_category(tags_with_probs)
-        final_tags = self._filter_tags_by_threshold(category_scores, self.tag_threshold)
-        ratings = self._extract_top_rating(category_scores, capabilities)
-
-        return UnifiedAnnotationResult(
-            model_name=self.model_name,
-            capabilities=capabilities,
-            tags=final_tags if TaskCapability.TAGS in capabilities else None,
-            captions=None,
-            scores=None,
-            ratings=ratings,
-            framework="onnx",
-            raw_output={
-                "category_scores": category_scores,
-                "threshold": self.tag_threshold,
-                "total_tags_count": len(self.all_tags),
-            },
-        )
+    ) -> np.ndarray[Any, np.dtype[Any]]:
+        """Camie は logit を出力するため sigmoid で確率へ変換します。"""
+        return self._sigmoid(raw_output.astype(np.float32))
 
     @staticmethod
     def _sigmoid(

--- a/src/image_annotator_lib/model_class/tagger_onnx.py
+++ b/src/image_annotator_lib/model_class/tagger_onnx.py
@@ -1,9 +1,16 @@
 """ONNX Runtime を使用する Tagger モデルの実装。"""
 
+import json
+from pathlib import Path
+from typing import Any, ClassVar
+
+import numpy as np
 import polars as pl
+from PIL import Image
 
 from ..core.base import ONNXBaseAnnotator
 from ..core.config import config_registry
+from ..core.types import TaskCapability, UnifiedAnnotationResult
 from ..core.utils import logger
 
 
@@ -227,3 +234,126 @@ class Z3D_E621Tagger(ONNXBaseAnnotator):
         general_set = set(current_general_indexes)
         general_set.update(unclassified_indexes)
         self.general_indexes = list(general_set)
+
+
+class CamieTagger(ONNXBaseAnnotator):
+    """Camie Tagger (ONNX版)。"""
+
+    onnx_model_filename: ClassVar[str] = "model_initial.onnx"
+    onnx_metadata_filename: ClassVar[str] = "model_initial_metadata.json"
+    onnx_metadata_extension: ClassVar[str] = ".json"
+    rating_source_scheme: ClassVar[str] = "danbooru4"
+
+    def __init__(self, model_name: str):
+        """CamieTagger を初期化します。"""
+        super().__init__(model_name=model_name)
+        self._category_attr_map = {
+            "rating": "rating_indexes",
+            "general": "general_indexes",
+            "character": "character_indexes",
+        }
+        self._init_empty_indexes()
+        self.tag_threshold = config_registry.get(self.model_name, "tag_threshold", 0.325)
+        logger.info(f"Camie tag threshold set to: {self.tag_threshold}")
+
+    def _init_empty_indexes(self) -> None:
+        """初期出力対象カテゴリのインデックスリストを空で初期化します。"""
+        for attr_name in self._category_attr_map.values():
+            setattr(self, attr_name, [])
+
+    def _load_tags(self) -> None:
+        """Camie JSON metadataからタグ名と対象カテゴリのインデックスをロードします。"""
+        metadata_path = (
+            self.components.get("metadata_path") or self.components.get("csv_path")
+            if self.components
+            else None
+        )
+        if not metadata_path:
+            logger.error("Camie metadata file path is missing from ONNX components.")
+            raise FileNotFoundError("Camie metadata file path not found.")
+
+        metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
+        idx_to_tag = metadata.get("idx_to_tag")
+        tag_to_category = metadata.get("tag_to_category")
+        if not isinstance(idx_to_tag, dict) or not isinstance(tag_to_category, dict):
+            raise ValueError("Camie metadata must contain idx_to_tag and tag_to_category dictionaries.")
+
+        self.all_tags = [str(idx_to_tag[str(i)]) for i in range(len(idx_to_tag))]
+        self._init_empty_indexes()
+        for index, tag_name in enumerate(self.all_tags):
+            category = tag_to_category.get(tag_name)
+            attr_name = self._category_attr_map.get(str(category))
+            if attr_name:
+                getattr(self, attr_name).append(index)
+
+        logger.info(f"Camie metadata loaded: total_tags={len(self.all_tags)}")
+
+    def _preprocess_images(self, images: list[Image.Image]) -> list[np.ndarray[Any, np.dtype[np.float32]]]:
+        """Camie公式ONNX経路に合わせ、黒padding + RGB + 0..1 NCHWで前処理します。"""
+        target_size = self.target_size or (512, 512)
+        image_size = target_size[0]
+        results = []
+        for image in images:
+            img_rgb = image.convert("RGB") if image.mode in {"RGBA", "P"} or image.mode != "RGB" else image
+            width, height = img_rgb.size
+            aspect_ratio = width / height
+            if aspect_ratio > 1:
+                new_width = image_size
+                new_height = int(new_width / aspect_ratio)
+            else:
+                new_height = image_size
+                new_width = int(new_height * aspect_ratio)
+
+            resized = img_rgb.resize((new_width, new_height), Image.Resampling.LANCZOS)
+            padded = Image.new("RGB", (image_size, image_size), (0, 0, 0))
+            padded.paste(resized, ((image_size - new_width) // 2, (image_size - new_height) // 2))
+            array = np.asarray(padded, dtype=np.float32) / 255.0
+            input_data = np.transpose(array, (2, 0, 1))
+            results.append(np.expand_dims(input_data, axis=0).astype(np.float32))
+        return results
+
+    def _format_predictions_single(
+        self, raw_output: np.ndarray[Any, np.dtype[Any]]
+    ) -> UnifiedAnnotationResult:
+        """Camie logitsにsigmoidを適用して統一結果へ整形します。"""
+        from ..core.utils import get_model_capabilities
+
+        capabilities = get_model_capabilities(self.model_name)
+        probabilities = self._sigmoid(raw_output.astype(np.float32))
+        predictions, error = self._validate_onnx_output(probabilities, self.all_tags, capabilities)
+        if error:
+            return error
+
+        tags_with_probs = list(zip(self.all_tags, predictions, strict=True))
+        category_scores = self._classify_tags_by_category(tags_with_probs)
+        final_tags = self._filter_tags_by_threshold(category_scores, self.tag_threshold)
+        ratings = self._extract_top_rating(category_scores, capabilities)
+
+        return UnifiedAnnotationResult(
+            model_name=self.model_name,
+            capabilities=capabilities,
+            tags=final_tags if TaskCapability.TAGS in capabilities else None,
+            captions=None,
+            scores=None,
+            ratings=ratings,
+            framework="onnx",
+            raw_output={
+                "category_scores": category_scores,
+                "threshold": self.tag_threshold,
+                "total_tags_count": len(self.all_tags),
+            },
+        )
+
+    @staticmethod
+    def _sigmoid(
+        raw_output: np.ndarray[Any, np.dtype[np.float32]],
+    ) -> np.ndarray[Any, np.dtype[np.float32]]:
+        return 1.0 / (1.0 + np.exp(-raw_output))
+
+    @staticmethod
+    def _normalize_rating_label(raw_label: str) -> str:
+        """Camie rating tags are stored as rating_general; expose danbooru4 labels."""
+        normalized = ONNXBaseAnnotator._normalize_rating_label(raw_label)
+        if normalized.startswith("rating_"):
+            return normalized.removeprefix("rating_")
+        return normalized

--- a/src/image_annotator_lib/resources/system/annotator_config.toml
+++ b/src/image_annotator_lib/resources/system/annotator_config.toml
@@ -79,6 +79,14 @@ estimated_size_gb = 0.52
 type = "tagger"
 capabilities = ["ratings"]
 
+[camie_tagger_initial]
+model_path = "Camais03/camie-tagger"
+class = "CamieTagger"
+estimated_size_gb = 0.856
+type = "tagger"
+capabilities = ["tags", "ratings"]
+tag_threshold = 0.325
+
 [wd-v1-4-convnext-tagger-v2]
 model_path = "SmilingWolf/wd-v1-4-convnext-tagger-v2"
 class = "WDTagger"

--- a/tests/runtime_validation/test_real_model_runtime.py
+++ b/tests/runtime_validation/test_real_model_runtime.py
@@ -100,3 +100,26 @@ def test_real_anime_rating_runtime() -> None:
         assert rating.source_scheme == "sankaku3"
         assert rating.confidence_score is not None
         assert 0.0 <= rating.confidence_score <= 1.0
+
+
+@pytest.mark.downloads_and_runs_model
+def test_real_camie_tagger_runtime() -> None:
+    """CamieTagger heavy smoke test for tags + rating output."""
+    if not _RESOURCE_IMG.exists():
+        pytest.skip(f"resource image not found: {_RESOURCE_IMG}")
+
+    img = Image.open(_RESOURCE_IMG).convert("RGB")
+    model_name = "camie_tagger_initial"
+    result = annotate(images_list=[img], model_name_list=[model_name])
+
+    assert len(result) == 1, f"expected 1 phash entry, got {len(result)}"
+    for _phash, models in result.items():
+        ann = models[model_name]
+        assert ann.error is None, f"{model_name} returned error: {ann.error}"
+        assert ann.tags is not None
+        assert ann.ratings is not None and len(ann.ratings) == 1
+        rating = ann.ratings[0]
+        assert rating.raw_label in {"general", "sensitive", "questionable", "explicit"}
+        assert rating.source_scheme == "danbooru4"
+        assert rating.confidence_score is not None
+        assert 0.0 <= rating.confidence_score <= 1.0

--- a/tests/unit/model_class/test_camie_tagger.py
+++ b/tests/unit/model_class/test_camie_tagger.py
@@ -81,6 +81,9 @@ def test_camie_loads_json_metadata(camie_config: str, camie_metadata_path: Path)
     assert annotator.general_indexes == [1]
     assert annotator.character_indexes == [2]
     assert annotator.rating_indexes == [3, 4, 5, 6]
+    # ライブラリはカテゴリを削らない: year / artist も保持される
+    assert annotator.year_indexes == [0]
+    assert annotator.artist_indexes == [7]
 
 
 @pytest.mark.unit
@@ -92,13 +95,20 @@ def test_camie_formats_sigmoid_tags_and_rating(camie_config: str, camie_metadata
     result = annotator._format_predictions_single(_logits(0.95, 0.80, 0.70, 0.05, 0.85, 0.20, 0.01, 0.99))
 
     assert result.error is None
-    assert result.tags == ["1girl", "hakurei_reimu"]
+    # rating 以外の全カテゴリ (year / artist 含む) のタグを confidence 降順で出力する
+    assert result.tags == ["artist_name", "year_2024", "1girl", "hakurei_reimu"]
     assert result.ratings is not None
     assert result.ratings[0].raw_label == "sensitive"
     assert result.ratings[0].confidence_score == pytest.approx(0.85)
     assert result.ratings[0].source_scheme == "danbooru4"
-    assert "artist" not in result.raw_output["category_scores"]
-    assert "year" not in result.raw_output["category_scores"]
+    # 全カテゴリの raw スコアが category_scores に残る (情報を削らない)
+    assert set(result.raw_output["category_scores"]) == {
+        "year",
+        "general",
+        "character",
+        "artist",
+        "ratings",
+    }
 
 
 @pytest.mark.unit

--- a/tests/unit/model_class/test_camie_tagger.py
+++ b/tests/unit/model_class/test_camie_tagger.py
@@ -1,0 +1,115 @@
+"""Unit tests for CamieTagger."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from image_annotator_lib.model_class.tagger_onnx import CamieTagger
+
+
+@pytest.fixture
+def camie_config(managed_config_registry) -> str:
+    managed_config_registry.set(
+        "test_camie",
+        {
+            "class": "CamieTagger",
+            "model_path": "Camais03/camie-tagger",
+            "device": "cpu",
+            "estimated_size_gb": 0.856,
+            "type": "tagger",
+            "capabilities": ["tags", "ratings"],
+            "tag_threshold": 0.325,
+        },
+    )
+    return "test_camie"
+
+
+@pytest.fixture
+def camie_metadata_path(tmp_path: Path) -> Path:
+    metadata = {
+        "idx_to_tag": {
+            "0": "year_2024",
+            "1": "1girl",
+            "2": "hakurei_reimu",
+            "3": "rating_general",
+            "4": "rating_sensitive",
+            "5": "rating_questionable",
+            "6": "rating_explicit",
+            "7": "artist_name",
+        },
+        "tag_to_category": {
+            "year_2024": "year",
+            "1girl": "general",
+            "hakurei_reimu": "character",
+            "rating_general": "rating",
+            "rating_sensitive": "rating",
+            "rating_questionable": "rating",
+            "rating_explicit": "rating",
+            "artist_name": "artist",
+        },
+    }
+    path = tmp_path / "model_initial_metadata.json"
+    path.write_text(json.dumps(metadata), encoding="utf-8")
+    return path
+
+
+def _logits(*probabilities: float) -> np.ndarray:
+    probs = np.array([probabilities], dtype=np.float32)
+    return np.log(probs / (1.0 - probs)).astype(np.float32)
+
+
+@pytest.mark.unit
+def test_camie_loads_json_metadata(camie_config: str, camie_metadata_path: Path) -> None:
+    annotator = CamieTagger(camie_config)
+    annotator.components = {"session": object(), "metadata_path": camie_metadata_path}
+
+    annotator._load_tags()
+
+    assert annotator.all_tags == [
+        "year_2024",
+        "1girl",
+        "hakurei_reimu",
+        "rating_general",
+        "rating_sensitive",
+        "rating_questionable",
+        "rating_explicit",
+        "artist_name",
+    ]
+    assert annotator.general_indexes == [1]
+    assert annotator.character_indexes == [2]
+    assert annotator.rating_indexes == [3, 4, 5, 6]
+
+
+@pytest.mark.unit
+def test_camie_formats_sigmoid_tags_and_rating(camie_config: str, camie_metadata_path: Path) -> None:
+    annotator = CamieTagger(camie_config)
+    annotator.components = {"session": object(), "metadata_path": camie_metadata_path}
+    annotator._load_tags()
+
+    result = annotator._format_predictions_single(_logits(0.95, 0.80, 0.70, 0.05, 0.85, 0.20, 0.01, 0.99))
+
+    assert result.error is None
+    assert result.tags == ["1girl", "hakurei_reimu"]
+    assert result.ratings is not None
+    assert result.ratings[0].raw_label == "sensitive"
+    assert result.ratings[0].confidence_score == pytest.approx(0.85)
+    assert result.ratings[0].source_scheme == "danbooru4"
+    assert "artist" not in result.raw_output["category_scores"]
+    assert "year" not in result.raw_output["category_scores"]
+
+
+@pytest.mark.unit
+def test_camie_preprocess_uses_black_padding(camie_config: str) -> None:
+    annotator = CamieTagger(camie_config)
+    annotator.target_size = (512, 512)
+    image = Image.new("RGB", (512, 256), color="red")
+
+    [processed] = annotator._preprocess_images([image])
+
+    assert processed.shape == (1, 3, 512, 512)
+    assert processed.dtype == np.float32
+    assert processed[0, :, 0, 0].tolist() == [0.0, 0.0, 0.0]
+    assert processed[0, :, 256, 256].tolist() == [1.0, 0.0, 0.0]


### PR DESCRIPTION
## Summary
- add CamieTagger as a large ONNX tagger using generalized model/metadata file loading
- parse Camie JSON metadata and expose rating/general/character only
- apply Camie sigmoid post-processing and normalize rating_* labels to danbooru4 labels
- document/register camie_tagger_initial without bundling GPL-3.0 model files

## Stacked PR
- Depends on #90 / issue #88.
- Base branch is feat/issue-88-onnx-loader until #90 is merged.

## Tests
- uv run ruff check src/image_annotator_lib/model_class/tagger_onnx.py src/image_annotator_lib/core/model_config.py tests/unit/model_class/test_camie_tagger.py tests/runtime_validation/test_real_model_runtime.py
- uv run ruff format --check src/image_annotator_lib/model_class/tagger_onnx.py src/image_annotator_lib/core/model_config.py tests/unit/model_class/test_camie_tagger.py tests/runtime_validation/test_real_model_runtime.py
- uv run pytest tests/unit/model_class/test_camie_tagger.py tests/unit/core/test_onnx_loader.py tests/unit/model_class/test_tagger_onnx.py tests/unit/fast/test_list_annotator_info.py
- Added but not run: tests/runtime_validation/test_real_model_runtime.py::test_real_camie_tagger_runtime -m downloads_and_runs_model (heavy ~856MB model download)

Closes #89