### PR TITLE
refactor: move WebAPI model discovery

### DIFF
--- a/src/image_annotator_lib/__init__.py
+++ b/src/image_annotator_lib/__init__.py
@@ -8,6 +8,27 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 
 from .api import PHashAnnotationResults as PHashAnnotationResults
 from .api import list_annotator_info
+from .core.config import config_registry
+from .core.constants import (
+    DEFAULT_PATHS,
+    MODEL_RUNTIME_CACHE_PATH,
+    SYSTEM_CONFIG_PATH,
+    USER_CONFIG_PATH,
+)
+from .core.model_factory import ModelLoad
+from .core.registry import (
+    initialize_registry,
+    list_available_annotators,
+)
+from .core.types import AnnotationResult, AnnotatorInfo, ModelType
+from .core.utils import init_logger
+from .exceptions.errors import AnnotatorError, ModelLoadError, ModelNotFoundError, OutOfMemoryError
+from .webapi.api_model_discovery import (
+    discover_available_vision_models,
+    get_available_models,
+    is_model_deprecated,
+    list_all_models,
+)
 from .webapi.batch import (
     BatchErrorPhase,
     BatchFetchResult,
@@ -29,27 +50,6 @@ from .webapi.batch import (
     retrieve_batch,
     submit_batch,
 )
-from .core.api_model_discovery import (
-    discover_available_vision_models,
-    get_available_models,
-    is_model_deprecated,
-    list_all_models,
-)
-from .core.config import config_registry
-from .core.constants import (
-    DEFAULT_PATHS,
-    MODEL_RUNTIME_CACHE_PATH,
-    SYSTEM_CONFIG_PATH,
-    USER_CONFIG_PATH,
-)
-from .core.model_factory import ModelLoad
-from .core.registry import (
-    initialize_registry,
-    list_available_annotators,
-)
-from .core.types import AnnotationResult, AnnotatorInfo, ModelType
-from .core.utils import init_logger
-from .exceptions.errors import AnnotatorError, ModelLoadError, ModelNotFoundError, OutOfMemoryError
 
 # --- Public API ---
 # ADR 0023 Phase 1: create_agent は廃止 (SimplifiedAgentFactory 全廃)。

--- a/src/image_annotator_lib/core/config.py
+++ b/src/image_annotator_lib/core/config.py
@@ -432,5 +432,5 @@ config_registry = _ConfigRegistryProxy()
 # ADR 0023 Phase 1 (Issue #35 PR #40): `available_api_models.toml` cache は **明示的に廃止**。
 # 旧 `_load_full_api_models_file` / `load_available_api_models` / `load_api_models_meta` /
 # `load_last_refresh` / `save_available_api_models` は本ファイルから削除された。
-# WebAPI モデル一覧と capability metadata は `core/api_model_discovery.py` で
+# WebAPI モデル一覧と capability metadata は `webapi/api_model_discovery.py` で
 # LiteLLM 同梱 DB から runtime 取得する (TOML キャッシュなし)。

--- a/src/image_annotator_lib/core/constants.py
+++ b/src/image_annotator_lib/core/constants.py
@@ -24,7 +24,7 @@ USER_CONFIG_PATH = CONFIG_DIR / "user_config.toml"
 MODEL_RUNTIME_CACHE_PATH = CONFIG_DIR / "model_runtime_cache.toml"
 
 # ADR 0023 Phase 1 (Issue #35, PR #40): `AVAILABLE_API_MODELS_CONFIG_PATH` 定数は廃止。
-# WebAPI モデル一覧は `core/api_model_discovery.py` で LiteLLM 同梱 DB から runtime
+# WebAPI モデル一覧は `webapi/api_model_discovery.py` で LiteLLM 同梱 DB から runtime
 # 取得する (TOML キャッシュなし)。
 
 DEFAULT_PATHS = {

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -234,7 +234,7 @@ def _try_register_model(
 
     if model_name in registry:
         if registry[model_name] is model_cls:
-            logger.debug(f"モデル名 '{model_name}' は既に登録されています（同一クラス）。スキップします。")
+            logger.debug(f"モデル名 '{model_name}' は既に登録されています(同一クラス)。スキップします。")
             return True
         logger.warning(
             f"モデル名 '{model_name}' は既に登録されています。クラス '{model_cls.__name__}' で上書きします。"
@@ -696,7 +696,7 @@ def _register_webapi_models_from_discovery() -> None:
     """
     logger.debug("LiteLLM 同梱 DB から WebAPI モデルの直接登録を開始します...")
     try:
-        from .api_model_discovery import discover_available_vision_models
+        from ..webapi.api_model_discovery import discover_available_vision_models
         from .webapi_annotator import WebApiAnnotator
 
         result = discover_available_vision_models()

--- a/src/image_annotator_lib/webapi/api_model_discovery.py
+++ b/src/image_annotator_lib/webapi/api_model_discovery.py
@@ -19,8 +19,8 @@ os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 
 import litellm
 
-from ..webapi.model_id import SUPPORTED_PROVIDERS
-from .utils import logger
+from ..core.utils import logger
+from .model_id import SUPPORTED_PROVIDERS
 
 _SUPPORTED_LITELLM_MODES: frozenset[str] = frozenset({"chat", "responses"})
 

--- a/tests/unit/core/test_api_model_discovery_filter.py
+++ b/tests/unit/core/test_api_model_discovery_filter.py
@@ -10,11 +10,12 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from image_annotator_lib.core.api_model_discovery import (
+from image_annotator_lib.webapi.api_model_discovery import (
     _canonicalize_litellm_id,
     _collect_models,
     _format_litellm_metadata,
@@ -323,7 +324,7 @@ class TestCollectModelsPassesProviderToGetModelInfo:
     get_model_info() には custom_llm_provider を明示して provider 推論経路に入らない。
     """
 
-    _COMPAT_INFO: dict = {
+    _COMPAT_INFO: ClassVar[dict] = {
         "litellm_provider": "openai",
         "supports_vision": True,
         "supports_function_calling": True,
@@ -340,7 +341,7 @@ class TestCollectModelsPassesProviderToGetModelInfo:
         mock_cost = {"ft:o4-mini-2025-04-16": self._COMPAT_INFO}
         mock_info = MagicMock(return_value=dict(self._COMPAT_INFO))
 
-        with patch("image_annotator_lib.core.api_model_discovery.litellm") as mock_litellm:
+        with patch("image_annotator_lib.webapi.api_model_discovery.litellm") as mock_litellm:
             mock_litellm.model_cost = mock_cost
             mock_litellm.get_model_info = mock_info
             _collect_models(require_compatible=False, exclude_deprecated=False)
@@ -354,7 +355,7 @@ class TestCollectModelsPassesProviderToGetModelInfo:
         mock_cost = {"gemini-2.0-flash-exp-image-generation": info}
         mock_info = MagicMock(return_value=info)
 
-        with patch("image_annotator_lib.core.api_model_discovery.litellm") as mock_litellm:
+        with patch("image_annotator_lib.webapi.api_model_discovery.litellm") as mock_litellm:
             mock_litellm.model_cost = mock_cost
             mock_litellm.get_model_info = mock_info
             _collect_models(require_compatible=False, exclude_deprecated=False)
@@ -379,7 +380,7 @@ class TestIsModelDeprecatedPassesProviderToGetModelInfo:
         }
         mock_info = MagicMock(return_value=info)
 
-        with patch("image_annotator_lib.core.api_model_discovery.litellm") as mock_litellm:
+        with patch("image_annotator_lib.webapi.api_model_discovery.litellm") as mock_litellm:
             mock_litellm.model_cost = {"ft:o4-mini-2025-04-16": info}
             mock_litellm.get_model_info = mock_info
             is_model_deprecated("ft:o4-mini-2025-04-16")

--- a/tests/unit/fixtures/mock_configs.py
+++ b/tests/unit/fixtures/mock_configs.py
@@ -78,6 +78,6 @@ def mock_empty_config():
 
 
 # ADR 0023 Phase 1 (Issue #35, PR #40): `load_available_api_models` は廃止された。
-# WebAPI モデル一覧の mock は `image_annotator_lib.core.api_model_discovery.discover_available_vision_models`
+# WebAPI モデル一覧の mock は `image_annotator_lib.webapi.api_model_discovery.discover_available_vision_models`
 # を直接 monkeypatch するか、test fixture で `_register_webapi_models_from_discovery` を
 # 差し替える形で対応する。本 fixture (`mock_api_models_config`) は削除。

--- a/tests/unit/standard/core/test_webapi_metadata_isolation.py
+++ b/tests/unit/standard/core/test_webapi_metadata_isolation.py
@@ -19,17 +19,17 @@ from unittest.mock import patch
 import pytest
 
 from image_annotator_lib.core import registry
-from image_annotator_lib.core.api_model_discovery import _is_litellm_model_annotation_compatible
 from image_annotator_lib.core.config import get_config_registry
 from image_annotator_lib.core.registry import (
     _register_webapi_models_from_discovery,
     get_webapi_metadata,
 )
+from image_annotator_lib.webapi.api_model_discovery import _is_litellm_model_annotation_compatible
 
 # `_register_webapi_models_from_discovery` は関数内で
-# `from .api_model_discovery import discover_available_vision_models` する。
+# `from ..webapi.api_model_discovery import discover_available_vision_models` する。
 # patch は定義元モジュールを対象にする。
-_DISCOVERY_PATCH_TARGET = "image_annotator_lib.core.api_model_discovery.discover_available_vision_models"
+_DISCOVERY_PATCH_TARGET = "image_annotator_lib.webapi.api_model_discovery.discover_available_vision_models"
 
 
 def _model_info(model_short: str, provider: str) -> dict:


### PR DESCRIPTION
## Summary

- Move WebAPI model discovery from `core/` to `image_annotator_lib.webapi`.
- Update public exports, registry imports, fixtures, and discovery tests to use the new path.
- Do not keep an old `image_annotator_lib.core.api_model_discovery` compatibility shim.

Replaces #112 after the stacked base branch was merged.
Closes #107

## Tests

- `uv run pytest tests/unit/core/test_api_model_discovery_filter.py tests/unit/standard/core/test_webapi_metadata_isolation.py`
- `uv run ruff check ...`
- `rg "image_annotator_lib\\.core\\.api_model_discovery|from \\.api_model_discovery import|core/api_model_discovery" src tests`
