### PR TITLE
fix(config): union system and user capabilities

### DIFF
--- a/src/image_annotator_lib/core/config.py
+++ b/src/image_annotator_lib/core/config.py
@@ -148,10 +148,32 @@ class ModelConfigRegistry:
         self._merged_config_data = copy.deepcopy(self._system_config_data)
         for model_name, user_model_config in self._user_config_data.items():
             if model_name in self._merged_config_data:
-                self._merged_config_data[model_name].update(copy.deepcopy(user_model_config))
+                merged_model_config = self._merged_config_data[model_name]
+                system_capabilities = merged_model_config.get("capabilities")
+                user_capabilities = user_model_config.get("capabilities")
+
+                merged_model_config.update(copy.deepcopy(user_model_config))
+                if system_capabilities is not None or user_capabilities is not None:
+                    merged_model_config["capabilities"] = self._merge_capabilities(
+                        system_capabilities,
+                        user_capabilities,
+                    )
             else:
                 self._merged_config_data[model_name] = copy.deepcopy(user_model_config)
         logger.debug("システム設定とユーザー設定をディープコピーでマージしました。")
+
+    @staticmethod
+    def _merge_capabilities(system_capabilities: Any, user_capabilities: Any) -> list[Any]:
+        """Merge capability declarations without letting user config remove system capabilities."""
+        merged: list[Any] = []
+        for capability_source in (system_capabilities, user_capabilities):
+            if capability_source is None:
+                continue
+            capabilities = capability_source if isinstance(capability_source, list) else [capability_source]
+            for capability in capabilities:
+                if capability not in merged:
+                    merged.append(copy.deepcopy(capability))
+        return merged
 
     def get(self, model_name: str, key: str, default: Any = None) -> Any | None:
         """指定されたモデルとキーに対応するマージ済みの設定値を取得します。"""

--- a/tests/unit/fast/test_config.py
+++ b/tests/unit/fast/test_config.py
@@ -149,6 +149,94 @@ def test_merge_configs(registry):
 
 
 @pytest.mark.fast
+def test_merge_configs_unions_builtin_model_capabilities(registry):
+    """Built-in model capabilities are additive across system and user config."""
+    registry._system_config_data = {
+        "wd-vit-tagger-v3": {
+            "type": "tagger",
+            "class": "WDTagger",
+            "capabilities": ["tags", "ratings"],
+        }
+    }
+    registry._user_config_data = {
+        "wd-vit-tagger-v3": {
+            "device": "cuda:0",
+            "capabilities": ["tags"],
+        }
+    }
+
+    registry._merge_configs()
+
+    assert registry.get("wd-vit-tagger-v3", "capabilities") == ["tags", "ratings"]
+    assert registry.get("wd-vit-tagger-v3", "device") == "cuda:0"
+
+
+@pytest.mark.fast
+def test_merge_configs_adds_user_capabilities_without_dropping_system_capabilities(registry):
+    """User config may add capabilities, but cannot remove system-declared ones."""
+    registry._system_config_data = {"canonical-scorer": {"capabilities": ["scores"]}}
+    registry._user_config_data = {"canonical-scorer": {"capabilities": ["score_labels"]}}
+
+    registry._merge_configs()
+
+    assert registry.get("canonical-scorer", "capabilities") == ["scores", "score_labels"]
+
+
+@pytest.mark.fast
+def test_merge_configs_custom_model_uses_user_defined_capabilities(registry):
+    """Custom local models without a system entry keep user-defined capabilities."""
+    registry._system_config_data = {}
+    registry._user_config_data = {
+        "custom-rating-model": {
+            "type": "tagger",
+            "class": "CustomTagger",
+            "capabilities": ["ratings"],
+        }
+    }
+
+    registry._merge_configs()
+
+    assert registry.get("custom-rating-model", "capabilities") == ["ratings"]
+
+
+@pytest.mark.fast
+def test_merge_configs_keeps_user_override_for_non_capability_fields(registry):
+    """Only capabilities are unioned; other fields retain user override semantics."""
+    registry._system_config_data = {
+        "wd-vit-tagger-v3": {
+            "device": "cpu",
+            "model_path": "/system/model.onnx",
+            "capabilities": ["tags", "ratings"],
+        }
+    }
+    registry._user_config_data = {
+        "wd-vit-tagger-v3": {
+            "device": "cuda:0",
+            "capabilities": ["tags"],
+        }
+    }
+
+    registry._merge_configs()
+
+    assert registry.get("wd-vit-tagger-v3", "device") == "cuda:0"
+    assert registry.get("wd-vit-tagger-v3", "model_path") == "/system/model.onnx"
+    assert registry.get("wd-vit-tagger-v3", "capabilities") == ["tags", "ratings"]
+
+
+@pytest.mark.fast
+def test_merge_configs_capability_union_does_not_mutate_sources(registry):
+    """Capability union uses copied values and leaves source configs untouched."""
+    registry._system_config_data = {"model": {"capabilities": ["tags", "ratings"]}}
+    registry._user_config_data = {"model": {"capabilities": ["tags"]}}
+
+    registry._merge_configs()
+    registry._merged_config_data["model"]["capabilities"].append("scores")
+
+    assert registry._system_config_data["model"]["capabilities"] == ["tags", "ratings"]
+    assert registry._user_config_data["model"]["capabilities"] == ["tags"]
+
+
+@pytest.mark.fast
 def test_get_value(registry):
     """Test the get method for retrieving config values."""
     registry._merged_config_data = MOCK_MERGED_CONFIG


### PR DESCRIPTION
## Summary
- merge built-in local model capabilities as a union of system and user config values
- preserve existing user override behavior for non-capability fields
- add regression coverage for rating-capable models, user-added capabilities, custom models, and source immutability

## Tests
- uv run pytest tests/unit/fast/test_config.py tests/unit/test_capability_utils.py tests/unit/fast/test_list_annotator_info.py
- uv run pytest -m "not downloads_and_runs_model and not calls_real_webapi"
- uv run ruff check src/image_annotator_lib/core/config.py tests/unit/fast/test_config.py
- uv run ruff format --check src/image_annotator_lib/core/config.py tests/unit/fast/test_config.py
- git diff --check
- git diff -- config/annotator_config.toml

Closes #96
Related #79