### PR TITLE
refactor: move WebAPI execution boundary

### DIFF
--- a/src/image_annotator_lib/api.py
+++ b/src/image_annotator_lib/api.py
@@ -89,7 +89,7 @@ def list_annotator_info() -> list[AnnotatorInfo]:
         get_webapi_metadata,
         initialize_registry,
     )
-    from .core.webapi_annotator import WebApiAnnotator
+    from .webapi.annotator import WebApiAnnotator
 
     if not _REGISTRY_INITIALIZED:
         initialize_registry()

--- a/src/image_annotator_lib/core/annotation_runner.py
+++ b/src/image_annotator_lib/core/annotation_runner.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from PIL import Image
 
+from ..webapi.annotator import WebApiAnnotator
 from .base.annotator import BaseAnnotator
 from .registry import (
     find_model_class_case_insensitive,
@@ -31,7 +32,6 @@ from .registry import (
 )
 from .types import PHashAnnotationResults, UnifiedAnnotationResult
 from .utils import calculate_phash, get_model_capabilities, logger
-from .webapi_annotator import WebApiAnnotator
 
 _MODEL_INSTANCE_REGISTRY: dict[str, Any] = {}
 

--- a/src/image_annotator_lib/core/base/__init__.py
+++ b/src/image_annotator_lib/core/base/__init__.py
@@ -2,7 +2,7 @@
 
 Note:
     ADR 0023 Phase 1 (Issue #35) で WebAPI 系は `WebApiAnnotator`
-    (`core/webapi_annotator.py`) に統合された。旧 `WebApiBaseAnnotator` は廃止。
+    (`webapi/annotator.py`) に統合された。旧 `WebApiBaseAnnotator` は廃止。
 """
 
 from .annotator import BaseAnnotator

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -487,7 +487,7 @@ def _requires_api_key(model_class: ModelClass, model_config: dict[str, Any]) -> 
         return bool(model_config["requires_api_key"])
 
     # WebApiAnnotator (またはサブクラス) は API key 必須
-    from .webapi_annotator import WebApiAnnotator
+    from ..webapi.annotator import WebApiAnnotator
 
     if issubclass(model_class, WebApiAnnotator):
         return True
@@ -518,7 +518,7 @@ def _resolve_registry_capabilities(model_name: str, is_api: bool) -> frozenset[T
 
     if is_api:
         # ADR 0023 Phase 1: WebApiAnnotator は AnnotationSchema (tags/captions/score) を返す
-        from .webapi_annotator import WebApiAnnotator  # 循環 import 回避のため遅延
+        from ..webapi.annotator import WebApiAnnotator  # 循環 import 回避のため遅延
 
         return WebApiAnnotator.ADVERTISED_CAPABILITIES
 
@@ -691,13 +691,13 @@ def _register_webapi_models_from_discovery() -> None:
     旧 `available_api_models.toml` 経由の登録は廃止。`discover_available_vision_models()`
     の `metadata` (LiteLLM `get_model_info()` 由来) を直接使用する。
 
-    Issue #35: 登録対象クラスは `WebApiAnnotator` (`core/webapi_annotator.py`) を
+    Issue #35: 登録対象クラスは `WebApiAnnotator` (`webapi/annotator.py`) を
     直接 import して使う。旧 `PydanticAIWebAPIAnnotator` 経路は廃止。
     """
     logger.debug("LiteLLM 同梱 DB から WebAPI モデルの直接登録を開始します...")
     try:
         from ..webapi.api_model_discovery import discover_available_vision_models
-        from .webapi_annotator import WebApiAnnotator
+        from ..webapi.annotator import WebApiAnnotator
 
         result = discover_available_vision_models()
         api_models: dict[str, dict[str, Any]] = result.get("metadata", {})

--- a/src/image_annotator_lib/core/types.py
+++ b/src/image_annotator_lib/core/types.py
@@ -79,7 +79,7 @@ class TagConfidence(TypedDict):
 # --- Web API 関連の型定義 ---
 #
 # ADR 0023 Phase 1 (Issue #35, PR #40): 旧 `WebApiBaseAnnotator` 系の dead types は
-# 全て削除された。WebAPI 系の type は `WebApiAnnotator` (`core/webapi_annotator.py`)
+# 全て削除された。WebAPI 系の type は `WebApiAnnotator` (`webapi/annotator.py`)
 # が直接 `UnifiedAnnotationResult` を構築するため、独立した type を必要としない。
 #
 # 削除済み:

--- a/src/image_annotator_lib/webapi/__init__.py
+++ b/src/image_annotator_lib/webapi/__init__.py
@@ -1,2 +1,1 @@
 """WebAPI execution support package."""
-

--- a/src/image_annotator_lib/webapi/annotator.py
+++ b/src/image_annotator_lib/webapi/annotator.py
@@ -15,10 +15,11 @@ from typing import Any, Self
 
 from PIL import Image
 
-from .base.annotator import BaseAnnotator
-from .provider_manager import ProviderManager
-from .types import AnnotationResult, RatingPrediction, TaskCapability, UnifiedAnnotationResult
-from .utils import calculate_phash, logger
+from image_annotator_lib.webapi.provider_manager import ProviderManager
+
+from ..core.base.annotator import BaseAnnotator
+from ..core.types import AnnotationResult, RatingPrediction, TaskCapability, UnifiedAnnotationResult
+from ..core.utils import calculate_phash, logger
 
 
 class WebApiAnnotator(BaseAnnotator):

--- a/src/image_annotator_lib/webapi/provider_manager.py
+++ b/src/image_annotator_lib/webapi/provider_manager.py
@@ -17,6 +17,8 @@ from typing import Any
 from PIL import Image
 from pydantic_ai import Agent
 
+from ..core.types import AnnotationResult, TaskCapability
+from ..core.utils import calculate_phash, logger
 from ..exceptions.errors import (
     ContentPolicyRefusalError,
     InferenceError,
@@ -24,13 +26,11 @@ from ..exceptions.errors import (
     SafetyRefusalError,
 )
 from ..model_class.annotator_webapi.webapi_shared import BASE_PROMPT
-from ..webapi.http_retry import build_retry_http_client
-from ..webapi.image_preprocess import preprocess_images_to_binary
-from ..webapi.model_id import build_pydantic_model, resolve_model_ref
-from ..webapi.output_normalization import build_annotation_output_normalizer
-from ..webapi.result_adapter import to_annotation_result
-from .types import AnnotationResult, TaskCapability
-from .utils import calculate_phash, logger
+from .http_retry import build_retry_http_client
+from .image_preprocess import preprocess_images_to_binary
+from .model_id import build_pydantic_model, resolve_model_ref
+from .output_normalization import build_annotation_output_normalizer
+from .result_adapter import to_annotation_result
 
 # ADR 0023 retry policy:
 # - output normalization / schema validation failure: PydanticAI `output_retries=1` で 1 回再生成

--- a/tests/unit/core/test_annotation_runner.py
+++ b/tests/unit/core/test_annotation_runner.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import pytest
 
 from image_annotator_lib.core import annotation_runner
-from image_annotator_lib.core.webapi_annotator import WebApiAnnotator
+from image_annotator_lib.webapi.annotator import WebApiAnnotator
 
 
 class _StubLocalAnnotator:

--- a/tests/unit/core/test_provider_manager_event_loop_context.py
+++ b/tests/unit/core/test_provider_manager_event_loop_context.py
@@ -19,8 +19,8 @@ import asyncio
 import pytest
 from PIL import Image
 
-from image_annotator_lib.core.provider_manager import ProviderManager
 from image_annotator_lib.exceptions.errors import InferenceError
+from image_annotator_lib.webapi.provider_manager import ProviderManager
 
 
 class _FakeRateLimitError(Exception):

--- a/tests/unit/core/test_provider_manager_exception_chain.py
+++ b/tests/unit/core/test_provider_manager_exception_chain.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from PIL import Image
 
-from image_annotator_lib.core.provider_manager import (
+from image_annotator_lib.webapi.provider_manager import (
     ProviderManager,
     _format_exception_chain,
 )

--- a/tests/unit/core/test_provider_manager_logger_keyerror.py
+++ b/tests/unit/core/test_provider_manager_logger_keyerror.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from PIL import Image
 
-from image_annotator_lib.core.provider_manager import ProviderManager
+from image_annotator_lib.webapi.provider_manager import ProviderManager
 
 
 class _FakeModelHTTPError(Exception):

--- a/tests/unit/core/test_provider_manager_output_normalization.py
+++ b/tests/unit/core/test_provider_manager_output_normalization.py
@@ -6,8 +6,8 @@ from PIL import Image
 from pydantic_ai import Agent
 from pydantic_ai.models.test import TestModel
 
-from image_annotator_lib.core.provider_manager import ProviderManager
 from image_annotator_lib.webapi.output_normalization import normalize_annotation_output
+from image_annotator_lib.webapi.provider_manager import ProviderManager
 
 
 def test_provider_manager_returns_normalized_annotation_result() -> None:

--- a/tests/unit/core/test_provider_manager_refusal.py
+++ b/tests/unit/core/test_provider_manager_refusal.py
@@ -8,11 +8,11 @@ from typing import Any
 
 import pytest
 
-from image_annotator_lib.core.provider_manager import _classify_refusal
 from image_annotator_lib.exceptions.errors import (
     ContentPolicyRefusalError,
     SafetyRefusalError,
 )
+from image_annotator_lib.webapi.provider_manager import _classify_refusal
 
 
 @pytest.mark.unit
@@ -502,7 +502,7 @@ def test_classify_refusal_body_content_filter_precedence_when_filter_first():
 @pytest.mark.unit
 def test_classify_refusal_body_walker_collects_all_reasons():
     """`_walk_for_reasons` が複数 reason を全て収集することの直接確認。"""
-    from image_annotator_lib.core.provider_manager import _walk_for_reasons
+    from image_annotator_lib.webapi.provider_manager import _walk_for_reasons
 
     body = {
         "stop_reason": "refusal",

--- a/tests/unit/core/test_webapi_annotator.py
+++ b/tests/unit/core/test_webapi_annotator.py
@@ -1,4 +1,4 @@
-"""ADR 0023 Phase 1: core/webapi_annotator.py の unit test."""
+"""ADR 0023 Phase 1: webapi/annotator.py の unit test."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import pytest
 
 from image_annotator_lib.core import utils
 from image_annotator_lib.core.types import TaskCapability
-from image_annotator_lib.core.webapi_annotator import WebApiAnnotator
+from image_annotator_lib.webapi.annotator import WebApiAnnotator
 
 
 class TestWebApiAnnotatorBasics:

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -10,7 +10,7 @@ import pytest
 
 from image_annotator_lib import AnnotatorInfo, list_annotator_info
 from image_annotator_lib.core.types import TaskCapability
-from image_annotator_lib.core.webapi_annotator import WebApiAnnotator
+from image_annotator_lib.webapi.annotator import WebApiAnnotator
 
 # --- テスト用ダミークラス ---
 

--- a/tests/unit/fixtures/mock_components.py
+++ b/tests/unit/fixtures/mock_components.py
@@ -87,7 +87,7 @@ def mock_model_load():
 @pytest.fixture
 def mock_provider_manager():
     """ProviderManager のモック"""
-    with patch("image_annotator_lib.core.provider_manager.ProviderManager") as mock:
+    with patch("image_annotator_lib.webapi.provider_manager.ProviderManager") as mock:
         mock.get_provider_instance.return_value = MagicMock()
         mock.run_inference_with_model.return_value = {
             "test_hash": {

--- a/tests/unit/standard/core/test_webapi_metadata_isolation.py
+++ b/tests/unit/standard/core/test_webapi_metadata_isolation.py
@@ -266,7 +266,7 @@ def test_registered_webapi_model_resolves_to_webapi_annotator(isolated_registry)
     がモデルクラス registry に `WebApiAnnotator` を登録し、metadata の `class` も
     `WebApiAnnotator` であることを検証する。
     """
-    from image_annotator_lib.core.webapi_annotator import WebApiAnnotator
+    from image_annotator_lib.webapi.annotator import WebApiAnnotator
 
     with patch(_DISCOVERY_PATCH_TARGET, return_value=_DISCOVERY_RESULT):
         _register_webapi_models_from_discovery()


### PR DESCRIPTION
## Summary

- Move the WebAPI execution boundary from `core/` to `image_annotator_lib.webapi`.
- Update registry, annotation runner, API, fixtures, imports, and patch targets for `WebApiAnnotator` and `ProviderManager`.
- Do not keep old `image_annotator_lib.core.provider_manager` or `image_annotator_lib.core.webapi_annotator` compatibility shims.

Replaces #113 after the stacked base branch was merged.
Closes #106

## Tests

- `uv run pytest tests/unit/core/test_webapi_annotator.py tests/unit/core/test_provider_manager_refusal.py tests/unit/core/test_provider_manager_exception_chain.py tests/unit/core/test_provider_manager_event_loop_context.py tests/unit/core/test_provider_manager_logger_keyerror.py tests/unit/core/test_provider_manager_output_normalization.py tests/unit/core/test_annotation_runner.py tests/unit/fast/test_list_annotator_info.py`
- `uv run pytest tests/unit/standard/core/test_webapi_metadata_isolation.py`
- `uv run ruff check ...`
- `rg "image_annotator_lib\\.core\\.(webapi_annotator|provider_manager)|from \\.(webapi_annotator|provider_manager) import|core/(webapi_annotator|provider_manager)" src tests`
