### PR TITLE
fix(core): expose ratings capability for rating-capable taggers

### DIFF
--- a/config/annotator_config.toml
+++ b/config/annotator_config.toml
@@ -47,48 +47,56 @@ model_path = "deepghs/idolsankaku-eva02-large-tagger-v1"
 class = "WDTagger"
 estimated_size_gb = 1.695
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [idolsankaku-swinv2-tagger-v1]
 model_path = "deepghs/idolsankaku-swinv2-tagger-v1"
 class = "WDTagger"
 estimated_size_gb = 0.587
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [Z3D-E621-Convnext]
 model_path = "toynya/Z3D-E621-Convnext"
 class = "Z3D_E621Tagger"
 estimated_size_gb = 0.544
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [wd-v1-4-convnext-tagger-v2]
 model_path = "SmilingWolf/wd-v1-4-convnext-tagger-v2"
 class = "WDTagger"
 estimated_size_gb = 0.542
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [wd-v1-4-convnextv2-tagger-v2]
 model_path = "SmilingWolf/wd-v1-4-convnextv2-tagger-v2"
 class = "WDTagger"
 estimated_size_gb = 0.543
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [wd-v1-4-moat-tagger-v2]
 model_path = "SmilingWolf/wd-v1-4-moat-tagger-v2"
 class = "WDTagger"
 estimated_size_gb = 0.456
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [wd-v1-4-swinv2-tagger-v2]
 model_path = "SmilingWolf/wd-v1-4-swinv2-tagger-v2"
 class = "WDTagger"
 estimated_size_gb = 0.636
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [wd-vit-tagger-v3]
 model_path = "SmilingWolf/wd-vit-tagger-v3"
 class = "WDTagger"
 estimated_size_gb = 0.529
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [anime_rating_mobilenetv3_sce_dist]
 model_path = "deepghs/anime_rating"
@@ -119,24 +127,28 @@ model_path = "SmilingWolf/wd-convnext-tagger-v3"
 class = "WDTagger"
 estimated_size_gb = 0.552
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [wd-swinv2-tagger-v3]
 model_path = "SmilingWolf/wd-swinv2-tagger-v3"
 class = "WDTagger"
 estimated_size_gb = 0.653
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [wd-vit-large-tagger-v3]
 model_path = "SmilingWolf/wd-vit-large-tagger-v3"
 class = "WDTagger"
 estimated_size_gb = 1.761
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [wd-eva02-large-tagger-v3]
 model_path = "SmilingWolf/wd-eva02-large-tagger-v3"
 class = "WDTagger"
 estimated_size_gb = 1.761
 type = "tagger"
+capabilities = [ "tags", "ratings",]
 
 [BLIPLargeCaptioning]
 model_path = "Salesforce/blip-image-captioning-large"
@@ -235,3 +247,4 @@ model_path = "https://github.com/KichangKim/DeepDanbooru/releases/download/v1-20
 class = "DeepDanbooruTagger"
 estimated_size_gb = 0.66
 type = "tagger"
+

