### PR TITLE
feat: add rating model type

### DIFF
--- a/config/annotator_config-sample.toml
+++ b/config/annotator_config-sample.toml
@@ -104,7 +104,7 @@ model_path = "deepghs/anime_rating"
 model_variant = "mobilenetv3_sce_dist"
 class = "AnimeRatingAnnotator"
 estimated_size_gb = 0.047
-type = "tagger"
+type = "rating"
 capabilities = ["ratings"]
 
 [anime_rating_caformer_s36_plus]
@@ -112,7 +112,7 @@ model_path = "deepghs/anime_rating"
 model_variant = "caformer_s36_plus"
 class = "AnimeRatingAnnotator"
 estimated_size_gb = 0.52
-type = "tagger"
+type = "rating"
 capabilities = ["ratings"]
 
 [camie_tagger_initial]

--- a/config/annotator_config.toml
+++ b/config/annotator_config.toml
@@ -103,7 +103,7 @@ model_path = "deepghs/anime_rating"
 model_variant = "mobilenetv3_sce_dist"
 class = "AnimeRatingAnnotator"
 estimated_size_gb = 0.047
-type = "tagger"
+type = "rating"
 capabilities = [ "ratings",]
 
 [anime_rating_caformer_s36_plus]
@@ -111,7 +111,7 @@ model_path = "deepghs/anime_rating"
 model_variant = "caformer_s36_plus"
 class = "AnimeRatingAnnotator"
 estimated_size_gb = 0.52
-type = "tagger"
+type = "rating"
 capabilities = [ "ratings",]
 
 [camie_tagger_initial]
@@ -247,4 +247,3 @@ model_path = "https://github.com/KichangKim/DeepDanbooru/releases/download/v1-20
 class = "DeepDanbooruTagger"
 estimated_size_gb = 0.66
 type = "tagger"
