### PR TITLE
fix: preserve local rating model capabilities

### DIFF
--- a/src/image_annotator_lib/core/utils.py
+++ b/src/image_annotator_lib/core/utils.py
@@ -21,6 +21,28 @@ DEFAULT_TIMEOUT = 30
 WD_MODEL_FILENAME = "model.onnx"
 WD_LABEL_FILENAME = "selected_tags.csv"
 
+# Canonical capabilities for local models that existed before the runtime
+# config gained an explicit `capabilities` field. This keeps old user
+# config/annotator_config.toml files from falling back to `type = "tagger"`
+# and losing RATINGS support.
+_KNOWN_LOCAL_MODEL_CAPABILITIES: dict[str, tuple[str, ...]] = {
+    "idolsankaku-eva02-large-tagger-v1": ("tags", "ratings"),
+    "idolsankaku-swinv2-tagger-v1": ("tags", "ratings"),
+    "Z3D-E621-Convnext": ("tags", "ratings"),
+    "anime_rating_mobilenetv3_sce_dist": ("ratings",),
+    "anime_rating_caformer_s36_plus": ("ratings",),
+    "camie_tagger_initial": ("tags", "ratings"),
+    "wd-v1-4-convnext-tagger-v2": ("tags", "ratings"),
+    "wd-v1-4-convnextv2-tagger-v2": ("tags", "ratings"),
+    "wd-v1-4-moat-tagger-v2": ("tags", "ratings"),
+    "wd-v1-4-swinv2-tagger-v2": ("tags", "ratings"),
+    "wd-vit-tagger-v3": ("tags", "ratings"),
+    "wd-convnext-tagger-v3": ("tags", "ratings"),
+    "wd-swinv2-tagger-v3": ("tags", "ratings"),
+    "wd-vit-large-tagger-v3": ("tags", "ratings"),
+    "wd-eva02-large-tagger-v3": ("tags", "ratings"),
+}
+
 # Explicitly export logger and other public functions
 __all__ = [
     "calculate_phash",
@@ -359,6 +381,14 @@ def get_model_capabilities(model_name: str) -> set[Any]:
     capabilities_config = config_registry.get(model_name, "capabilities", [])
 
     if not capabilities_config:
+        known_capabilities = _KNOWN_LOCAL_MODEL_CAPABILITIES.get(model_name)
+        if known_capabilities is not None:
+            logger.debug(
+                f"モデル '{model_name}' のcapabilitiesを既知ローカルモデル定義から補完: "
+                f"{list(known_capabilities)}"
+            )
+            return {TaskCapability(cap) for cap in known_capabilities}
+
         # フォールバック: type フィールドから推論
         model_type = config_registry.get(model_name, "type", "")
         type_to_capabilities: dict[str, list[TaskCapability]] = {

--- a/tests/unit/test_capability_utils.py
+++ b/tests/unit/test_capability_utils.py
@@ -121,3 +121,48 @@ class TestGetModelCapabilities:
         capabilities = get_model_capabilities("gpt-4o-rating")
 
         assert capabilities == {TaskCapability.TAGS, TaskCapability.RATINGS}
+
+    @patch("image_annotator_lib.core.registry.get_webapi_metadata", return_value=None)
+    @patch("image_annotator_lib.core.config.config_registry")
+    def test_known_local_rating_tagger_keeps_ratings_when_old_config_has_no_capabilities(
+        self, mock_config_registry, _mock_get_webapi_metadata
+    ):
+        """Issue #365: old runtime config lacks capabilities for known rating taggers."""
+        mock_config_registry.get.side_effect = lambda _model, key, default=None: {
+            "capabilities": [],
+            "type": "tagger",
+        }.get(key, default)
+
+        capabilities = get_model_capabilities("wd-vit-tagger-v3")
+
+        assert capabilities == {TaskCapability.TAGS, TaskCapability.RATINGS}
+
+    @patch("image_annotator_lib.core.registry.get_webapi_metadata", return_value=None)
+    @patch("image_annotator_lib.core.config.config_registry")
+    def test_known_local_rating_only_model_keeps_ratings_when_old_config_has_no_capabilities(
+        self, mock_config_registry, _mock_get_webapi_metadata
+    ):
+        """Issue #365: ratings-only local models must not be inferred as tags-only."""
+        mock_config_registry.get.side_effect = lambda _model, key, default=None: {
+            "capabilities": [],
+            "type": "tagger",
+        }.get(key, default)
+
+        capabilities = get_model_capabilities("anime_rating_mobilenetv3_sce_dist")
+
+        assert capabilities == {TaskCapability.RATINGS}
+
+    @patch("image_annotator_lib.core.registry.get_webapi_metadata", return_value=None)
+    @patch("image_annotator_lib.core.config.config_registry")
+    def test_unknown_local_tagger_stays_tags_only_when_capabilities_missing(
+        self, mock_config_registry, _mock_get_webapi_metadata
+    ):
+        """Issue #365: do not promote unknown taggers to ratings capability."""
+        mock_config_registry.get.side_effect = lambda _model, key, default=None: {
+            "capabilities": [],
+            "type": "tagger",
+        }.get(key, default)
+
+        capabilities = get_model_capabilities("custom-tags-only-model")
+
+        assert capabilities == {TaskCapability.TAGS}


### PR DESCRIPTION
## Summary
- Add canonical fallback capabilities for known local rating-capable models when an older runtime annotator_config lacks explicit capabilities
- Keep unknown tagger models on the existing type-based tags-only fallback
- Add regression tests for known rating taggers, ratings-only local models, and unknown taggers

## Tests
- uv run pytest local_packages/image-annotator-lib/tests/unit/test_capability_utils.py
- uv run ruff check local_packages/image-annotator-lib/src/image_annotator_lib/core/utils.py local_packages/image-annotator-lib/tests/unit/test_capability_utils.py
- uv run python -c 'from image_annotator_lib.core.config import config_registry; from image_annotator_lib.core.utils import get_model_capabilities; config_registry.load(config_path="/workspaces/LoRAIro/config/annotator_config.toml"); names=["idolsankaku-eva02-large-tagger-v1","Z3D-E621-Convnext","wd-vit-tagger-v3","anime_rating_mobilenetv3_sce_dist"]; print({n: sorted(c.value for c in get_model_capabilities(n)) for n in names})'