--- a/src/image_annotator_lib/core/utils.py
+++ b/src/image_annotator_lib/core/utils.py
@@ -320,6 +320,66 @@ def determine_effective_device(requested_device: str, model_name: str | None = N
     return actual_device
 
 
+# LoRAIro #365: Local tagger classes that emit model-native ratings in addition to tags.
+# Used as a class-name-based fallback in `get_model_capabilities` when the user-side
+# `config/annotator_config.toml` is older than the bundled template and lacks the
+# explicit `capabilities = ["tags", "ratings"]` field. The SSoT for rating output is
+# the model class itself (presence of `rating_source_scheme` / rating index extraction),
+# so we encode that knowledge here to avoid silently dropping ratings.
+#
+# Note: rating-only annotators (e.g. AnimeRatingAnnotator) are NOT listed here —
+# they always ship with explicit `capabilities = ["ratings"]` in the system template
+# and would otherwise be misclassified as TAGS+RATINGS.
+RATING_CAPABLE_TAGGER_CLASSES: frozenset[str] = frozenset(
+    {
+        "WDTagger",
+        "Z3D_E621Tagger",
+        "CamieTagger",
+    }
+)
+
+
+def _infer_capabilities_from_type(model_name: str) -> set[Any] | None:
+    """設定ファイルの `type` フィールドから capabilities を推論する。
+
+    `type == "tagger"` の場合は `class` フィールドも参照し、rating 対応モデルなら
+    `RATINGS` capability も付与する (LoRAIro #365)。ユーザー側
+    `config/annotator_config.toml` が古く `capabilities` 未指定でも、rating output
+    を落とさないためのフォールバック。
+
+    Args:
+        model_name: モデル名
+
+    Returns:
+        推論できた場合は capability set、type 未知の場合は None。
+    """
+    from .config import config_registry
+    from .types import TaskCapability
+
+    model_type = config_registry.get(model_name, "type", "")
+    type_to_capabilities: dict[str, list[TaskCapability]] = {
+        "tagger": [TaskCapability.TAGS],
+        "scorer": [TaskCapability.SCORES],
+        "captioner": [TaskCapability.CAPTIONS],
+    }
+    inferred = type_to_capabilities.get(model_type, [])
+    if not inferred:
+        return None
+
+    # LoRAIro #365: tagger クラスが rating 出力対応なら RATINGS も足す。
+    if model_type == "tagger":
+        model_class = config_registry.get(model_name, "class", "")
+        if model_class in RATING_CAPABLE_TAGGER_CLASSES:
+            inferred = [*inferred, TaskCapability.RATINGS]
+            logger.debug(
+                f"モデル '{model_name}' (class={model_class}) は rating 対応 tagger のため "
+                f"RATINGS capability を付与"
+            )
+
+    logger.debug(f"モデル '{model_name}' のcapabilitiesをtypeから推論: {model_type} -> {inferred}")
+    return set(inferred)
+
+
 def get_model_capabilities(model_name: str) -> set[Any]:
     """モデル名からcapabilitiesを取得する。
 
@@ -328,6 +388,8 @@ def get_model_capabilities(model_name: str) -> set[Any]:
            Vision LLM は tags/captions/scores 全タスクをサポートするため全 capability を返す。
         2. 設定ファイル (config_registry) の `capabilities` フィールドが明示されていればそれを使う。
         3. 設定ファイルの `type` フィールドから推論する (tagger/scorer/captioner)。
+           `type == "tagger"` の場合は `class` フィールドも参照し、ratings 対応モデルなら
+           `RATINGS` capability も付与する (LoRAIro #365)。
         4. 解決できなければ WARNING を出して空 set を返す。
 
     Args:
@@ -359,17 +421,10 @@ def get_model_capabilities(model_name: str) -> set[Any]:
     capabilities_config = config_registry.get(model_name, "capabilities", [])
 
     if not capabilities_config:
-        # フォールバック: type フィールドから推論
-        model_type = config_registry.get(model_name, "type", "")
-        type_to_capabilities: dict[str, list[TaskCapability]] = {
-            "tagger": [TaskCapability.TAGS],
-            "scorer": [TaskCapability.SCORES],
-            "captioner": [TaskCapability.CAPTIONS],
-        }
-        inferred = type_to_capabilities.get(model_type, [])
-        if inferred:
-            logger.debug(f"モデル '{model_name}' のcapabilitiesをtypeから推論: {model_type} -> {inferred}")
-            return set(inferred)
+        # 3. フォールバック: type フィールドから推論
+        inferred_capabilities = _infer_capabilities_from_type(model_name)
+        if inferred_capabilities is not None:
+            return inferred_capabilities
 
         logger.warning(f"モデル '{model_name}' のcapabilitiesが設定されていません")
         return set()

--- a/tests/unit/test_capability_utils.py
+++ b/tests/unit/test_capability_utils.py
@@ -107,9 +107,7 @@ class TestGetModelCapabilities:
         assert capabilities == {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
 
     @patch("image_annotator_lib.core.registry.get_webapi_metadata")
-    def test_get_model_capabilities_webapi_respects_explicit_ratings(
-        self, mock_get_webapi_metadata
-    ):
+    def test_get_model_capabilities_webapi_respects_explicit_ratings(self, mock_get_webapi_metadata):
         """Issue #82: WebAPI metadata can explicitly request rating capability."""
         mock_get_webapi_metadata.return_value = {
             "api_model_id": "openai/gpt-4o",
@@ -121,3 +119,69 @@ class TestGetModelCapabilities:
         capabilities = get_model_capabilities("gpt-4o-rating")
 
         assert capabilities == {TaskCapability.TAGS, TaskCapability.RATINGS}
+
+    @patch("image_annotator_lib.core.config.config_registry")
+    def test_type_fallback_rating_capable_wd_tagger_includes_ratings(self, mock_config_registry):
+        """LoRAIro #365: type 推論フォールバックで WDTagger は RATINGS も含める。
+
+        ユーザー側 `config/annotator_config.toml` が古く `capabilities` 未指定でも、
+        `class = "WDTagger"` であれば rating output を保持する。
+        """
+        # 1回目: capabilities=[] (未設定), 2回目: type="tagger", 3回目: class="WDTagger"
+        mock_config_registry.get.side_effect = [[], "tagger", "WDTagger"]
+
+        capabilities = get_model_capabilities("wd-vit-tagger-v3")
+
+        assert capabilities == {TaskCapability.TAGS, TaskCapability.RATINGS}
+
+    @patch("image_annotator_lib.core.config.config_registry")
+    def test_type_fallback_rating_capable_z3d_tagger_includes_ratings(self, mock_config_registry):
+        """LoRAIro #365: Z3D_E621Tagger も rating 対応として扱う。"""
+        mock_config_registry.get.side_effect = [[], "tagger", "Z3D_E621Tagger"]
+
+        capabilities = get_model_capabilities("Z3D-E621-Convnext")
+
+        assert capabilities == {TaskCapability.TAGS, TaskCapability.RATINGS}
+
+    @patch("image_annotator_lib.core.config.config_registry")
+    def test_type_fallback_rating_capable_camie_tagger_includes_ratings(self, mock_config_registry):
+        """LoRAIro #365: CamieTagger も rating 対応として扱う。"""
+        mock_config_registry.get.side_effect = [[], "tagger", "CamieTagger"]
+
+        capabilities = get_model_capabilities("camie_tagger_initial")
+
+        assert capabilities == {TaskCapability.TAGS, TaskCapability.RATINGS}
+
+    @patch("image_annotator_lib.core.config.config_registry")
+    def test_type_fallback_tags_only_tagger_excludes_ratings(self, mock_config_registry):
+        """LoRAIro #365: rating 非対応 tagger (DeepDanbooruTagger) は TAGS のみ。
+
+        DeepDanbooru モデルは rating index/source_scheme を持たないので、
+        type 推論フォールバックでも RATINGS は付かない。
+        """
+        mock_config_registry.get.side_effect = [[], "tagger", "DeepDanbooruTagger"]
+
+        capabilities = get_model_capabilities("deepdanbooru-v3-20211112-sgd-e28")
+
+        assert capabilities == {TaskCapability.TAGS}
+
+    @patch("image_annotator_lib.core.config.config_registry")
+    def test_type_fallback_tagger_without_class_field_excludes_ratings(self, mock_config_registry):
+        """class フィールド未設定の tagger は TAGS のみ (安全側にフォールバック)。"""
+        mock_config_registry.get.side_effect = [[], "tagger", ""]
+
+        capabilities = get_model_capabilities("unknown-tagger")
+
+        assert capabilities == {TaskCapability.TAGS}
+
+    @patch("image_annotator_lib.core.config.config_registry")
+    def test_explicit_capabilities_override_class_based_fallback(self, mock_config_registry):
+        """明示 capabilities が指定されていれば class ベースフォールバックは適用しない。
+
+        例: WDTagger ベースだが ratings を意図的に無効化したい場合。
+        """
+        mock_config_registry.get.return_value = ["tags"]
+
+        capabilities = get_model_capabilities("wd-vit-tagger-v3-tags-only")
+
+        assert capabilities == {TaskCapability.TAGS}


### PR DESCRIPTION
## Summary

`get_model_capabilities()` の type 推論フォールバックで、`WDTagger` / `Z3D_E621Tagger` / `CamieTagger` ベースの rating 対応ローカル tagger が `TAGS` だけに落ちる問題を解消する。LoRAIro WinネイティブGUIのバッチアノテーションログで `capabilitiesをtypeから推論: tagger -> [TAGS]` として記録されている振る舞いに該当する。

## Changes

### 1. `config/annotator_config.toml`
Rating output 可能な tagger エントリ (idolsankaku-eva02 / idolsankaku-swinv2 / Z3D-E621-Convnext / wd-v1-4-* / wd-vit-tagger-v3) に `capabilities = ["tags", "ratings"]` を明示追加。SSoT として明確化。

### 2. `src/image_annotator_lib/core/utils.py`
- `_infer_capabilities_from_type()` を切り出し、`get_model_capabilities()` から呼ぶ形にリファクタ。
- `RATING_CAPABLE_TAGGER_CLASSES = frozenset({"WDTagger", "Z3D_E621Tagger", "CamieTagger"})` を導入。
- type 推論時に `class` フィールドが該当すれば `RATINGS` capability を自動付与。

### 3. `tests/unit/test_capability_utils.py`
6 件のテスト追加:
- WDTagger / Z3D_E621Tagger / CamieTagger の class fallback で RATINGS 付与
- DeepDanbooruTagger は TAGS のみ (rating 非対応の負例)
- class 未設定の tagger は TAGS のみ (安全側にフォールバック)
- 明示 capabilities は class fallback を override する

## 採用アプローチと根拠

**dual approach** (config TOML 明示 + class-name fallback) を採用しました。

| 案 | 利点 | 欠点 |
|---|---|---|
| (a) config TOML のみ | SSoT 明確、モデル個別制御 | user_config.toml が古いと反映されない |
| (b) `type_to_capabilities` 拡張 (`"tagger": [TAGS, RATINGS]`) | コード 1 行追加で済む | DeepDanbooru 等 rating 非対応 tagger まで誤って RATINGS 持ちに |
| **採用: (a) + class-name fallback** | (a) を SSoT としつつ、古い user config への保険 | コード行数増 |

(b) 単独は `DeepDanbooruTagger` のような rating 非対応 model class まで RATINGS にしてしまうため不採用。class-name allowlist (`RATING_CAPABLE_TAGGER_CLASSES`) で rating 対応 model class のみ明示的に補強。

## Verification

- `tests/unit/test_capability_utils.py` 全 15 件 pass (既存 9 + 新規 6)
- CI-equivalent filter `-m "not downloads_and_runs_model and not calls_real_webapi"` で iam-lib 全 705 件 pass、regression なし
- Ruff format + check ともにクリーン

## Refs

- 発端 issue: NEXTAltair/LoRAIro#365
- 親 cluster: NEXTAltair/LoRAIro#364

🤖 Generated with [Claude Code](https://claude.com/claude-code)