### PR TITLE
test: isolate system config writes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,61 @@ sys.path.insert(0, str(tests_dir))
 # from unit.fixtures.shared_fixtures import *
 
 
+def _remove_test_config_entries(config_registry) -> None:
+    """共有 config registry からテスト専用モデルを取り除く。"""
+    for config_store_name in (
+        "_system_config_data",
+        "_user_config_data",
+        "_merged_config_data",
+    ):
+        config_store = getattr(config_registry, config_store_name, {})
+        if isinstance(config_store, dict):
+            test_models = [k for k in config_store if "test" in k.lower() or k == "dummy-model"]
+            for model in test_models:
+                config_store.pop(model, None)
+
+
+@pytest.fixture(autouse=True)
+def isolate_system_config(monkeypatch, tmp_path):
+    """テスト中の system config 永続化先を一時ファイルに隔離する。"""
+    import copy
+
+    from image_annotator_lib.core import config as config_module
+    from image_annotator_lib.core.config import _load_config_from_file, config_registry
+
+    original_system_path = config_registry._system_config_path
+    original_user_path = config_registry._user_config_path
+    original_system_config = copy.deepcopy(config_registry._system_config_data)
+    original_user_config = copy.deepcopy(config_registry._user_config_data)
+    original_merged_config = copy.deepcopy(config_registry._merged_config_data)
+
+    isolated_system_path = tmp_path / "config" / "annotator_config.toml"
+    isolated_user_path = tmp_path / "config" / "user_config.toml"
+    isolated_system_path.parent.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        config_module,
+        "DEFAULT_PATHS",
+        {
+            **config_module.DEFAULT_PATHS,
+            "config_toml": isolated_system_path,
+            "user_config_toml": isolated_user_path,
+        },
+    )
+    config_registry._system_config_path = isolated_system_path
+    config_registry._user_config_path = isolated_user_path
+    _load_config_from_file.cache_clear()
+
+    yield
+
+    config_registry._system_config_path = original_system_path
+    config_registry._user_config_path = original_user_path
+    config_registry._system_config_data = original_system_config
+    config_registry._user_config_data = original_user_config
+    config_registry._merged_config_data = original_merged_config
+    _load_config_from_file.cache_clear()
+
+
 @pytest.fixture(autouse=True)
 def reset_global_state(request):
     """各テスト前後でグローバル状態をリセット"""
@@ -70,6 +125,7 @@ def reset_global_state(request):
                 test_models = [k for k in config_registry._config.keys() if "test" in k.lower()]
                 for model in test_models:
                     config_registry._config.pop(model, None)
+            _remove_test_config_entries(config_registry)
 
         except ImportError:
             # モジュールがまだロードされていない場合はスキップ

--- a/tests/unit/fast/test_config.py
+++ b/tests/unit/fast/test_config.py
@@ -10,6 +10,7 @@ from image_annotator_lib.core import config as config_module
 from image_annotator_lib.core.config import (
     ModelConfigRegistry,
     _load_config_from_file,
+    config_registry,
 )
 
 # Import shared fixtures
@@ -189,6 +190,18 @@ def test_save_user_config(registry, tmp_path):
     assert data["new_model"]["key"] == "value"
 
 
+@pytest.mark.fast
+def test_add_default_setting_does_not_modify_project_system_config():
+    """Regression test for Issue #95: test stubs must not persist to real config."""
+    project_system_config = Path("config/annotator_config.toml")
+    original_content = project_system_config.read_text(encoding="utf-8")
+
+    config_registry.add_default_setting("test_stub_model", "class", "TestOnlyAnnotator")
+
+    assert project_system_config.read_text(encoding="utf-8") == original_content
+    assert "test_stub_model" in config_registry._system_config_data
+
+
 # --- Tests for Standalone Functions ---
 
 
@@ -204,7 +217,7 @@ def test_load_config_from_file_errors(tmp_path):
         f.write("this is not toml")
 
     # It should re-raise the exception
-    with pytest.raises(Exception):
+    with pytest.raises(toml.TomlDecodeError):
         _load_config_from_file(bad_toml_path)
 
 

--- a/tests/unit/standard/core/base/test_annotator.py
+++ b/tests/unit/standard/core/base/test_annotator.py
@@ -23,16 +23,15 @@ def setup_test_model_config():
         "capabilities": ["tags"],
     }
     for key, value in config.items():
-        config_registry.add_default_setting("test_model", key, value)
-
-    # Store original get_all_config for potential restoration
-    original_get_all_config = config_registry.get_all_config
+        config_registry.set_system_value("test_model", key, value)
 
     yield
 
     # Cleanup
     try:
-        config_registry._config.pop("test_model", None)
+        config_registry._system_config_data.pop("test_model", None)
+        config_registry._user_config_data.pop("test_model", None)
+        config_registry._merged_config_data.pop("test_model", None)
     except (AttributeError, KeyError):
         pass
 
