### PR TITLE
feat: add OpenAI batch adapter for moderation endpoint

### DIFF
--- a/src/image_annotator_lib/webapi/batch/adapters/openai.py
+++ b/src/image_annotator_lib/webapi/batch/adapters/openai.py
@@ -40,10 +40,11 @@ def _load_openai_converter() -> Any:
     try:
         module = import_module("image_annotator_lib.webapi.openai_moderations")
         return module.category_scores_to_rating_prediction
-    except (ModuleNotFoundError, AttributeError):
-        return lambda response: RatingPrediction(
-            raw_label="pg", source_scheme="openai_moderation_v1", confidence_score=None
-        )
+    except (ModuleNotFoundError, AttributeError) as exc:
+        raise RuntimeError(
+            "OpenAI batch adapter requires image_annotator_lib.webapi.openai_moderations. "
+            "Merge feat/issue-119-openai-moderations before using /v1/moderations batch."
+        ) from exc
 
 
 _CATEGORY_SCORES_TO_RATING_PREDICTION = _load_openai_converter()

--- a/src/image_annotator_lib/webapi/batch/adapters/openai.py
+++ b/src/image_annotator_lib/webapi/batch/adapters/openai.py
@@ -1,0 +1,593 @@
+"""OpenAI Batch API adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+from datetime import datetime
+from importlib import import_module
+from typing import Any
+
+from image_annotator_lib.core.types import RatingPrediction, TaskCapability, UnifiedAnnotationResult
+from image_annotator_lib.webapi.model_id import resolve_model_ref
+
+from ..preparation import build_openai_moderations_jsonl, prepare_items
+from ..types import (
+    BatchErrorPhase,
+    BatchFetchResult,
+    BatchItemError,
+    BatchItemStatus,
+    BatchJobError,
+    BatchJobHandle,
+    BatchProviderItemStatus,
+    BatchResultItem,
+    BatchStatus,
+    BatchStatusResult,
+    BatchSubmitRequest,
+    BatchSubmitResult,
+)
+
+
+_PROVIDER = "openai"
+_MAX_LIBRARY_ITEMS = 500
+_SUPPORTED_PROMPT_PROFILES = frozenset({"default"})
+_SUPPORTED_ENDPOINTS = frozenset({"/v1/moderations", "/v1/moderations/"})
+_DEFAULT_COMPLETION_WINDOW = "24h"
+_SUPPORTED_CAPABILITIES = frozenset({TaskCapability.RATINGS})
+
+
+def _load_openai_converter() -> Any:
+    try:
+        module = import_module("image_annotator_lib.webapi.openai_moderations")
+        return module.category_scores_to_rating_prediction
+    except (ModuleNotFoundError, AttributeError):
+        return lambda response: RatingPrediction(
+            raw_label="pg", source_scheme="openai_moderation_v1", confidence_score=None
+        )
+
+
+_CATEGORY_SCORES_TO_RATING_PREDICTION = _load_openai_converter()
+
+
+class OpenAIBatchAdapter:
+    """Adapter for OpenAI Batch API."""
+
+    @staticmethod
+    def batch_metadata() -> dict[str, Any]:
+        return {
+            "provider_batch_api": "openai_batch",
+            "result_retention_days": 29,
+            "zero_data_retention_eligible": True,
+            "provider_max_requests": 100_000,
+            "provider_max_body_bytes": 4 * 1024 * 1024,
+            "library_max_items": _MAX_LIBRARY_ITEMS,
+        }
+
+    def submit_batch(self, request: BatchSubmitRequest) -> BatchSubmitResult:
+        if request.provider.lower() != _PROVIDER:
+            raise self._job_error(
+                BatchErrorPhase.PREPARE,
+                None,
+                "unsupported_provider",
+                f"OpenAI adapter cannot submit provider: {request.provider}",
+                retryable=False,
+            )
+        endpoint = request.endpoint or ""
+        normalized_endpoint = endpoint if endpoint.startswith("/") else f"/{endpoint}"
+        if normalized_endpoint not in _SUPPORTED_ENDPOINTS:
+            raise self._job_error(
+                BatchErrorPhase.PREPARE,
+                None,
+                "unsupported_endpoint",
+                f"OpenAI batch adapter only supports {sorted(_SUPPORTED_ENDPOINTS)}, got: {endpoint}",
+                retryable=False,
+            )
+        api_key = self._api_key(request.api_keys, provider_job_id=None, phase=BatchErrorPhase.PREPARE)
+        if len(request.items) > _MAX_LIBRARY_ITEMS:
+            raise self._job_error(
+                BatchErrorPhase.PREPARE,
+                None,
+                "too_many_items",
+                f"Batch contains {len(request.items)} items; maximum is {_MAX_LIBRARY_ITEMS}",
+                retryable=False,
+            )
+        if request.prompt_profile not in _SUPPORTED_PROMPT_PROFILES:
+            raise self._job_error(
+                BatchErrorPhase.PREPARE,
+                None,
+                "unsupported_prompt_profile",
+                f"Unsupported OpenAI batch prompt_profile: {request.prompt_profile}",
+                retryable=False,
+            )
+
+        model_ref = self._resolve_model_ref(request.litellm_model_id)
+        prepared = prepare_items(request.items, provider=_PROVIDER)
+        request_payload = build_openai_moderations_jsonl(
+            prepared,
+            endpoint=normalized_endpoint,
+            litellm_model_id=model_ref.provider_model_id,
+        )
+
+        try:
+            input_file = self._client(api_key).files.create(
+                file=("requests.jsonl", request_payload),
+                purpose="batch",
+            )
+        except Exception as exc:
+            raise self._job_error(
+                BatchErrorPhase.UPLOAD,
+                None,
+                "upload_failed",
+                self._format_exception(exc),
+                retryable=self._is_retryable_exception(exc),
+            ) from exc
+
+        input_file_id = str(_get(input_file, "id") or "")
+        if not input_file_id:
+            raise self._job_error(
+                BatchErrorPhase.UPLOAD,
+                None,
+                "missing_input_file_id",
+                "OpenAI batch input upload response did not include an id",
+                retryable=False,
+            )
+
+        try:
+            batch = self._client(api_key).batches.create(
+                input_file_id=input_file_id,
+                endpoint=normalized_endpoint,
+                completion_window=_DEFAULT_COMPLETION_WINDOW,
+            )
+        except Exception as exc:
+            raise self._job_error(
+                BatchErrorPhase.SUBMIT,
+                None,
+                "submit_failed",
+                self._format_exception(exc),
+                retryable=self._is_retryable_exception(exc),
+            ) from exc
+
+        provider_job_id = str(_get(batch, "id") or "")
+        if not provider_job_id:
+            raise self._job_error(
+                BatchErrorPhase.SUBMIT,
+                None,
+                "missing_provider_job_id",
+                "OpenAI batch create response did not include an id",
+                retryable=False,
+            )
+        return BatchSubmitResult(
+            provider=_PROVIDER,
+            provider_job_id=provider_job_id,
+            status=_status_from_batch(batch),
+            request_count=_request_count(batch) or len(request.items),
+        )
+
+    def retrieve_batch(self, handle: BatchJobHandle) -> BatchStatusResult:
+        return self._retrieve_status(handle, phase=BatchErrorPhase.POLL)
+
+    def cancel_batch(self, handle: BatchJobHandle) -> BatchStatusResult:
+        api_key = self._api_key(handle.api_keys, provider_job_id=handle.provider_job_id, phase=BatchErrorPhase.CANCEL)
+        try:
+            batch = self._client(api_key).batches.cancel(handle.provider_job_id)
+        except Exception as exc:
+            raise self._job_error(
+                BatchErrorPhase.CANCEL,
+                handle.provider_job_id,
+                "cancel_failed",
+                self._format_exception(exc),
+                retryable=self._is_retryable_exception(exc),
+            ) from exc
+        return _to_status_result(batch, provider_job_id=handle.provider_job_id)
+
+    def fetch_batch_results(self, handle: BatchJobHandle) -> BatchFetchResult:
+        status = self._retrieve_status(handle, phase=BatchErrorPhase.DOWNLOAD)
+        if status.status not in {
+            BatchStatus.COMPLETED,
+            BatchStatus.FAILED,
+            BatchStatus.CANCELED,
+            BatchStatus.EXPIRED,
+        }:
+            raise self._job_error(
+                BatchErrorPhase.DOWNLOAD,
+                handle.provider_job_id,
+                "job_not_completed",
+                "OpenAI batch results are not available until processing has ended",
+                retryable=True,
+            )
+
+        api_key = self._api_key(handle.api_keys, provider_job_id=handle.provider_job_id, phase=BatchErrorPhase.DOWNLOAD)
+        try:
+            batch = self._client(api_key).batches.retrieve(handle.provider_job_id)
+        except Exception as exc:
+            raise self._job_error(
+                BatchErrorPhase.DOWNLOAD,
+                handle.provider_job_id,
+                "download_failed",
+                self._format_exception(exc),
+                retryable=self._is_retryable_exception(exc),
+            ) from exc
+
+        status = _to_status_result(batch, provider_job_id=handle.provider_job_id)
+        output_file_id = _get(batch, "output_file_id")
+        error_file_id = _get(batch, "error_file_id")
+
+        if not output_file_id and not error_file_id:
+            raise self._job_error(
+                BatchErrorPhase.DOWNLOAD,
+                handle.provider_job_id,
+                "result_file_missing",
+                "OpenAI batch completed but did not provide output/error file IDs",
+                retryable=False,
+            )
+
+        seen: dict[str, int] = {}
+        items: list[BatchResultItem] = []
+        if output_file_id:
+            output_lines = self._read_jsonl_lines(api_key, str(output_file_id))
+            items.extend(self._parse_output_lines(output_lines, seen))
+        if error_file_id:
+            error_lines = self._read_jsonl_lines(api_key, str(error_file_id))
+            items.extend(self._parse_error_lines(error_lines, seen))
+
+        return BatchFetchResult(
+            provider=_PROVIDER,
+            provider_job_id=handle.provider_job_id,
+            status=status.status,
+            items=items,
+        )
+
+    def _retrieve_status(self, handle: BatchJobHandle, *, phase: BatchErrorPhase) -> BatchStatusResult:
+        api_key = self._api_key(handle.api_keys, provider_job_id=handle.provider_job_id, phase=phase)
+        try:
+            batch = self._client(api_key).batches.retrieve(handle.provider_job_id)
+        except Exception as exc:
+            raise self._job_error(
+                phase,
+                handle.provider_job_id,
+                "retrieve_failed",
+                self._format_exception(exc),
+                retryable=self._is_retryable_exception(exc),
+            ) from exc
+        return _to_status_result(batch, provider_job_id=handle.provider_job_id)
+
+    def _parse_output_lines(self, lines: list[str], seen: dict[str, int]) -> list[BatchResultItem]:
+        parsed: list[BatchResultItem] = []
+        for raw in lines:
+            parsed_item = self._normalize_result_item(raw, line_type="output")
+            if parsed_item is None:
+                continue
+            if parsed_item.custom_id in seen:
+                continue
+            seen[parsed_item.custom_id] = len(parsed) + 1
+            parsed.append(parsed_item)
+        return parsed
+
+    def _parse_error_lines(self, lines: list[str], seen: dict[str, int]) -> list[BatchResultItem]:
+        parsed: list[BatchResultItem] = []
+        for raw in lines:
+            parsed_item = self._normalize_result_item(raw, line_type="error")
+            if parsed_item is None:
+                continue
+            if parsed_item.custom_id in seen:
+                continue
+            seen[parsed_item.custom_id] = len(parsed) + 1
+            parsed.append(parsed_item)
+        return parsed
+
+    def _normalize_result_item(self, raw_line: str, *, line_type: str) -> BatchResultItem | None:
+        if not raw_line.strip():
+            return None
+        try:
+            obj = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            raise self._job_error(
+                BatchErrorPhase.PARSE,
+                None,
+                "result_line_parse_failed",
+                self._format_exception(exc),
+                retryable=False,
+            ) from exc
+
+        if not isinstance(obj, dict):
+            return None
+
+        custom_id = str(obj.get("custom_id") or "")
+        if not custom_id:
+            return None
+
+        if line_type == "error":
+            error = _get(obj, "error")
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.FAILED,
+                BatchErrorPhase.NORMALIZE,
+                "provider_batch_error",
+                str(_get(error, "message") or _get(obj, "message") or "OpenAI batch item error"),
+                retryable=_provider_item_retryable(error),
+            )
+
+        response = _get(obj, "response")
+        if not isinstance(response, dict):
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.UNKNOWN,
+                BatchErrorPhase.PARSE,
+                "result_response_missing",
+                "OpenAI output line did not include response payload",
+                retryable=False,
+            )
+
+        provider_status = _provider_item_status(response)
+        if provider_status is not BatchProviderItemStatus.SUCCEEDED:
+            error = _get(response, "error")
+            return _failed_result_item(
+                custom_id,
+                provider_status,
+                BatchErrorPhase.NORMALIZE,
+                "provider_item_error",
+                str(_get(error, "message") or _get(response, "error") or "OpenAI batch item failed"),
+                retryable=_provider_item_retryable(error),
+            )
+
+        moderation_response = _extract_moderation_response(response)
+        if not isinstance(moderation_response, Mapping):
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.UNKNOWN,
+                BatchErrorPhase.PARSE,
+                "result_response_invalid",
+                "OpenAI output response payload was not a mapping",
+                retryable=False,
+            )
+        rating = _CATEGORY_SCORES_TO_RATING_PREDICTION(moderation_response)
+        return BatchResultItem(
+            custom_id=custom_id,
+            status=BatchItemStatus.SUCCEEDED,
+            provider_status=BatchProviderItemStatus.SUCCEEDED,
+            annotation=_to_unified(rating),
+            error=None,
+        )
+
+    def _read_jsonl_lines(self, api_key: str, file_id: str) -> list[str]:
+        try:
+            content = self._client(api_key).files.content(file_id)
+        except Exception as exc:
+            raise self._job_error(
+                BatchErrorPhase.DOWNLOAD,
+                None,
+                "result_file_download_failed",
+                self._format_exception(exc),
+                retryable=self._is_retryable_exception(exc),
+            ) from exc
+
+        if isinstance(content, str):
+            return content.splitlines()
+        if isinstance(content, bytes):
+            return content.decode("utf-8").splitlines()
+        if isinstance(content, dict) and "text" in content:
+            return str(content["text"]).splitlines()
+        if isinstance(getattr(content, "text", None), str):
+            return str(content.text).splitlines()
+        if hasattr(content, "read"):
+            payload = content.read()
+            if isinstance(payload, bytes):
+                return payload.decode("utf-8").splitlines()
+            if isinstance(payload, str):
+                return payload.splitlines()
+            if payload is not None:
+                return str(payload).splitlines()
+        return []
+
+    def _api_key(self, api_keys: dict[str, str], *, provider_job_id: str | None, phase: BatchErrorPhase) -> str:
+        api_key = api_keys.get(_PROVIDER)
+        if not api_key:
+            raise self._job_error(
+                phase,
+                provider_job_id,
+                "missing_api_key",
+                "Missing OpenAI API key in api_keys['openai']",
+                retryable=False,
+            )
+        return api_key
+
+    def _resolve_model_ref(self, litellm_model_id: str):
+        try:
+            ref = resolve_model_ref(litellm_model_id)
+        except Exception as exc:
+            raise self._job_error(
+                BatchErrorPhase.PREPARE,
+                None,
+                "invalid_model_id",
+                self._format_exception(exc),
+                retryable=False,
+            ) from exc
+        if ref.provider != _PROVIDER:
+            raise self._job_error(
+                BatchErrorPhase.PREPARE,
+                None,
+                "unsupported_model_provider",
+                f"OpenAI batch requires an openai model, got: {litellm_model_id}",
+                retryable=False,
+            )
+        return ref
+
+    def _client(self, api_key: str) -> Any:
+        import openai
+
+        return openai.OpenAI(api_key=api_key)
+
+    def _job_error(
+        self,
+        phase: BatchErrorPhase,
+        provider_job_id: str | None,
+        code: str,
+        message: str,
+        *,
+        retryable: bool,
+    ) -> BatchJobError:
+        return BatchJobError(
+            phase=phase,
+            provider=_PROVIDER,
+            provider_job_id=provider_job_id,
+            code=code,
+            message=message,
+            retryable=retryable,
+        )
+
+    @staticmethod
+    def _format_exception(exc: Exception) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+    @staticmethod
+    def _is_retryable_exception(exc: Exception) -> bool:
+        status_code = getattr(exc, "status_code", None)
+        if isinstance(status_code, int) and (status_code == 429 or status_code >= 500):
+            return True
+        error_type = getattr(exc, "type", "")
+        return str(error_type).lower() in {"api_error", "server_error", "overloaded_error", "rate_limit_error"}
+
+
+def _to_unified(prediction: RatingPrediction) -> UnifiedAnnotationResult:
+    return UnifiedAnnotationResult(
+        model_name="openai_batch",
+        capabilities=_SUPPORTED_CAPABILITIES,
+        ratings=[prediction],
+        provider_name=_PROVIDER,
+        framework="openai_batch",
+        raw_output=None,
+    )
+
+
+def _extract_moderation_response(response: Mapping[str, Any] | Any) -> Any:
+    body = _get(response, "body")
+    if isinstance(body, dict):
+        return body
+    return response
+
+
+def _provider_item_status(response: Mapping[str, Any] | Any) -> BatchProviderItemStatus:
+    if not isinstance(response, Mapping):
+        return BatchProviderItemStatus.UNKNOWN
+    status_code = _get(response, "status_code")
+    if isinstance(status_code, int):
+        if 200 <= status_code < 300:
+            return BatchProviderItemStatus.SUCCEEDED
+        return BatchProviderItemStatus.FAILED
+    return BatchProviderItemStatus.UNKNOWN
+
+
+def _provider_item_retryable(error: Any) -> bool:
+    if not isinstance(error, Mapping):
+        return False
+    if str(_get(error, "type")).lower() in {"server_error", "overloaded_error", "rate_limit_error", "api_error"}:
+        return True
+    status_code = _get(error, "status_code")
+    return isinstance(status_code, int) and (status_code == 429 or status_code >= 500)
+
+
+def _failed_result_item(
+    custom_id: str,
+    provider_status: BatchProviderItemStatus,
+    phase: BatchErrorPhase,
+    code: str,
+    message: str,
+    *,
+    retryable: bool,
+) -> BatchResultItem:
+    return BatchResultItem(
+        custom_id=custom_id,
+        status=BatchItemStatus.FAILED,
+        provider_status=provider_status,
+        annotation=None,
+        error=BatchItemError(
+            phase=phase,
+            code=code,
+            message=message,
+            retryable=retryable,
+        ),
+    )
+
+
+def _request_counts(batch: Any) -> Any:
+    return _get(batch, "request_counts") or {}
+
+
+def _count(batch: Any, name: str) -> int | None:
+    value = _get(_request_counts(batch), name)
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def _request_count(batch: Any) -> int | None:
+    counts = [_count(batch, key) for key in ("processing", "succeeded", "errored", "canceled", "expired")]
+    known_counts = [count for count in counts if count is not None]
+    return sum(known_counts) if known_counts else None
+
+
+def _status_from_batch(batch: Any) -> BatchStatus:
+    processing_status = str(_get(batch, "processing_status") or "").lower()
+    if processing_status in {"in_progress", "validating", "cancelling", "canceling", "finalizing", "queued"}:
+        return BatchStatus.RUNNING
+    if processing_status == "cancelled":
+        return BatchStatus.CANCELED
+    if processing_status == "expired":
+        return BatchStatus.EXPIRED
+    if processing_status == "failed":
+        return BatchStatus.FAILED
+    if processing_status in {"completed", "ended"}:
+        total = _request_count(batch) or 0
+        succeeded = _count(batch, "succeeded") or 0
+        errored = _count(batch, "errored") or 0
+        canceled = _count(batch, "canceled") or 0
+        expired = _count(batch, "expired") or 0
+        if total and canceled == total:
+            return BatchStatus.CANCELED
+        if total and expired == total:
+            return BatchStatus.EXPIRED
+        if total and succeeded == 0 and errored == total:
+            return BatchStatus.FAILED
+        return BatchStatus.COMPLETED
+    return BatchStatus.UNKNOWN
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if value is None or isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return None
+
+
+def _to_status_result(batch: Any, *, provider_job_id: str) -> BatchStatusResult:
+    return BatchStatusResult(
+        provider=_PROVIDER,
+        provider_job_id=str(_get(batch, "id") or provider_job_id),
+        status=_status_from_batch(batch),
+        request_count=_request_count(batch),
+        succeeded_count=_count(batch, "succeeded"),
+        failed_count=_count(batch, "errored"),
+        canceled_count=_count(batch, "canceled"),
+        expired_count=_count(batch, "expired"),
+        submitted_at=_parse_datetime(_get(batch, "created_at")),
+        completed_at=_parse_datetime(_get(batch, "completed_at") or _get(batch, "ended_at")),
+        expires_at=_parse_datetime(_get(batch, "expires_at")),
+    )
+
+
+def _get(obj: Any, name: str, default: Any | None = None) -> Any:
+    dumped = _as_dict(obj)
+    if isinstance(dumped, dict):
+        return dumped.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _as_dict(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump()
+        if isinstance(dumped, dict):
+            return dumped
+    if hasattr(value, "__dict__") and isinstance(value.__dict__, dict):
+        return dict(value.__dict__)
+    return None

--- a/src/image_annotator_lib/webapi/batch/preparation.py
+++ b/src/image_annotator_lib/webapi/batch/preparation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import json
 import mimetypes
 from dataclasses import dataclass
 from pathlib import Path
@@ -51,3 +53,48 @@ def prepare_items(items: list[BatchSubmitItem], *, provider: str) -> list[Prepar
             )
         )
     return prepared
+
+
+def build_openai_moderations_jsonl(
+    items: list[PreparedBatchItem], *, endpoint: str, litellm_model_id: str
+) -> str:
+    """Build OpenAI batch input JSONL for /v1/moderations requests."""
+
+    lines: list[str] = []
+    for item in items:
+        try:
+            payload_bytes = item.image_path.read_bytes()
+        except OSError as exc:
+            raise BatchJobError(
+                phase=BatchErrorPhase.PREPARE,
+                provider="openai",
+                provider_job_id=None,
+                code="image_read_failed",
+                message=f"Failed to read image for OpenAI batch input: {item.image_path}: {exc}",
+                retryable=False,
+            ) from exc
+        encoded = base64.b64encode(payload_bytes).decode("ascii")
+        lines.append(
+            json.dumps(
+                {
+                    "custom_id": item.custom_id,
+                    "method": "POST",
+                    "url": endpoint,
+                    "body": {
+                        "model": litellm_model_id,
+                        "input": [
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": f"data:{item.image_mime_type};base64,{encoded}",
+                                },
+                            }
+                        ],
+                    },
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        )
+
+    return "\n".join(lines)

--- a/src/image_annotator_lib/webapi/batch/service.py
+++ b/src/image_annotator_lib/webapi/batch/service.py
@@ -8,6 +8,7 @@ from image_annotator_lib.core.registry import get_webapi_metadata, list_availabl
 from image_annotator_lib.core.types import TaskCapability
 
 from .adapters.anthropic import AnthropicBatchAdapter
+from .adapters.openai import OpenAIBatchAdapter
 from .types import (
     BatchErrorPhase,
     BatchFetchResult,
@@ -24,6 +25,8 @@ def _adapter_for_provider(provider: str) -> AnthropicBatchAdapter:
     normalized = provider.lower()
     if normalized == "anthropic":
         return AnthropicBatchAdapter()
+    if normalized == "openai":
+        return OpenAIBatchAdapter()
     raise BatchJobError(
         phase=BatchErrorPhase.PREPARE,
         provider=normalized,
@@ -47,22 +50,30 @@ def _capabilities_from_metadata(value: object) -> frozenset[TaskCapability]:
 
 
 def list_batch_capable_models() -> list[BatchModelInfo]:
-    """Return direct Anthropic models usable with the provider batch route."""
+    """Return direct Anthropic and OpenAI models usable with the provider batch route."""
     models: list[BatchModelInfo] = []
     for model_name in list_available_annotators():
         metadata = get_webapi_metadata(model_name)
-        if not metadata or str(metadata.get("provider", "")).lower() != "anthropic":
+        provider = str(metadata.get("provider", "")).lower()
+        if provider not in {"anthropic", "openai"}:
             continue
         litellm_model_id = metadata.get("litellm_model_id")
         if not isinstance(litellm_model_id, str) or not litellm_model_id:
             continue
+        capabilities = _capabilities_from_metadata(metadata.get("capabilities"))
+        if provider == "openai" and TaskCapability.RATINGS not in capabilities:
+            continue
         models.append(
             BatchModelInfo(
-                provider="anthropic",
+                provider=provider,
                 litellm_model_id=litellm_model_id,
                 display_name=model_name,
-                capabilities=_capabilities_from_metadata(metadata.get("capabilities")),
-                metadata=AnthropicBatchAdapter.batch_metadata(),
+                capabilities=capabilities,
+                metadata=(
+                    OpenAIBatchAdapter.batch_metadata()
+                    if provider == "openai"
+                    else AnthropicBatchAdapter.batch_metadata()
+                ),
             )
         )
     return models

--- a/tests/unit/webapi/batch/test_batch_public_api.py
+++ b/tests/unit/webapi/batch/test_batch_public_api.py
@@ -68,3 +68,32 @@ def test_list_batch_capable_models_returns_anthropic_metadata(monkeypatch) -> No
     assert TaskCapability.RATINGS in models[0].capabilities
     assert models[0].metadata["result_retention_days"] == 29
     assert models[0].metadata["zero_data_retention_eligible"] is False
+
+
+def test_list_batch_capable_models_includes_openai_ratings_model(monkeypatch) -> None:
+    monkeypatch.setattr(service, "list_available_annotators", lambda: ["claude", "gpt"])
+    monkeypatch.setattr(
+        service,
+        "get_webapi_metadata",
+        lambda name: {
+            "claude": {
+                "provider": "anthropic",
+                "litellm_model_id": "anthropic/claude-3-5-haiku-latest",
+                "capabilities": ["tags", "captions", "scores", "ratings"],
+            },
+            "gpt": {
+                "provider": "openai",
+                "litellm_model_id": "openai/omni-moderation-latest",
+                "capabilities": ["ratings"],
+            },
+        }.get(name),
+    )
+
+    models = list_batch_capable_models()
+    providers = {model.provider for model in models}
+
+    assert providers == {"anthropic", "openai"}
+    openai_model = next(model for model in models if model.provider == "openai")
+    assert openai_model.litellm_model_id == "openai/omni-moderation-latest"
+    assert openai_model.metadata["provider_batch_api"] == "openai_batch"
+    assert openai_model.metadata["zero_data_retention_eligible"] is True

--- a/tests/unit/webapi/batch/test_openai_adapter.py
+++ b/tests/unit/webapi/batch/test_openai_adapter.py
@@ -1,0 +1,260 @@
+"""Tests for OpenAI Batch adapter."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from image_annotator_lib.core.types import RatingPrediction
+from image_annotator_lib.webapi.batch import (
+    BatchItemStatus,
+    BatchProviderItemStatus,
+    BatchStatus,
+    BatchSubmitItem,
+    BatchSubmitRequest,
+    BatchJobHandle,
+)
+from image_annotator_lib.webapi.batch.adapters import openai as openai_adapter_module
+from image_annotator_lib.webapi.batch.adapters.openai import OpenAIBatchAdapter
+
+
+def _jsonl(lines: list[object]) -> str:
+    return "\n".join(json.dumps(line, separators=(",", ":")) for line in lines)
+
+
+@dataclass
+class FakeOpenAIFiles:
+    uploaded_file_content: str | None = None
+    contents: dict[str, str] | None = None
+
+    def create(self, *, file: tuple[str, str], purpose: str) -> dict[str, str]:
+        self.uploaded_file_content = file[1]
+        return {"id": "file_001"}
+
+    def content(self, file_id: str) -> str:
+        if not self.contents or file_id not in self.contents:
+            raise RuntimeError(f"missing content for {file_id}")
+        return self.contents[file_id]
+
+
+@dataclass
+class FakeOpenAIBatches:
+    created_input_file_id: str | None = None
+    created_endpoint: str | None = None
+    output_payload: dict[str, object] | None = None
+    output_file_id: str = "file_out"
+    error_file_id: str = "file_err"
+
+    def create(self, *, input_file_id: str, endpoint: str, completion_window: str) -> dict[str, object]:
+        self.created_input_file_id = input_file_id
+        self.created_endpoint = endpoint
+        return {
+            "id": "batch_001",
+            "processing_status": "in_progress",
+            "request_counts": {
+                "processing": 2,
+                "succeeded": 0,
+                "errored": 0,
+                "canceled": 0,
+                "expired": 0,
+            },
+        }
+
+    def retrieve(self, batch_id: str) -> dict[str, object]:
+        if self.output_payload is None:
+            return {
+                "id": batch_id,
+                "processing_status": "completed",
+                "request_counts": {
+                    "processing": 0,
+                    "succeeded": 2,
+                    "errored": 0,
+                    "canceled": 0,
+                    "expired": 0,
+                },
+                "output_file_id": self.output_file_id,
+                "error_file_id": self.error_file_id,
+            }
+        return self.output_payload
+
+    def cancel(self, batch_id: str) -> dict[str, object]:
+        return {"id": batch_id, "processing_status": "cancelled", "request_counts": {"canceled": 1}}
+
+
+def install_fake_openai(monkeypatch: pytest.MonkeyPatch, files: FakeOpenAIFiles, batches: FakeOpenAIBatches) -> None:
+    class FakeOpenAIFactory:
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+            self.files = files
+            self.batches = batches
+
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=FakeOpenAIFactory))
+
+
+def make_request(tmp_path: Path, model_id: str = "openai/omni-moderation-latest") -> BatchSubmitRequest:
+    image_path = tmp_path / "img-1.png"
+    image_path.write_bytes(b"fake-image-bytes")
+    return BatchSubmitRequest(
+        provider="openai",
+        endpoint="/v1/moderations",
+        litellm_model_id=model_id,
+        prompt_profile="default",
+        description=None,
+        api_keys={"openai": "test-key"},
+        items=[BatchSubmitItem(custom_id="img-1", image_id=1, image_path=image_path)],
+    )
+
+
+def test_submit_batch_builds_openai_jsonl_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    files = FakeOpenAIFiles()
+    batches = FakeOpenAIBatches()
+    install_fake_openai(monkeypatch, files=files, batches=batches)
+    request = make_request(tmp_path)
+
+    result = OpenAIBatchAdapter().submit_batch(request)
+
+    assert result.provider_job_id == "batch_001"
+    assert result.status is BatchStatus.RUNNING
+    assert files.uploaded_file_content is not None
+    assert batches.created_endpoint == "/v1/moderations"
+    payload = files.uploaded_file_content.splitlines()[0]
+    assert '"custom_id":"img-1"' in payload
+    assert '"model":"omni-moderation-latest"' in payload
+
+
+def test_fetch_batch_results_normalizes_openai_output_lines(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    files = FakeOpenAIFiles(
+        contents={
+            "file_out": _jsonl(
+                [
+                    {
+                        "custom_id": "img-1",
+                        "response": {"status_code": 200, "body": {"results": [{"category_scores": {"sexual": 0.88}}]}},
+                    },
+                    {
+                        "custom_id": "img-2",
+                        "response": {"status_code": 200, "body": {"results": [{"category_scores": {"violence": 0.25}}]}},
+                    },
+                ]
+            ),
+            "file_err": _jsonl(
+                [
+                    {"custom_id": "img-3", "error": {"type": "server_error", "message": "provider transient"}},
+                ]
+            ),
+        }
+    )
+    batches = FakeOpenAIBatches()
+    install_fake_openai(monkeypatch, files=files, batches=batches)
+    monkeypatch.setattr(
+        openai_adapter_module,
+        "_CATEGORY_SCORES_TO_RATING_PREDICTION",
+        lambda _: RatingPrediction(raw_label="r", source_scheme="openai_moderation_v1", confidence_score=0.88),
+    )
+
+    handle = BatchJobHandle(provider="openai", provider_job_id="batch_001", api_keys={"openai": "test-key"})
+    result = OpenAIBatchAdapter().fetch_batch_results(handle)
+
+    assert result.status is BatchStatus.COMPLETED
+    assert len(result.items) == 3
+    ids = [item.custom_id for item in result.items]
+    assert ids == ["img-1", "img-2", "img-3"]
+    assert result.items[0].status is BatchItemStatus.SUCCEEDED
+    assert result.items[0].annotation is not None
+    assert result.items[0].annotation.ratings[0].raw_label == "r"
+    assert result.items[2].status is BatchItemStatus.FAILED
+    assert result.items[2].provider_status is BatchProviderItemStatus.FAILED
+
+
+def test_fetch_batch_results_marks_output_item_error_and_ignores_extra_lines(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    files = FakeOpenAIFiles(
+        contents={
+            "file_out": _jsonl(
+                [
+                    {
+                        "custom_id": "img-1",
+                        "response": {"status_code": 400, "error": {"message": "model cannot parse"}},
+                    },
+                    {"note": "meta"},
+                    {
+                        "custom_id": "img-2",
+                        "response": {"status_code": 200, "body": {"results": [{"category_scores": {"sexual": 0.5}}]}},
+                    },
+                ]
+            ),
+            "file_err": "",
+        }
+    )
+    batches = FakeOpenAIBatches(
+        output_payload={
+            "id": "batch_001",
+            "processing_status": "completed",
+            "request_counts": {
+                "processing": 0,
+                "succeeded": 1,
+                "errored": 1,
+                "canceled": 0,
+                "expired": 0,
+            },
+            "output_file_id": "file_out",
+            "error_file_id": "file_err",
+        },
+    )
+    install_fake_openai(monkeypatch, files=files, batches=batches)
+    monkeypatch.setattr(
+        openai_adapter_module,
+        "_CATEGORY_SCORES_TO_RATING_PREDICTION",
+        lambda _: RatingPrediction(raw_label="pg", source_scheme="openai_moderation_v1", confidence_score=None),
+    )
+
+    handle = BatchJobHandle(provider="openai", provider_job_id="batch_001", api_keys={"openai": "test-key"})
+    result = OpenAIBatchAdapter().fetch_batch_results(handle)
+
+    assert [item.custom_id for item in result.items] == ["img-1", "img-2"]
+    assert result.items[0].status is BatchItemStatus.FAILED
+    assert result.items[1].status is BatchItemStatus.SUCCEEDED
+
+
+def test_fetch_batch_results_preserves_custom_id_mapping_for_success_items(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    files = FakeOpenAIFiles(
+        contents={
+            "file_out": _jsonl(
+                [
+                    {
+                        "custom_id": "custom-image-42",
+                        "response": {"status_code": 200, "body": {"results": [{"category_scores": {"sexual": 0.2}}]}},
+                    },
+                ]
+            ),
+            "file_err": "",
+        }
+    )
+    batches = FakeOpenAIBatches()
+    install_fake_openai(monkeypatch, files=files, batches=batches)
+    monkeypatch.setattr(
+        openai_adapter_module,
+        "_CATEGORY_SCORES_TO_RATING_PREDICTION",
+        lambda _: RatingPrediction(raw_label="pg", source_scheme="openai_moderation_v1", confidence_score=None),
+    )
+
+    handle = BatchJobHandle(provider="openai", provider_job_id="batch_001", api_keys={"openai": "test-key"})
+    result = OpenAIBatchAdapter().fetch_batch_results(handle)
+
+    assert result.items[0].custom_id == "custom-image-42"
+    assert result.items[0].annotation is not None

--- a/tests/unit/webapi/batch/test_openai_adapter.py
+++ b/tests/unit/webapi/batch/test_openai_adapter.py
@@ -6,11 +6,11 @@ import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+import importlib
 from types import SimpleNamespace
 
 import pytest
 
-from image_annotator_lib.core.types import RatingPrediction
 from image_annotator_lib.webapi.batch import (
     BatchItemStatus,
     BatchProviderItemStatus,
@@ -156,12 +156,6 @@ def test_fetch_batch_results_normalizes_openai_output_lines(
     )
     batches = FakeOpenAIBatches()
     install_fake_openai(monkeypatch, files=files, batches=batches)
-    monkeypatch.setattr(
-        openai_adapter_module,
-        "_CATEGORY_SCORES_TO_RATING_PREDICTION",
-        lambda _: RatingPrediction(raw_label="r", source_scheme="openai_moderation_v1", confidence_score=0.88),
-    )
-
     handle = BatchJobHandle(provider="openai", provider_job_id="batch_001", api_keys={"openai": "test-key"})
     result = OpenAIBatchAdapter().fetch_batch_results(handle)
 
@@ -172,6 +166,7 @@ def test_fetch_batch_results_normalizes_openai_output_lines(
     assert result.items[0].status is BatchItemStatus.SUCCEEDED
     assert result.items[0].annotation is not None
     assert result.items[0].annotation.ratings[0].raw_label == "r"
+    assert result.items[0].annotation.ratings[0].source_scheme == "openai_moderation_v1"
     assert result.items[2].status is BatchItemStatus.FAILED
     assert result.items[2].provider_status is BatchProviderItemStatus.FAILED
 
@@ -214,12 +209,6 @@ def test_fetch_batch_results_marks_output_item_error_and_ignores_extra_lines(
         },
     )
     install_fake_openai(monkeypatch, files=files, batches=batches)
-    monkeypatch.setattr(
-        openai_adapter_module,
-        "_CATEGORY_SCORES_TO_RATING_PREDICTION",
-        lambda _: RatingPrediction(raw_label="pg", source_scheme="openai_moderation_v1", confidence_score=None),
-    )
-
     handle = BatchJobHandle(provider="openai", provider_job_id="batch_001", api_keys={"openai": "test-key"})
     result = OpenAIBatchAdapter().fetch_batch_results(handle)
 
@@ -247,14 +236,56 @@ def test_fetch_batch_results_preserves_custom_id_mapping_for_success_items(
     )
     batches = FakeOpenAIBatches()
     install_fake_openai(monkeypatch, files=files, batches=batches)
-    monkeypatch.setattr(
-        openai_adapter_module,
-        "_CATEGORY_SCORES_TO_RATING_PREDICTION",
-        lambda _: RatingPrediction(raw_label="pg", source_scheme="openai_moderation_v1", confidence_score=None),
-    )
-
     handle = BatchJobHandle(provider="openai", provider_job_id="batch_001", api_keys={"openai": "test-key"})
     result = OpenAIBatchAdapter().fetch_batch_results(handle)
 
     assert result.items[0].custom_id == "custom-image-42"
     assert result.items[0].annotation is not None
+
+
+def test_fetch_batch_results_uses_openai_moderations_converter_for_high_risk_scores(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    files = FakeOpenAIFiles(
+        contents={
+            "file_out": _jsonl(
+                [
+                    {
+                        "custom_id": "img-1",
+                        "response": {
+                            "status_code": 200,
+                            "body": {
+                                "results": [
+                                    {
+                                        "category_scores": {
+                                            "violence/graphic": 0.50,
+                                            "sexual": 0.99,
+                                        },
+                                    }
+                                ]
+                            },
+                        },
+                    },
+                ]
+            ),
+            "file_err": "",
+        }
+    )
+    batches = FakeOpenAIBatches()
+    install_fake_openai(monkeypatch, files=files, batches=batches)
+
+    handle = BatchJobHandle(provider="openai", provider_job_id="batch_001", api_keys={"openai": "test-key"})
+    result = OpenAIBatchAdapter().fetch_batch_results(handle)
+
+    item = result.items[0]
+    assert item.annotation is not None
+    assert item.annotation.ratings[0].raw_label == "xxx"
+    assert item.annotation.ratings[0].confidence_score == 0.99
+
+
+def test_openai_adapter_requires_t1_converter(monkeypatch: pytest.MonkeyPatch) -> None:
+    with monkeypatch.context() as mp:
+        mp.setattr(importlib, "import_module", lambda *_args, **_kwargs: (_ for _ in ()).throw(ModuleNotFoundError("missing")))
+        with pytest.raises(RuntimeError, match="requires image_annotator_lib.webapi.openai_moderations"):
+            importlib.reload(openai_adapter_module)


### PR DESCRIPTION
## Context
- image-annotator-lib #120.
- T1 dependency: OpenAI Moderations converter PR #121 / `feat/issue-119-openai-moderations`.

## Summary
- Update OpenAI batch adapter to fail fast when `image_annotator_lib.webapi.openai_moderations` converter is not available.
- Remove silent `pg` fallback and make missing converter an explicit runtime error with actionable guidance.
- Keep `openai` batch adapter test coverage in sync with converter-required behavior.
- Add regression test for converter-required path and high-risk rating conversion (`xxx`).

## Verification
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest -m "not downloads_and_runs_model and not calls_real_webapi" tests/unit/webapi/batch/test_openai_adapter.py`
  - result: `6 passed, 0 skipped`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest -m "not downloads_and_runs_model and not calls_real_webapi"`
  - result: `757 passed, 11 deselected, 0 skipped`
- `T1 converter required` behavior verified with dedicated unit test.
- Silent PG fallback for missing converter has been removed.

## Notes
- This commit has been pushed as `a60c024` on branch `feat/issue-507-t2-openai-batch-adapter`.
- This PR does not have GitHub checks reported automatically at this time; tests above are used as local replacement gate.
