### PR TITLE
feat: add OpenAI Moderations rating conversion (#119)

### DIFF
--- a/src/image_annotator_lib/webapi/openai_moderations.py
+++ b/src/image_annotator_lib/webapi/openai_moderations.py
@@ -1,0 +1,123 @@
+"""OpenAI Moderations → LoRAIro rating conversion utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from image_annotator_lib.core.types import RatingPrediction
+
+
+OPENAI_MODERATION_SOURCE_SCHEME = "openai_moderation_v1"
+
+
+@dataclass(frozen=True)
+class _RatedCategory:
+    raw_label: str
+    confidence_score: float
+    weight: int
+
+
+_RATING_ORDER = ("pg", "pg13", "r", "x", "xxx")
+
+# Priority from low to high by index; when multiple conditions match, choose the highest index.
+_CATEGORY_RULES: dict[str, list[tuple[float, str]]] = {
+    "sexual": [(0.30, "pg13"), (0.60, "r"), (0.90, "x"), (0.98, "xxx")],
+    "violence": [(0.60, "pg13")],
+    "violence/graphic": [(0.50, "r")],
+    "self-harm": [(0.70, "r")],
+    "self-harm/intent": [(0.70, "r")],
+    "self-harm/instructions": [(0.70, "r")],
+}
+
+_IGNORED_CATEGORIES = {
+    "harassment",
+    "harassment/threatening",
+    "hate",
+    "hate/threatening",
+    "illicit",
+    "illicit/violent",
+    "sexual/minors",
+}
+
+
+def _to_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _extract_result_payload(response: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Accept either a moderation result object or parent API response."""
+
+    if "results" in response and isinstance(response["results"], list) and response["results"]:
+        first = response["results"][0]
+        if isinstance(first, dict):
+            return first
+    return response
+
+
+def _iter_category_scores(response: Mapping[str, Any]) -> Mapping[str, float]:
+    raw_scores = response.get("category_scores")
+    if not isinstance(raw_scores, Mapping):
+        return {}
+
+    scores: dict[str, float] = {}
+    for category, score in raw_scores.items():
+        if category in _IGNORED_CATEGORIES:
+            continue
+        if category not in _CATEGORY_RULES:
+            continue
+        normalized = _to_float(score)
+        if normalized is None:
+            continue
+        scores[category] = normalized
+    return scores
+
+
+def _select_rating(scores: Mapping[str, float]) -> tuple[str, float] | None:
+    best: _RatedCategory | None = None
+    for category, score in scores.items():
+        rule_list = _CATEGORY_RULES[category]
+        candidate: str | None = None
+        for threshold, raw_label in rule_list:
+            if score >= threshold:
+                candidate = raw_label
+        if candidate is None:
+            continue
+
+        weight = _RATING_ORDER.index(candidate)
+        candidate_rating = _RatedCategory(raw_label=candidate, confidence_score=score, weight=weight)
+
+        if (
+            best is None
+            or candidate_rating.weight > best.weight
+            or (
+                candidate_rating.weight == best.weight
+                and candidate_rating.confidence_score > best.confidence_score
+            )
+        ):
+            best = candidate_rating
+
+    if best is None:
+        return None
+    return (best.raw_label, best.confidence_score)
+
+
+def category_scores_to_rating_prediction(response: Mapping[str, Any]) -> RatingPrediction:
+    """Convert a single OpenAI moderation result to a `RatingPrediction`."""
+
+    if not isinstance(response, Mapping):
+        return RatingPrediction(raw_label="pg", source_scheme=OPENAI_MODERATION_SOURCE_SCHEME, confidence_score=None)
+
+    result = _extract_result_payload(response)
+    scores = _iter_category_scores(result)
+    selected = _select_rating(scores)
+
+    if selected is None:
+        return RatingPrediction(raw_label="pg", source_scheme=OPENAI_MODERATION_SOURCE_SCHEME, confidence_score=None)
+
+    raw_label, confidence = selected
+    return RatingPrediction(raw_label=raw_label, source_scheme=OPENAI_MODERATION_SOURCE_SCHEME, confidence_score=confidence)

--- a/tests/unit/webapi/test_openai_moderations.py
+++ b/tests/unit/webapi/test_openai_moderations.py
@@ -1,0 +1,138 @@
+"""Tests for OpenAI Moderations -> RatingPrediction conversion."""
+
+from __future__ import annotations
+
+from image_annotator_lib.core.types import RatingPrediction
+from image_annotator_lib.webapi.openai_moderations import (
+    OPENAI_MODERATION_SOURCE_SCHEME,
+    category_scores_to_rating_prediction,
+)
+
+
+def test_category_scores_defaults_to_pg_when_no_match() -> None:
+    result = category_scores_to_rating_prediction({"category_scores": {"violence": 0.10}})
+
+    assert result == RatingPrediction(
+        raw_label="pg",
+        source_scheme=OPENAI_MODERATION_SOURCE_SCHEME,
+        confidence_score=None,
+    )
+
+
+def test_ignores_unscoped_categories() -> None:
+    result = category_scores_to_rating_prediction(
+        {
+            "category_scores": {
+                "harassment": 0.99,
+                "hate": 0.99,
+                "illicit/violent": 0.99,
+                "sexual/minors": 0.99,
+            }
+        }
+    )
+
+    assert result.raw_label == "pg"
+    assert result.source_scheme == OPENAI_MODERATION_SOURCE_SCHEME
+
+
+def test_sexual_boundary_pg13() -> None:
+    assert category_scores_to_rating_prediction({"category_scores": {"sexual": 0.30}}).raw_label == "pg13"
+    assert category_scores_to_rating_prediction({"category_scores": {"sexual": 0.29}}).raw_label == "pg"
+
+
+def test_sexual_boundary_r_and_x() -> None:
+    assert category_scores_to_rating_prediction({"category_scores": {"sexual": 0.60}}).raw_label == "r"
+    assert category_scores_to_rating_prediction({"category_scores": {"sexual": 0.89}}).raw_label == "r"
+    assert category_scores_to_rating_prediction({"category_scores": {"sexual": 0.90}}).raw_label == "x"
+
+
+def test_sexual_boundary_xxx() -> None:
+    assert category_scores_to_rating_prediction({"category_scores": {"sexual": 0.98}}).raw_label == "xxx"
+    assert category_scores_to_rating_prediction({"category_scores": {"sexual": 0.99}}).raw_label == "xxx"
+
+
+def test_violence_graphic_is_capped_at_r() -> None:
+    assert category_scores_to_rating_prediction(
+        {"category_scores": {"violence/graphic": 0.99}}
+    ).raw_label == "r"
+
+
+def test_violence_graphic_and_violence_choose_same_or_heavier_label() -> None:
+    result = category_scores_to_rating_prediction(
+        {"category_scores": {"violence/graphic": 0.99, "violence": 0.99}}
+    )
+
+    assert result.raw_label == "r"
+
+
+def test_self_harm_categories_share_r_threshold() -> None:
+    result = category_scores_to_rating_prediction(
+        {
+            "category_scores": {
+                "self-harm": 0.70,
+                "self-harm/intent": 0.70,
+                "self-harm/instructions": 0.70,
+            }
+        }
+    )
+
+    assert result.raw_label == "r"
+
+
+def test_selects_heaviest_label_across_categories() -> None:
+    result = category_scores_to_rating_prediction(
+        {
+            "category_scores": {
+                "sexual": 0.99,
+                "violence": 0.99,
+            }
+        }
+    )
+
+    assert result.raw_label == "xxx"
+
+
+def test_confidence_score_follows_selected_raw_rating_category() -> None:
+    result = category_scores_to_rating_prediction(
+        {
+            "category_scores": {
+                "violence": 0.70,
+                "sexual": 0.61,
+            }
+        }
+    )
+
+    assert result.confidence_score == 0.61
+
+
+def test_confidence_score_uses_highest_of_equal_label_weight() -> None:
+    result = category_scores_to_rating_prediction(
+        {
+            "category_scores": {
+                "sexual": 0.61,
+                "self-harm": 0.70,
+            }
+        }
+    )
+
+    assert result.raw_label == "r"
+    assert result.confidence_score == 0.70
+
+
+def test_accepts_openai_result_payload_shape() -> None:
+    result = category_scores_to_rating_prediction(
+        {
+            "id": "modr-123",
+            "results": [
+                {
+                    "flagged": True,
+                    "category_scores": {
+                        "sexual": 0.60,
+                        "violence": 0.20,
+                    },
+                }
+            ],
+        }
+    )
+
+    assert result.raw_label == "r"


### PR DESCRIPTION
## Summary
- Add OpenAI Moderations category-score → RatingPrediction conversion utility for issue #119.
- Add unit tests covering thresholds, ignored categories, and payload shape handling.

## Verification
- targeted unit tests:  -> 12 passed
- iam-lib CI-equivalent: ============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-8.4.2, pluggy-1.6.0
rootdir: /tmp/worktrees/issue-507-t1/local_packages/image-annotator-lib
configfile: pyproject.toml
testpaths: tests
plugins: bdd-8.1.0, xdist-3.8.0, clarity-1.0.1, logfire-4.14.2, cov-7.0.0, anyio-4.11.0, mock-3.15.1
collected 761 items / 11 deselected / 750 selected

tests/features/test_model_factory_v2.py .......                          [  0%]
tests/integration/test_config_migration.py ................              [  3%]
tests/integration/test_context_manager_lifecycle_integration.py ......   [  3%]
tests/integration/test_context_manager_robustness.py ....                [  4%]
tests/integration/test_list_annotator_info_e2e.py .                      [  4%]
tests/integration/test_model_factory_integration.py ........             [  5%]
tests/unit/core/base/test_onnx.py .............                          [  7%]
tests/unit/core/base/test_tensorflow.py ................                 [  9%]
tests/unit/core/test_annotation_runner.py .....                          [ 10%]
tests/unit/core/test_api_model_discovery_filter.py ..................... [ 12%]
..........                                                               [ 14%]
tests/unit/core/test_base_annotator_di.py ..............                 [ 16%]
tests/unit/core/test_build_results_strict_typing.py ...                  [ 16%]
tests/unit/core/test_config_errors.py ...                                [ 16%]
tests/unit/core/test_error_handling.py ...............................   [ 21%]
tests/unit/core/test_filesystem_errors.py ...                            [ 21%]
tests/unit/core/test_http_retry.py ...........................           [ 25%]
tests/unit/core/test_http_retry_transport.py ........................    [ 28%]
tests/unit/core/test_image_preprocess.py ....                            [ 28%]
tests/unit/core/test_lazy_torch_import.py .                              [ 28%]
tests/unit/core/test_memory_device_errors.py .                           [ 29%]
tests/unit/core/test_model_config.py ................................... [ 33%]
......                                                                   [ 34%]
tests/unit/core/test_model_factory.py .................................. [ 39%]
.................                                                        [ 41%]
tests/unit/core/test_model_factory_errors.py ........                    [ 42%]
tests/unit/core/test_model_factory_memory.py ........                    [ 43%]
tests/unit/core/test_model_id.py ....................                    [ 46%]
tests/unit/core/test_onnx_loader.py ....                                 [ 46%]
tests/unit/core/test_output_normalization.py .....................       [ 49%]
tests/unit/core/test_provider_manager_event_loop_context.py ....         [ 50%]
tests/unit/core/test_provider_manager_exception_chain.py .........       [ 51%]
tests/unit/core/test_provider_manager_logger_keyerror.py .               [ 51%]
tests/unit/core/test_provider_manager_output_normalization.py .          [ 51%]
tests/unit/core/test_provider_manager_refusal.py ....................... [ 54%]
...................                                                      [ 57%]
tests/unit/core/test_result_adapter.py .......                           [ 58%]
tests/unit/core/test_utils.py ...........................                [ 61%]
tests/unit/core/test_webapi_annotator.py ...........                     [ 63%]
tests/unit/fast/test_annotation_runner.py ......                         [ 63%]
tests/unit/fast/test_basic_error_handling.py .........                   [ 65%]
tests/unit/fast/test_config.py ............................              [ 68%]
tests/unit/fast/test_list_annotator_info.py ...................          [ 71%]
tests/unit/fast/test_model_errors.py .                                   [ 71%]
tests/unit/model_class/test_camie_tagger.py ...                          [ 71%]
tests/unit/model_class/test_rating_onnx.py ....                          [ 72%]
tests/unit/model_class/test_scorer_models.py .......                     [ 73%]
tests/unit/model_class/test_tagger_onnx.py ...........                   [ 74%]
tests/unit/model_class/test_tagger_tensorflow.py ...................     [ 77%]
tests/unit/model_class/test_tagger_transformers.py ..........            [ 78%]
tests/unit/standard/core/base/test_annotator.py ..................       [ 81%]
tests/unit/standard/core/base/test_transfomers.py ........               [ 82%]
tests/unit/standard/core/test_base.py .....                              [ 82%]
tests/unit/standard/core/test_model_factory_unit.py ..............       [ 84%]
tests/unit/standard/core/test_registry.py ............                   [ 86%]
tests/unit/standard/core/test_registry_helpers.py .................      [ 88%]
tests/unit/standard/core/test_webapi_metadata_isolation.py ..........    [ 89%]
tests/unit/test_capability_utils.py ................                     [ 92%]
tests/unit/test_capability_validation.py .....................           [ 94%]
tests/unit/test_import_smoke.py ..                                       [ 95%]
tests/unit/test_unified_validation_schema.py ........                    [ 96%]
tests/unit/webapi/batch/test_anthropic_adapter.py ..............         [ 98%]
tests/unit/webapi/batch/test_batch_public_api.py ...                     [ 98%]
tests/unit/webapi/test_openai_moderations.py ............                [100%]

===================== 750 passed, 11 deselected in 28.81s ====================== -> 750 passed, 11 deselected, 0 skipped

Refs:
- closes #119 in image-annotator-lib