-

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -234,7 +234,7 @@ def _try_register_model(
 
     if model_name in registry:
         if registry[model_name] is model_cls:
-            logger.debug(f"モデル名 '{model_name}' は既に登録されています（同一クラス）。スキップします。")
+            logger.debug(f"モデル名 '{model_name}' は既に登録されています(同一クラス)。スキップします。")
             return True
         logger.warning(
             f"モデル名 '{model_name}' は既に登録されています。クラス '{model_cls.__name__}' で上書きします。"
@@ -416,7 +416,7 @@ def get_webapi_metadata(model_name: str) -> dict[str, Any] | None:
     return _WEBAPI_MODEL_METADATA.get(model_name)
 
 
-_VALID_MODEL_TYPES: frozenset[str] = frozenset(("tagger", "scorer", "captioner", "vision"))
+_VALID_MODEL_TYPES: frozenset[str] = frozenset(("tagger", "scorer", "captioner", "vision", "rating"))
 
 
 def _determine_model_type(
@@ -435,7 +435,7 @@ def _determine_model_type(
         model_config: モデル設定
 
     Returns:
-        ModelType: "tagger" / "scorer" / "captioner" / "vision" のいずれか
+        ModelType: "tagger" / "scorer" / "captioner" / "vision" / "rating" のいずれか
     """
     # 設定の `type` を最優先で参照 (実際の config キーは "type")
     config_type = model_config.get("type")
@@ -446,10 +446,16 @@ def _determine_model_type(
     model_name_lower = model_name.lower()
     class_name_lower = model_class.__name__.lower()
 
+    # レーティング専用モデルの判定
+    if any(keyword in model_name_lower for keyword in ["anime_rating", "moderation"]):
+        return "rating"
+    if any(keyword in class_name_lower for keyword in ["ratingannotator", "moderation"]):
+        return "rating"
+
     # スコア系モデルの判定
-    if any(keyword in model_name_lower for keyword in ["aesthetic", "score", "rating", "quality"]):
+    if any(keyword in model_name_lower for keyword in ["aesthetic", "score", "quality"]):
         return "scorer"
-    if any(keyword in class_name_lower for keyword in ["aesthetic", "score", "rating", "quality"]):
+    if any(keyword in class_name_lower for keyword in ["aesthetic", "score", "quality"]):
         return "scorer"
 
     # タガー系モデルの判定

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -448,19 +448,21 @@ def _determine_model_type(
     Returns:
         ModelType: "tagger" / "scorer" / "captioner" / "vision" / "rating" のいずれか
     """
-    # 既存 user config には AnimeRatingAnnotator を type="tagger" としてコピー済みの
-    # ものがあるため、既知の rating-only モデルは legacy type より優先して補正する。
-    if _is_rating_only_model(model_name, model_class):
-        return "rating"
-
     # 設定の `type` を優先で参照 (実際の config キーは "type")
     config_type = model_config.get("type")
     if isinstance(config_type, str) and config_type in _VALID_MODEL_TYPES:
+        # 既存 user config には AnimeRatingAnnotator を type="tagger" としてコピー済みの
+        # ものがあるため、既知の rating-only モデルだけ legacy tagger type を補正する。
+        if config_type == "tagger" and _is_rating_only_model(model_name, model_class):
+            return "rating"
         return cast(ModelType, config_type)
 
     # モデル名やクラス名から推定
     model_name_lower = model_name.lower()
     class_name_lower = model_class.__name__.lower()
+
+    if _is_rating_only_model(model_name, model_class):
+        return "rating"
 
     # スコア系モデルの判定
     if any(keyword in model_name_lower for keyword in ["aesthetic", "score", "quality"]):

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -419,6 +419,17 @@ def get_webapi_metadata(model_name: str) -> dict[str, Any] | None:
 _VALID_MODEL_TYPES: frozenset[str] = frozenset(("tagger", "scorer", "captioner", "vision", "rating"))
 
 
+def _is_rating_only_model(model_name: str, model_class: ModelClass) -> bool:
+    """Known rating-only models override legacy config ``type`` values."""
+    model_name_lower = model_name.lower()
+    class_name_lower = model_class.__name__.lower()
+    return (
+        any(keyword in model_name_lower for keyword in ("anime_rating", "moderation"))
+        or "ratingannotator" in class_name_lower
+        or "moderation" in class_name_lower
+    )
+
+
 def _determine_model_type(
     model_name: str, model_class: ModelClass, model_config: dict[str, Any]
 ) -> ModelType:
@@ -437,7 +448,12 @@ def _determine_model_type(
     Returns:
         ModelType: "tagger" / "scorer" / "captioner" / "vision" / "rating" のいずれか
     """
-    # 設定の `type` を最優先で参照 (実際の config キーは "type")
+    # 既存 user config には AnimeRatingAnnotator を type="tagger" としてコピー済みの
+    # ものがあるため、既知の rating-only モデルは legacy type より優先して補正する。
+    if _is_rating_only_model(model_name, model_class):
+        return "rating"
+
+    # 設定の `type` を優先で参照 (実際の config キーは "type")
     config_type = model_config.get("type")
     if isinstance(config_type, str) and config_type in _VALID_MODEL_TYPES:
         return cast(ModelType, config_type)
@@ -445,12 +461,6 @@ def _determine_model_type(
     # モデル名やクラス名から推定
     model_name_lower = model_name.lower()
     class_name_lower = model_class.__name__.lower()
-
-    # レーティング専用モデルの判定
-    if any(keyword in model_name_lower for keyword in ["anime_rating", "moderation"]):
-        return "rating"
-    if any(keyword in class_name_lower for keyword in ["ratingannotator", "moderation"]):
-        return "rating"
 
     # スコア系モデルの判定
     if any(keyword in model_name_lower for keyword in ["aesthetic", "score", "quality"]):

--- a/src/image_annotator_lib/core/types.py
+++ b/src/image_annotator_lib/core/types.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
@@ -208,7 +208,8 @@ AnnotationResultV2 = (
 
 # --- capability-based統一バリデーションスキーマ (Plan対応) ---
 
-class TaskCapability(str, Enum):
+
+class TaskCapability(StrEnum):
     """サポートするタスク能力(ADR 0002: SCORE_LABELS 追加)。"""
 
     TAGS = "tags"
@@ -313,7 +314,7 @@ UnifiedPHashAnnotationResults = dict[str, dict[str, UnifiedAnnotationResult]]
 # --- アノテーターメタデータ用の型定義 (Issue #19) ---
 
 
-ModelType = Literal["tagger", "scorer", "captioner", "vision"]
+ModelType = Literal["tagger", "scorer", "captioner", "vision", "rating"]
 """アノテーターモデルの主用途分類。
 
 `is_api` と直交した capability 軸の分類。WebAPI モデルでも tagger/scorer/captioner
@@ -323,6 +324,7 @@ ModelType = Literal["tagger", "scorer", "captioner", "vision"]
 - "scorer": 数値スコアモデル (aesthetic scorer 等)
 - "captioner": キャプション生成モデル (BLIP, GIT 等)
 - "vision": 汎用 vision モデル / 未分類 (汎用 VLM 等)
+- "rating": レーティング専用モデル (anime_rating / moderation preflight 等)
 """
 
 
@@ -332,7 +334,7 @@ class AnnotatorInfo:
 
     Attributes:
         name: モデル名 (レジストリキー)。
-        model_type: モデルの主用途分類 (tagger/scorer/captioner/vision)。
+        model_type: モデルの主用途分類 (tagger/scorer/captioner/vision/rating)。
         capabilities: モデルが提供する出力種別の集合。
         is_local: ローカル実行モデルか。
         is_api: 外部 API を呼ぶモデルか (API キー必要)。

--- a/src/image_annotator_lib/core/utils.py
+++ b/src/image_annotator_lib/core/utils.py
@@ -361,6 +361,7 @@ def _infer_capabilities_from_type(model_name: str) -> set[Any] | None:
         "tagger": [TaskCapability.TAGS],
         "scorer": [TaskCapability.SCORES],
         "captioner": [TaskCapability.CAPTIONS],
+        "rating": [TaskCapability.RATINGS],
     }
     inferred = type_to_capabilities.get(model_type, [])
     if not inferred:

--- a/src/image_annotator_lib/resources/system/annotator_config.toml
+++ b/src/image_annotator_lib/resources/system/annotator_config.toml
@@ -68,7 +68,7 @@ model_path = "deepghs/anime_rating"
 model_variant = "mobilenetv3_sce_dist"
 class = "AnimeRatingAnnotator"
 estimated_size_gb = 0.047
-type = "tagger"
+type = "rating"
 capabilities = ["ratings"]
 
 [anime_rating_caformer_s36_plus]
@@ -76,7 +76,7 @@ model_path = "deepghs/anime_rating"
 model_variant = "caformer_s36_plus"
 class = "AnimeRatingAnnotator"
 estimated_size_gb = 0.52
-type = "tagger"
+type = "rating"
 capabilities = ["ratings"]
 
 [camie_tagger_initial]

--- a/tests/integration/test_list_annotator_info_e2e.py
+++ b/tests/integration/test_list_annotator_info_e2e.py
@@ -27,7 +27,7 @@ def test_list_annotator_info_real_registry():
         assert info.is_local != info.is_api, f"{info.name}: XOR 違反"
         if info.is_api:
             assert info.device is None, f"{info.name}: API モデルなのに device あり"
-        assert info.model_type in ("tagger", "scorer", "captioner", "vision")
+        assert info.model_type in ("tagger", "scorer", "captioner", "vision", "rating")
 
     # 名前ソートされている
     names = [info.name for info in infos]

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -27,6 +27,10 @@ class _DummyCaptioner:
     """ローカル ML キャプショナーのダミー実装。クラス名から model_type=captioner と判定される。"""
 
 
+class _DummyRatingAnnotator:
+    """ローカル ML レーティング専用モデルのダミー実装。"""
+
+
 # Note: ADR 0023 Phase 1 (Issue #35) で `_requires_api_key` は class 名照合ではなく
 # `issubclass(model_class, WebApiAnnotator)` 判定に変わった。WebAPI ダミー class は
 # 廃止し、registry に直接 `WebApiAnnotator` を登録する形式に書き換え済み。
@@ -141,6 +145,30 @@ def test_local_ml_model_classification(patched_registry):
     assert info.is_api is False
     assert info.device == "cuda"
     assert TaskCapability.TAGS in info.capabilities
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_local_rating_model_classification(patched_registry):
+    """rating 専用モデルが model_type='rating' / RATINGS capability で分類される。"""
+    with patched_registry(
+        model_dict={"anime_rating_mobilenetv3_sce_dist": _DummyRatingAnnotator},
+        config_dict={
+            "anime_rating_mobilenetv3_sce_dist": {
+                "type": "rating",
+                "device": "cuda",
+                "capabilities": ["ratings"],
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    assert len(result) == 1
+    info = result[0]
+    assert info.model_type == "rating"
+    assert info.capabilities == frozenset({TaskCapability.RATINGS})
+    assert info.is_local is True
+    assert info.is_api is False
 
 
 @pytest.mark.unit

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -173,6 +173,25 @@ def test_local_rating_model_classification(patched_registry):
 
 @pytest.mark.unit
 @pytest.mark.fast
+def test_rating_only_class_overrides_legacy_tagger_type(patched_registry):
+    """既存 user config の type='tagger' でも rating 専用 class は rating に補正する。"""
+    with patched_registry(
+        model_dict={"anime_rating_mobilenetv3_sce_dist": _DummyRatingAnnotator},
+        config_dict={
+            "anime_rating_mobilenetv3_sce_dist": {
+                "type": "tagger",
+                "device": "cuda",
+                "capabilities": ["ratings"],
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    assert result[0].model_type == "rating"
+
+
+@pytest.mark.unit
+@pytest.mark.fast
 def test_webapi_model_classification(patched_registry):
     """WebApiAnnotator が is_api=True, device=None で分類される。"""
     with patched_registry(

--- a/tests/unit/fast/test_list_annotator_info.py
+++ b/tests/unit/fast/test_list_annotator_info.py
@@ -192,6 +192,25 @@ def test_rating_only_class_overrides_legacy_tagger_type(patched_registry):
 
 @pytest.mark.unit
 @pytest.mark.fast
+def test_rating_name_respects_explicit_non_legacy_type(patched_registry):
+    """rating 風の名前でも legacy tagger 以外の明示 type は尊重する。"""
+    with patched_registry(
+        model_dict={"custom_moderation_score": _DummyScorer},
+        config_dict={
+            "custom_moderation_score": {
+                "type": "scorer",
+                "device": "cuda",
+                "capabilities": ["scores"],
+            }
+        },
+    ):
+        result = list_annotator_info()
+
+    assert result[0].model_type == "scorer"
+
+
+@pytest.mark.unit
+@pytest.mark.fast
 def test_webapi_model_classification(patched_registry):
     """WebApiAnnotator が is_api=True, device=None で分類される。"""
     with patched_registry(

--- a/tests/unit/test_capability_utils.py
+++ b/tests/unit/test_capability_utils.py
@@ -175,6 +175,15 @@ class TestGetModelCapabilities:
         assert capabilities == {TaskCapability.TAGS}
 
     @patch("image_annotator_lib.core.config.config_registry")
+    def test_type_fallback_rating_maps_to_ratings_only(self, mock_config_registry):
+        """rating 専用 type は scores/tags を付けず RATINGS のみに推論する。"""
+        mock_config_registry.get.side_effect = [[], "rating"]
+
+        capabilities = get_model_capabilities("anime_rating_mobilenetv3_sce_dist")
+
+        assert capabilities == {TaskCapability.RATINGS}
+
+    @patch("image_annotator_lib.core.config.config_registry")
     def test_explicit_capabilities_override_class_based_fallback(self, mock_config_registry):
         """明示 capabilities が指定されていれば class ベースフォールバックは適用しない。
 


### PR DESCRIPTION
## Summary
- Add `model_type="rating"` as the primary type for rating-only annotators.
- Classify AnimeRatingAnnotator configs as `rating` while preserving `RATINGS` as the output capability.
- Keep tagger/scorer + ratings models classified as their primary task plus ratings.

## Tests
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest local_packages/image-annotator-lib/tests/unit/fast/test_list_annotator_info.py local_packages/image-annotator-lib/tests/unit/test_capability_utils.py -q`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check ...`