### PR TITLE
test: verify WebAPI import compatibility

### DIFF
--- a/src/image_annotator_lib/exceptions/errors.py
+++ b/src/image_annotator_lib/exceptions/errors.py
@@ -627,7 +627,7 @@ class InsufficientCreditsError(WebApiError):
 class IdMappingError(WebApiError):
     """litellm_model_id の解析に失敗した場合の例外。
 
-    `core/model_id.resolve_model_ref()` が prefix 解析や builder dispatch に失敗した
+    `webapi/model_id.resolve_model_ref()` が prefix 解析や builder dispatch に失敗した
     ときに raise する。空文字 / `provider/model` 形式違反などが該当する。
 
     Attributes:

--- a/src/image_annotator_lib/webapi/provider_manager.py
+++ b/src/image_annotator_lib/webapi/provider_manager.py
@@ -287,7 +287,7 @@ class ProviderManager:
 
         Args:
             model_name: 呼び出し元モデル名 (logging 用、解決には使わない)。
-            provider: `core/model_id.SUPPORTED_PROVIDERS` の provider 名。
+            provider: `webapi/model_id.SUPPORTED_PROVIDERS` の provider 名。
             api_keys: provider -> API key の dict。
         """
         if api_keys and provider in api_keys and api_keys[provider]:

--- a/tests/unit/test_import_smoke.py
+++ b/tests/unit/test_import_smoke.py
@@ -12,6 +12,15 @@ import sys
 
 import pytest
 
+from image_annotator_lib.webapi.annotator import WebApiAnnotator
+from image_annotator_lib.webapi.api_model_discovery import discover_available_vision_models
+from image_annotator_lib.webapi.http_retry import build_retry_http_client
+from image_annotator_lib.webapi.image_preprocess import preprocess_images_to_binary
+from image_annotator_lib.webapi.model_id import resolve_model_ref
+from image_annotator_lib.webapi.output_normalization import normalize_annotation_output
+from image_annotator_lib.webapi.provider_manager import ProviderManager
+from image_annotator_lib.webapi.result_adapter import to_annotation_result
+
 _HEAVY_MODULES: tuple[str, ...] = ("torch", "torchvision", "transformers", "onnxruntime", "tensorflow")
 """eager load を禁止する heavy native dep の module 名集合。"""
 
@@ -58,3 +67,17 @@ def test_import_image_annotator_lib_does_not_eager_load_heavy_deps() -> None:
     assert loaded == [], (
         f"eager-loaded heavy deps after bare `import image_annotator_lib`: {loaded}"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_webapi_package_import_surface() -> None:
+    """WebAPI subsystem の最終 import surface が `image_annotator_lib.webapi` にあること。"""
+    assert WebApiAnnotator.__name__ == "WebApiAnnotator"
+    assert ProviderManager.__name__ == "ProviderManager"
+    assert callable(resolve_model_ref)
+    assert callable(discover_available_vision_models)
+    assert callable(build_retry_http_client)
+    assert callable(preprocess_images_to_binary)
+    assert callable(normalize_annotation_output)
+    assert callable(to_annotation_result)


### PR DESCRIPTION
## Summary

- Add import smoke coverage for the final `image_annotator_lib.webapi.*` surface after the WebAPI relocation PRs landed.
- Update remaining diagnostic comments to refer to `webapi/model_id`.
- Verify no old `image_annotator_lib.core.*` WebAPI import paths remain in the integration test surface.

Replaces #114 after the stacked base branches were merged.
Closes #108

## Tests

- `uv run pytest tests/unit/test_import_smoke.py tests/integration/test_list_annotator_info_e2e.py tests/unit/core/test_api_model_discovery_filter.py tests/unit/standard/core/test_webapi_metadata_isolation.py tests/unit/core/test_webapi_annotator.py tests/unit/core/test_provider_manager_output_normalization.py tests/unit/fast/test_list_annotator_info.py`
- `uv run ruff check src/image_annotator_lib/webapi/provider_manager.py src/image_annotator_lib/exceptions/errors.py tests/unit/test_import_smoke.py`