@@ -397,7 +396,7 @@ class TestBaseAnnotator:
     @pytest.mark.standard
     def test_abstract_methods_not_implemented(self):
         """抽象メソッドが実装されていない場合のテスト"""
-        with patch("image_annotator_lib.core.base.annotator.config_registry") as mock_config:
+        with patch("image_annotator_lib.core.base.annotator.config_registry"):
             # BaseAnnotator を直接インスタンス化しようとするとエラーになることを確認
             with pytest.raises(TypeError):
                 BaseAnnotator("test_model")  # type: ignore

--- a/tests/unit/standard/core/base/test_transfomers.py
+++ b/tests/unit/standard/core/base/test_transfomers.py
@@ -6,6 +6,7 @@ from PIL import Image
 
 from image_annotator_lib.core.base.transformers import TransformersBaseAnnotator
 from image_annotator_lib.core.types import UnifiedAnnotationResult
+from image_annotator_lib.exceptions.errors import ConfigurationError
 
 
 @pytest.fixture(autouse=True)
@@ -20,13 +21,15 @@ def setup_dummy_model_config():
         "capabilities": ["tags", "captions"],
     }
     for key, value in config.items():
-        config_registry.add_default_setting("dummy-model", key, value)
+        config_registry.set_system_value("dummy-model", key, value)
 
     yield
 
     # Cleanup
     try:
-        config_registry._config.pop("dummy-model", None)
+        config_registry._system_config_data.pop("dummy-model", None)
+        config_registry._user_config_data.pop("dummy-model", None)
+        config_registry._merged_config_data.pop("dummy-model", None)
     except (AttributeError, KeyError):
         pass
 
@@ -140,7 +143,7 @@ def test_preprocess_images_no_processor():
     annotator = DummyTransformersAnnotator("dummy-model")
     if annotator.components is not None:
         annotator.components.pop("processor", None)
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurationError):
         annotator._preprocess_images([Image.new("RGB", (32, 32))])
 
 
@@ -150,7 +153,7 @@ def test_run_inference_no_model():
     if annotator.components is not None:
         annotator.components["model"] = None
     mock_tensor = MagicMock()
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         annotator._run_inference([{"input_ids": mock_tensor}])
 
 
@@ -160,7 +163,7 @@ def test_format_predictions_no_processor():
     if annotator.components is not None:
         annotator.components["processor"] = None
     mock_tensor = MagicMock()
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         annotator._format_predictions([mock_tensor])
 
 

--- a/tests/unit/standard/core/test_base.py
+++ b/tests/unit/standard/core/test_base.py
@@ -45,12 +45,16 @@ def setup_test_base_annotator_config():
         "class": "ConcreteAnnotator",
     }
     for key, value in config.items():
-        config_registry.add_default_setting(test_model_name, key, value)
+        config_registry.set_system_value(test_model_name, key, value)
 
     yield
 
     # Cleanup after test
     try:
+        system_data = getattr(config_registry, "_system_config_data", {})
+        system_data.pop(test_model_name, None)
+        user_data = getattr(config_registry, "_user_config_data", {})
+        user_data.pop(test_model_name, None)
         merged_data = getattr(config_registry, "_merged_config_data", {})
         merged_data.pop(test_model_name, None)
     except (AttributeError, KeyError):
@@ -87,7 +91,7 @@ def setup_test_transformers_config():
         "class": "TransformersBaseAnnotator",
     }
     for key, value in config.items():
-        config_registry.add_default_setting(test_model_name, key, value)
+        config_registry.set_system_value(test_model_name, key, value)
 
     yield
 


### PR DESCRIPTION
## Summary

- Isolate test-time system/user config persistence to per-test temp paths.
- Replace setup-only `add_default_setting()` calls with in-memory `set_system_value()` in affected standard tests.
- Add a regression test that proves `config/annotator_config.toml` is not modified by test stub registration.

## Root Cause

Several test fixtures used `config_registry.add_default_setting(...)` for setup. That API persists `_system_config_data` via `save_system_config()`, so pytest could write test-only model stubs back into the real project system catalog.

## Validation

- `uv run ruff check tests/conftest.py tests/unit/fast/test_config.py tests/unit/standard/core/test_base.py tests/unit/standard/core/base/test_annotator.py tests/unit/standard/core/base/test_transfomers.py`
- `uv run pytest tests/unit/fast/test_config.py tests/unit/standard/core/test_base.py tests/unit/standard/core/base/test_annotator.py tests/unit/standard/core/base/test_transfomers.py` (`49 passed`)
- `uv run pytest -m "not downloads_and_runs_model and not calls_real_webapi"` (`706 passed, 11 deselected`)
- `git diff -- config/annotator_config.toml config/user_config.toml` is empty after pytest.

Fixes #95