### PR TITLE
fix(config): cache runtime model sizes separately

### DIFF
--- a/src/image_annotator_lib/__init__.py
+++ b/src/image_annotator_lib/__init__.py
@@ -17,6 +17,7 @@ from .core.api_model_discovery import (
 from .core.config import config_registry
 from .core.constants import (
     DEFAULT_PATHS,
+    MODEL_RUNTIME_CACHE_PATH,
     SYSTEM_CONFIG_PATH,
     USER_CONFIG_PATH,
 )
@@ -34,6 +35,7 @@ from .exceptions.errors import AnnotatorError, ModelLoadError, ModelNotFoundErro
 # get_available_models / list_all_models / is_model_deprecated は LiteLLM runtime call に切替。
 __all__ = [
     "DEFAULT_PATHS",
+    "MODEL_RUNTIME_CACHE_PATH",
     "SYSTEM_CONFIG_PATH",
     "USER_CONFIG_PATH",
     "AnnotationResult",

--- a/src/image_annotator_lib/core/config.py
+++ b/src/image_annotator_lib/core/config.py
@@ -13,6 +13,8 @@ from .constants import (
 )
 from .utils import logger
 
+RUNTIME_MODEL_METADATA_KEYS = frozenset({"estimated_size_gb"})
+
 
 @lru_cache
 def _load_config_from_file(config_path: Path) -> dict[str, dict[str, Any]]:
@@ -40,23 +42,32 @@ class ModelConfigRegistry:
     def __init__(self) -> None:
         """初期化時に設定データを空の辞書で初期化します。"""
         self._system_config_data: dict[str, dict[str, Any]] = {}
+        self._runtime_cache_data: dict[str, dict[str, Any]] = {}
         self._user_config_data: dict[str, dict[str, Any]] = {}
         self._merged_config_data: dict[str, dict[str, Any]] = {}
         self._system_config_path: Path | None = None
+        self._runtime_cache_path: Path | None = None
         self._user_config_path: Path | None = None
 
     def _determine_config_paths(
         self,
         config_path: str | Path | None = None,
         user_config_path: str | Path | None = None,
+        runtime_cache_path: str | Path | None = None,
     ) -> None:
         """システム設定とユーザー設定のパスを決定し、インスタンス変数に格納する。"""
         self._system_config_path = Path(config_path if config_path else DEFAULT_PATHS["config_toml"])
         self._user_config_path = Path(
             user_config_path if user_config_path else DEFAULT_PATHS["user_config_toml"]
         )
+        self._runtime_cache_path = Path(
+            runtime_cache_path
+            if runtime_cache_path
+            else DEFAULT_PATHS["model_runtime_cache_toml"]
+        )
         logger.debug(f"システム設定パスを決定: {self._system_config_path}")
         logger.debug(f"ユーザー設定パスを決定: {self._user_config_path}")
+        logger.debug(f"モデル runtime cache パスを決定: {self._runtime_cache_path}")
 
     def _ensure_system_config_exists(self) -> None:
         """システム設定ファイルが存在しない場合、テンプレートからコピーする。"""
@@ -129,23 +140,70 @@ class ModelConfigRegistry:
                 f"ユーザー設定ファイル {self._user_config_path} が存在しないかパスが指定されていません。"
             )
 
+    @staticmethod
+    def _filter_runtime_cache_data(config_data: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        """Runtime cache から許可された runtime-derived metadata だけを抽出する。"""
+        runtime_cache_data: dict[str, dict[str, Any]] = {}
+        for model_name, model_config in config_data.items():
+            if not isinstance(model_config, dict):
+                continue
+            filtered_config = {
+                key: copy.deepcopy(value)
+                for key, value in model_config.items()
+                if key in RUNTIME_MODEL_METADATA_KEYS
+            }
+            if filtered_config:
+                runtime_cache_data[model_name] = filtered_config
+        return runtime_cache_data
+
+    def _load_and_set_runtime_cache(self) -> None:
+        """Runtime-derived model metadata cache を読み込み、内部状態を更新する。"""
+        self._runtime_cache_data = {}
+        if self._runtime_cache_path is not None and self._runtime_cache_path.exists():
+            if self._runtime_cache_path.is_file():
+                try:
+                    loaded_data = _load_config_from_file(self._runtime_cache_path)
+                    self._runtime_cache_data = self._filter_runtime_cache_data(loaded_data)
+                    logger.info(
+                        f"モデル runtime cache を {self._runtime_cache_path} から読み込みました。"
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"モデル runtime cache {self._runtime_cache_path} の読み込み中にエラー: {e}"
+                    )
+                    self._runtime_cache_data = {}
+            else:
+                logger.warning(
+                    f"モデル runtime cache パス {self._runtime_cache_path} はファイルではありません。読み込みをスキップします。"
+                )
+        else:
+            logger.debug(
+                f"モデル runtime cache {self._runtime_cache_path} が存在しないかパスが指定されていません。"
+            )
+
     def load(
         self,
         config_path: str | Path | None = None,
         user_config_path: str | Path | None = None,
+        runtime_cache_path: str | Path | None = None,
     ) -> None:
         """システム設定ファイルとユーザー設定ファイルを読み込み、内部データを更新します。"""
         logger.info("設定ファイルの読み込みを開始します...")
-        self._determine_config_paths(config_path, user_config_path)
+        self._determine_config_paths(config_path, user_config_path, runtime_cache_path)
         self._ensure_system_config_exists()
         self._load_and_set_system_config()
+        self._load_and_set_runtime_cache()
         self._load_and_set_user_config()
         self._merge_configs()
         logger.info("設定ファイルの読み込みが完了しました。")
 
     def _merge_configs(self) -> None:
-        """システム設定とユーザー設定をマージして _merged_config_data を作成 (Deep Copyを使用)"""
+        """システム、runtime cache、ユーザー設定をマージして _merged_config_data を作成する。"""
         self._merged_config_data = copy.deepcopy(self._system_config_data)
+        for model_name, runtime_model_config in self._runtime_cache_data.items():
+            if model_name not in self._merged_config_data:
+                self._merged_config_data[model_name] = {}
+            self._merged_config_data[model_name].update(copy.deepcopy(runtime_model_config))
         for model_name, user_model_config in self._user_config_data.items():
             if model_name in self._merged_config_data:
                 merged_model_config = self._merged_config_data[model_name]
@@ -200,6 +258,17 @@ class ModelConfigRegistry:
             self._system_config_data[model_name] = {}
         self._system_config_data[model_name][key] = value
         # Immediately update the merged view as well
+        self._merge_configs()
+
+    def set_runtime_cache_value(self, model_name: str, key: str, value: Any) -> None:
+        """指定されたモデルの runtime-derived metadata を runtime cache として更新します。"""
+        if key not in RUNTIME_MODEL_METADATA_KEYS:
+            logger.warning(f"モデル runtime cache に保存できないキーをスキップ: {key}")
+            return
+        logger.debug(f"モデル runtime cache を更新: モデル '{model_name}', キー '{key}', 値 '{value}'")
+        if model_name not in self._runtime_cache_data:
+            self._runtime_cache_data[model_name] = {}
+        self._runtime_cache_data[model_name][key] = value
         self._merge_configs()
 
     def add_default_setting(self, section_name: str, key: str, value: Any) -> None:
@@ -270,6 +339,31 @@ class ModelConfigRegistry:
         except Exception as e:
             logger.error(
                 f"ユーザー設定ファイル {save_path} の保存中にエラーが発生しました: {e}", exc_info=True
+            )
+
+    def save_runtime_cache(self, runtime_cache_path: str | Path | None = None) -> None:
+        """現在の runtime-derived model metadata cache を指定されたファイルパスに保存します。"""
+        save_path = Path(runtime_cache_path) if runtime_cache_path else self._runtime_cache_path
+
+        if save_path is None:
+            logger.error("モデル runtime cache の保存パスが指定されていません。保存をスキップします。")
+            return
+
+        if not self._runtime_cache_data:
+            logger.debug("保存すべきモデル runtime cache がありません。保存をスキップします。")
+            return
+
+        try:
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(save_path, "w", encoding="utf-8") as f:
+                toml.dump(self._runtime_cache_data, f)
+            _load_config_from_file.cache_clear()
+            logger.info(f"モデル runtime cache を {save_path} に保存しました。")
+
+        except Exception as e:
+            logger.error(
+                f"モデル runtime cache {save_path} の保存中にエラーが発生しました: {e}",
+                exc_info=True,
             )
 
     def save_system_config(self, system_config_path: str | Path | None = None) -> None:

--- a/src/image_annotator_lib/core/constants.py
+++ b/src/image_annotator_lib/core/constants.py
@@ -20,6 +20,8 @@ CACHE_DIR = PROJECT_ROOT / "models"
 SYSTEM_CONFIG_PATH = CONFIG_DIR / "annotator_config.toml"
 # ユーザー設定ファイルのパス (プロジェクトルート/config/user_config.toml)
 USER_CONFIG_PATH = CONFIG_DIR / "user_config.toml"
+# Runtime-derived model metadata cache (deletable local state)
+MODEL_RUNTIME_CACHE_PATH = CONFIG_DIR / "model_runtime_cache.toml"
 
 # ADR 0023 Phase 1 (Issue #35, PR #40): `AVAILABLE_API_MODELS_CONFIG_PATH` 定数は廃止。
 # WebAPI モデル一覧は `core/api_model_discovery.py` で LiteLLM 同梱 DB から runtime
@@ -28,6 +30,7 @@ USER_CONFIG_PATH = CONFIG_DIR / "user_config.toml"
 DEFAULT_PATHS = {
     "config_toml": SYSTEM_CONFIG_PATH,  # プロジェクト config
     "user_config_toml": USER_CONFIG_PATH,  # プロジェクト config
+    "model_runtime_cache_toml": MODEL_RUNTIME_CACHE_PATH,  # プロジェクト runtime state
     "log_file": LOG_DIR / "image-annotator-lib.log",  # プロジェクト logs
     "cache_dir": CACHE_DIR,  # プロジェクト models
 }

--- a/src/image_annotator_lib/core/loaders/loader_base.py
+++ b/src/image_annotator_lib/core/loaders/loader_base.py
@@ -220,16 +220,18 @@ class LoaderBase(ABC):
 
     @staticmethod
     def _save_size_to_config(model_name: str, size_mb: float) -> None:
-        """計算されたサイズを MB 単位で Config に保存する。"""
+        """計算されたサイズを MB 単位で runtime cache に保存する。"""
         if size_mb <= 0:
             return
         try:
             size_gb = size_mb / 1024
-            config_registry.set_system_value(model_name, "estimated_size_gb", round(size_gb, 3))
-            config_registry.save_system_config()
-            logger.debug(f"モデル '{model_name}' 計算サイズ ({size_gb:.3f}GB) をシステム設定に保存。")
+            config_registry.set_runtime_cache_value(
+                model_name, "estimated_size_gb", round(size_gb, 3)
+            )
+            config_registry.save_runtime_cache()
+            logger.debug(f"モデル '{model_name}' 計算サイズ ({size_gb:.3f}GB) を runtime cache に保存。")
         except Exception as e:
-            logger.error(f"モデル '{model_name}' サイズのシステム設定保存中にエラー: {e}", exc_info=True)
+            logger.error(f"モデル '{model_name}' サイズの runtime cache 保存中にエラー: {e}", exc_info=True)
 
     @classmethod
     def _get_or_calculate_size(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ def _remove_test_config_entries(config_registry) -> None:
     """共有 config registry からテスト専用モデルを取り除く。"""
     for config_store_name in (
         "_system_config_data",
+        "_runtime_cache_data",
         "_user_config_data",
         "_merged_config_data",
     ):
@@ -52,12 +53,15 @@ def isolate_system_config(monkeypatch, tmp_path):
     from image_annotator_lib.core.config import _load_config_from_file, config_registry
 
     original_system_path = config_registry._system_config_path
+    original_runtime_cache_path = config_registry._runtime_cache_path
     original_user_path = config_registry._user_config_path
     original_system_config = copy.deepcopy(config_registry._system_config_data)
+    original_runtime_cache = copy.deepcopy(config_registry._runtime_cache_data)
     original_user_config = copy.deepcopy(config_registry._user_config_data)
     original_merged_config = copy.deepcopy(config_registry._merged_config_data)
 
     isolated_system_path = tmp_path / "config" / "annotator_config.toml"
+    isolated_runtime_cache_path = tmp_path / "config" / "model_runtime_cache.toml"
     isolated_user_path = tmp_path / "config" / "user_config.toml"
     isolated_system_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -67,18 +71,22 @@ def isolate_system_config(monkeypatch, tmp_path):
         {
             **config_module.DEFAULT_PATHS,
             "config_toml": isolated_system_path,
+            "model_runtime_cache_toml": isolated_runtime_cache_path,
             "user_config_toml": isolated_user_path,
         },
     )
     config_registry._system_config_path = isolated_system_path
+    config_registry._runtime_cache_path = isolated_runtime_cache_path
     config_registry._user_config_path = isolated_user_path
     _load_config_from_file.cache_clear()
 
     yield
 
     config_registry._system_config_path = original_system_path
+    config_registry._runtime_cache_path = original_runtime_cache_path
     config_registry._user_config_path = original_user_path
     config_registry._system_config_data = original_system_config
+    config_registry._runtime_cache_data = original_runtime_cache
     config_registry._user_config_data = original_user_config
     config_registry._merged_config_data = original_merged_config
     _load_config_from_file.cache_clear()

--- a/tests/unit/core/test_model_factory.py
+++ b/tests/unit/core/test_model_factory.py
@@ -845,7 +845,7 @@ def test_calculate_transformer_size_mb_error():
 @pytest.mark.unit
 @pytest.mark.fast
 def test_save_size_to_config_success():
-    """Test saving calculated size to config."""
+    """Test saving calculated size to runtime cache."""
     model_name = "test-model"
     size_mb = 2048.0  # 2GB
     expected_size_gb = 2.0
@@ -853,10 +853,12 @@ def test_save_size_to_config_success():
     with patch("image_annotator_lib.core.loaders.loader_base.config_registry") as mock_config:
         ModelLoad._save_size_to_config(model_name, size_mb)
 
-        mock_config.set_system_value.assert_called_once_with(
+        mock_config.set_runtime_cache_value.assert_called_once_with(
             model_name, "estimated_size_gb", expected_size_gb
         )
-        mock_config.save_system_config.assert_called_once()
+        mock_config.save_runtime_cache.assert_called_once()
+        mock_config.set_system_value.assert_not_called()
+        mock_config.save_system_config.assert_not_called()
 
 
 @pytest.mark.unit
@@ -869,6 +871,8 @@ def test_save_size_to_config_zero_size():
     with patch("image_annotator_lib.core.loaders.loader_base.config_registry") as mock_config:
         ModelLoad._save_size_to_config(model_name, size_mb)
 
+        mock_config.set_runtime_cache_value.assert_not_called()
+        mock_config.save_runtime_cache.assert_not_called()
         mock_config.set_system_value.assert_not_called()
         mock_config.save_system_config.assert_not_called()
 

--- a/tests/unit/fast/test_config.py
+++ b/tests/unit/fast/test_config.py
@@ -39,10 +39,12 @@ def registry():
 def tmp_config_paths(tmp_path):
     """Create temporary config paths for testing."""
     system_path = tmp_path / "system" / "annotator_config.toml"
+    runtime_cache_path = tmp_path / "runtime" / "model_runtime_cache.toml"
     user_path = tmp_path / "user" / "user_config.toml"
     system_path.parent.mkdir()
+    runtime_cache_path.parent.mkdir()
     user_path.parent.mkdir()
-    return system_path, user_path
+    return system_path, runtime_cache_path, user_path
 
 
 # --- Tests for ModelConfigRegistry ---
@@ -52,6 +54,7 @@ def tmp_config_paths(tmp_path):
 def test_registry_init(registry):
     """Test that the registry initializes with empty dicts."""
     assert registry._system_config_data == {}
+    assert registry._runtime_cache_data == {}
     assert registry._user_config_data == {}
     assert registry._merged_config_data == {}
 
@@ -62,19 +65,27 @@ def test_determine_config_paths(registry, monkeypatch):
     monkeypatch.setattr(
         config_module,
         "DEFAULT_PATHS",
-        {"config_toml": "/default/system/config.toml", "user_config_toml": "/default/user/config.toml"},
+        {
+            "config_toml": "/default/system/config.toml",
+            "model_runtime_cache_toml": "/default/runtime/model_runtime_cache.toml",
+            "user_config_toml": "/default/user/config.toml",
+        },
     )
 
     # Test with default paths
     registry._determine_config_paths()
     assert registry._system_config_path == Path("/default/system/config.toml")
+    assert registry._runtime_cache_path == Path("/default/runtime/model_runtime_cache.toml")
     assert registry._user_config_path == Path("/default/user/config.toml")
 
     # Test with custom paths
     registry._determine_config_paths(
-        config_path="/custom/system.toml", user_config_path="/custom/user.toml"
+        config_path="/custom/system.toml",
+        runtime_cache_path="/custom/runtime.toml",
+        user_config_path="/custom/user.toml",
     )
     assert registry._system_config_path == Path("/custom/system.toml")
+    assert registry._runtime_cache_path == Path("/custom/runtime.toml")
     assert registry._user_config_path == Path("/custom/user.toml")
 
 
@@ -117,20 +128,25 @@ def test_ensure_system_config_exists_does_nothing(mock_copy, registry, tmp_path)
 @pytest.mark.fast
 def test_load_and_set_configs(registry, tmp_config_paths):
     """Test loading system and user configs."""
-    system_path, user_path = tmp_config_paths
+    system_path, runtime_cache_path, user_path = tmp_config_paths
 
     with open(system_path, "w") as f:
         toml.dump(MOCK_SYSTEM_CONFIG, f)
+    with open(runtime_cache_path, "w") as f:
+        toml.dump({"model-a": {"estimated_size_gb": 1.25, "device": "cpu"}}, f)
     with open(user_path, "w") as f:
         toml.dump(MOCK_USER_CONFIG, f)
 
     registry._system_config_path = system_path
+    registry._runtime_cache_path = runtime_cache_path
     registry._user_config_path = user_path
 
     registry._load_and_set_system_config()
+    registry._load_and_set_runtime_cache()
     registry._load_and_set_user_config()
 
     assert registry._system_config_data == MOCK_SYSTEM_CONFIG
+    assert registry._runtime_cache_data == {"model-a": {"estimated_size_gb": 1.25}}
     assert registry._user_config_data == MOCK_USER_CONFIG
 
 
@@ -146,6 +162,74 @@ def test_merge_configs(registry):
     # Ensure it's a deep copy
     registry._merged_config_data["annotator"]["device"] = "new_device"
     assert MOCK_SYSTEM_CONFIG["annotator"]["device"] == "cpu"
+
+
+@pytest.mark.fast
+def test_merge_configs_prefers_user_over_runtime_cache_over_system(registry):
+    """estimated_size_gb precedence is user > runtime cache > system."""
+    registry._system_config_data = {
+        "system-only": {"estimated_size_gb": 1.0},
+        "cached-model": {"estimated_size_gb": 1.0},
+        "user-model": {"estimated_size_gb": 1.0},
+    }
+    registry._runtime_cache_data = {
+        "cached-model": {"estimated_size_gb": 2.0},
+        "user-model": {"estimated_size_gb": 2.0},
+    }
+    registry._user_config_data = {"user-model": {"estimated_size_gb": 3.0}}
+
+    registry._merge_configs()
+
+    assert registry.get("system-only", "estimated_size_gb") == 1.0
+    assert registry.get("cached-model", "estimated_size_gb") == 2.0
+    assert registry.get("user-model", "estimated_size_gb") == 3.0
+
+
+@pytest.mark.fast
+def test_merge_configs_uses_system_size_when_runtime_cache_missing(registry):
+    """Missing runtime cache keeps annotator_config.toml value as fallback."""
+    registry._system_config_data = {"model": {"estimated_size_gb": 1.0}}
+    registry._runtime_cache_data = {}
+    registry._user_config_data = {}
+
+    registry._merge_configs()
+
+    assert registry.get("model", "estimated_size_gb") == 1.0
+
+
+@pytest.mark.fast
+def test_runtime_cache_filters_non_runtime_metadata(registry, tmp_path):
+    """Runtime cache is restricted to runtime-derived metadata."""
+    runtime_cache_path = tmp_path / "model_runtime_cache.toml"
+    with open(runtime_cache_path, "w") as f:
+        toml.dump(
+            {
+                "model": {
+                    "estimated_size_gb": 1.25,
+                    "device": "cuda:0",
+                    "capabilities": ["tags"],
+                }
+            },
+            f,
+        )
+
+    registry._runtime_cache_path = runtime_cache_path
+    registry._load_and_set_runtime_cache()
+
+    assert registry._runtime_cache_data == {"model": {"estimated_size_gb": 1.25}}
+
+
+@pytest.mark.fast
+def test_save_runtime_cache_persists_only_runtime_metadata(registry, tmp_path):
+    """Runtime cache writes are local deletable state, separate from system config."""
+    runtime_cache_path = tmp_path / "model_runtime_cache.toml"
+    registry._runtime_cache_path = runtime_cache_path
+
+    registry.set_runtime_cache_value("model", "estimated_size_gb", 2.5)
+    registry.set_runtime_cache_value("model", "device", "cuda:0")
+    registry.save_runtime_cache()
+
+    assert toml.load(runtime_cache_path) == {"model": {"estimated_size_gb": 2.5}}
 
 
 @pytest.mark.fast
@@ -288,6 +372,19 @@ def test_add_default_setting_does_not_modify_project_system_config():
 
     assert project_system_config.read_text(encoding="utf-8") == original_content
     assert "test_stub_model" in config_registry._system_config_data
+
+
+@pytest.mark.fast
+def test_runtime_size_cache_does_not_modify_project_system_config():
+    """Regression test for Issue #97: runtime size cache must not rewrite system catalog."""
+    project_system_config = Path("config/annotator_config.toml")
+    original_content = project_system_config.read_text(encoding="utf-8")
+
+    config_registry.set_runtime_cache_value("test_runtime_model", "estimated_size_gb", 2.0)
+    config_registry.save_runtime_cache()
+
+    assert project_system_config.read_text(encoding="utf-8") == original_content
+    assert config_registry.get("test_runtime_model", "estimated_size_gb") == 2.0
 
 
 # --- Tests for Standalone Functions ---

--- a/tests/unit/standard/core/test_model_factory_unit.py
+++ b/tests/unit/standard/core/test_model_factory_unit.py
@@ -102,10 +102,14 @@ def test_get_model_size_from_config_not_found(mock_config_registry):
 @pytest.mark.unit
 @patch("image_annotator_lib.core.loaders.loader_base.config_registry")
 def test_save_size_to_config(mock_config_registry):
-    """計算したモデルサイズを config に保存するテスト"""
+    """計算したモデルサイズを runtime cache に保存するテスト"""
     ModelLoad._save_size_to_config("test_model", 2048)  # 2GB
-    mock_config_registry.set_system_value.assert_called_once_with("test_model", "estimated_size_gb", 2.0)
-    mock_config_registry.save_system_config.assert_called_once()
+    mock_config_registry.set_runtime_cache_value.assert_called_once_with(
+        "test_model", "estimated_size_gb", 2.0
+    )
+    mock_config_registry.save_runtime_cache.assert_called_once()
+    mock_config_registry.set_system_value.assert_not_called()
+    mock_config_registry.save_system_config.assert_not_called()
 
 
 # --- Error Handling ---


### PR DESCRIPTION
## Summary

- Add `config/model_runtime_cache.toml` as deletable runtime state for computed local model metadata.
- Merge model config with `user_config.toml > model_runtime_cache.toml > annotator_config.toml` precedence.
- Save auto-calculated `estimated_size_gb` to runtime cache instead of rewriting `config/annotator_config.toml`.
- Add regression coverage for runtime cache precedence and system catalog non-mutation.

Fixes #97

## Validation

- `uv run ruff check src/image_annotator_lib/__init__.py src/image_annotator_lib/core/constants.py src/image_annotator_lib/core/config.py src/image_annotator_lib/core/loaders/loader_base.py tests/conftest.py tests/unit/fast/test_config.py tests/unit/core/test_model_factory.py tests/unit/standard/core/test_model_factory_unit.py`
- `uv run pytest tests/unit/fast/test_config.py tests/unit/core/test_model_factory.py tests/unit/standard/core/test_model_factory_unit.py` (`93 passed`)
- `uv run pytest -m "not downloads_and_runs_model and not calls_real_webapi"` (`716 passed, 11 deselected`)
- `git diff --check`
- `uv run mypy src/image_annotator_lib` fails on pre-existing type errors outside this change; no reported errors are in the files touched by this PR.
