### PR TITLE
feat: support sync OpenAI moderation inference

### DIFF
--- a/src/image_annotator_lib/webapi/api_model_discovery.py
+++ b/src/image_annotator_lib/webapi/api_model_discovery.py
@@ -23,6 +23,7 @@ from ..core.utils import logger
 from .model_id import SUPPORTED_PROVIDERS
 
 _SUPPORTED_LITELLM_MODES: frozenset[str] = frozenset({"chat", "responses"})
+_OPENAI_MODERATION_PREFIX = "openai/omni-moderation-"
 
 
 def _canonicalize_litellm_id(
@@ -85,7 +86,14 @@ def is_allowed_provider(model_id: str, info: dict[str, Any] | None = None) -> bo
     return provider in SUPPORTED_PROVIDERS
 
 
-def _is_litellm_model_annotation_compatible(info: dict[str, Any]) -> bool:
+def _is_openai_moderation_model(model_id: str | None) -> bool:
+    return bool(model_id and model_id.startswith(_OPENAI_MODERATION_PREFIX))
+
+
+def _is_litellm_model_annotation_compatible(
+    info: dict[str, Any],
+    model_id: str | None = None,
+) -> bool:
     """画像アノテーションに適したモデルか判定する (Vision + Tool/Function calling)。
 
     ADR 0023 Phase 1 (Issue #45): structured output は PydanticAI default Tool Output
@@ -93,6 +101,9 @@ def _is_litellm_model_annotation_compatible(info: dict[str, Any]) -> bool:
     主条件にする。`supports_response_schema` は NativeOutput 最適化の参考用 metadata
     として LiteLLM 側にあるが、本判定では使わない。
     """
+    if _is_openai_moderation_model(model_id):
+        return True
+
     mode = info.get("mode", "chat")
     return (
         info.get("supports_vision") is True
@@ -180,15 +191,18 @@ def _collect_models(
             continue
         if info is None:
             continue
-        if require_compatible and not _is_litellm_model_annotation_compatible(info):
+        formatted = _format_litellm_metadata(model_id, info)
+        if formatted is None:
+            continue
+        if require_compatible and not _is_litellm_model_annotation_compatible(
+            info, model_id=formatted["model_name_short"]
+        ):
             continue
         if exclude_deprecated and info.get("deprecation_date"):
             continue
-        formatted = _format_litellm_metadata(model_id, info)
-        if formatted:
-            # Issue #60: dict キーは正規化後 ID で統一。
-            # registry / CLI / LoRAIro DB 列に伝播する `model_name_short` と一致させる。
-            metadata[formatted["model_name_short"]] = formatted
+        # Issue #60: dict キーは正規化後 ID で統一。
+        # registry / CLI / LoRAIro DB 列に伝播する `model_name_short` と一致させる。
+        metadata[formatted["model_name_short"]] = formatted
     return metadata
 
 

--- a/src/image_annotator_lib/webapi/batch/preparation.py
+++ b/src/image_annotator_lib/webapi/batch/preparation.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import mimetypes
 from dataclasses import dataclass
 from pathlib import Path
+
+from image_annotator_lib.webapi.image_payload import build_base64_data_url
 
 from .types import BatchErrorPhase, BatchJobError, BatchSubmitItem
 
@@ -73,7 +74,6 @@ def build_openai_moderations_jsonl(
                 message=f"Failed to read image for OpenAI batch input: {item.image_path}: {exc}",
                 retryable=False,
             ) from exc
-        encoded = base64.b64encode(payload_bytes).decode("ascii")
         lines.append(
             json.dumps(
                 {
@@ -86,7 +86,7 @@ def build_openai_moderations_jsonl(
                             {
                                 "type": "image_url",
                                 "image_url": {
-                                    "url": f"data:{item.image_mime_type};base64,{encoded}",
+                                    "url": build_base64_data_url(payload_bytes, item.image_mime_type),
                                 },
                             }
                         ],

--- a/src/image_annotator_lib/webapi/image_payload.py
+++ b/src/image_annotator_lib/webapi/image_payload.py
@@ -1,0 +1,15 @@
+"""Shared image payload helpers for WebAPI requests."""
+
+from __future__ import annotations
+
+import base64
+
+
+def build_base64_data_url(payload: bytes, mime_type: str) -> str:
+    """Return an RFC 2397 data URL for an image payload."""
+
+    encoded = base64.b64encode(payload).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+__all__ = ["build_base64_data_url"]

--- a/src/image_annotator_lib/webapi/provider_manager.py
+++ b/src/image_annotator_lib/webapi/provider_manager.py
@@ -27,8 +27,10 @@ from ..exceptions.errors import (
 )
 from ..model_class.annotator_webapi.webapi_shared import BASE_PROMPT
 from .http_retry import build_retry_http_client
+from .image_payload import build_base64_data_url
 from .image_preprocess import preprocess_images_to_binary
 from .model_id import build_pydantic_model, resolve_model_ref
+from .openai_moderations import category_scores_to_rating_prediction
 from .output_normalization import build_annotation_output_normalizer
 from .result_adapter import to_annotation_result
 
@@ -45,6 +47,7 @@ _USER_PROMPT_TEXT = "Analyze this image and provide annotations as specified."
 
 # LoRAIro #274: cause/context chain を辿る最大段数 (循環・過剰深さの安全弁)。
 _EXCEPTION_CHAIN_MAX_DEPTH = 5
+_OPENAI_MODERATION_PREFIX = "openai/omni-moderation-"
 
 
 def _build_system_prompt(capabilities: set[TaskCapability] | frozenset[TaskCapability] | None) -> str:
@@ -134,6 +137,14 @@ class ProviderManager:
         Returns:
             `dict[phash, AnnotationResult]`。画像ごとに 1 entry。
         """
+        if _is_openai_moderation_model(litellm_model_id):
+            return await cls._run_openai_moderation_inference(
+                model_name=model_name,
+                images_list=images_list,
+                litellm_model_id=litellm_model_id,
+                api_keys=api_keys,
+            )
+
         # ADR 0023 Phase 1.8 (Issue #46): transport retry 付き AsyncClient を推論呼び出しごとに
         # 新規生成する。Agent / Provider / Model キャッシュなし方針 (ADR 0023 Agent ライフサイクル)
         # に揃え、httpx.AsyncClient も同じ寿命で aclose() する。test 経路 (`_test_agent` 注入) では
@@ -294,6 +305,82 @@ class ProviderManager:
             return api_keys[provider]
 
         raise MissingApiKeyError(provider=provider)
+
+    @classmethod
+    async def _run_openai_moderation_inference(
+        cls,
+        *,
+        model_name: str,
+        images_list: list[Image.Image],
+        litellm_model_id: str,
+        api_keys: dict[str, str] | None,
+    ) -> dict[str, AnnotationResult]:
+        """Run OpenAI Moderations directly for image rating models."""
+
+        ref = resolve_model_ref(litellm_model_id)
+        api_key = cls._resolve_api_key(model_name, ref.provider, api_keys)
+        http_client = build_retry_http_client()
+        try:
+            from openai import AsyncOpenAI
+
+            client = AsyncOpenAI(api_key=api_key, http_client=http_client)
+            binary_contents = preprocess_images_to_binary(images_list)
+            results: dict[str, AnnotationResult] = {}
+            for index, (image, binary) in enumerate(zip(images_list, binary_contents, strict=True)):
+                phash = calculate_phash(image) or f"unknown_image_{index}"
+                try:
+                    response = await client.moderations.create(
+                        model=ref.provider_model_id,
+                        input=[
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": build_base64_data_url(binary.data, binary.media_type),
+                                },
+                            }
+                        ],
+                    )
+                    payload = _openai_response_to_dict(response)
+                    prediction = category_scores_to_rating_prediction(payload)
+                    results[phash] = AnnotationResult(
+                        phash=phash,
+                        tags=[],
+                        formatted_output={
+                            "tags": [],
+                            "captions": [],
+                            "score": None,
+                            "ratings": [prediction],
+                        },
+                        error=None,
+                    )
+                except Exception as exc:
+                    error_detail = _format_exception_chain(exc)
+                    logger.error(
+                        f"OpenAI Moderations 推論失敗: model={model_name}, "
+                        f"litellm_model_id={litellm_model_id}, error={error_detail}"
+                    )
+                    results[phash] = to_annotation_result(None, phash, error=error_detail)
+            return results
+        finally:
+            await http_client.aclose()
+
+
+def _is_openai_moderation_model(litellm_model_id: str) -> bool:
+    return litellm_model_id.startswith(_OPENAI_MODERATION_PREFIX)
+
+
+def _openai_response_to_dict(response: Any) -> dict[str, Any]:
+    if isinstance(response, dict):
+        return response
+    model_dump = getattr(response, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump(mode="json")
+        return dumped if isinstance(dumped, dict) else {}
+    to_dict = getattr(response, "to_dict", None)
+    if callable(to_dict):
+        dumped = to_dict()
+        return dumped if isinstance(dumped, dict) else {}
+    return {}
 
 
 # --- Refusal 分類のための内部 helper ---

--- a/tests/unit/core/test_api_model_discovery_filter.py
+++ b/tests/unit/core/test_api_model_discovery_filter.py
@@ -49,6 +49,26 @@ class TestIsLitellmModelAnnotationCompatible:
         }
         assert _is_litellm_model_annotation_compatible(info) is False
 
+    def test_openai_moderation_model_is_compatible_without_function_calling(self):
+        """OpenAI Moderations は PydanticAI tool calling を使わない専用経路として登録対象。"""
+        info = {
+            "supports_vision": False,
+            "supports_function_calling": False,
+            "mode": "moderation",
+        }
+        assert (
+            _is_litellm_model_annotation_compatible(info, model_id="openai/omni-moderation-latest") is True
+        )
+
+    def test_unrelated_non_tool_model_stays_excluded(self):
+        """非 tool モデルの互換条件は OpenAI Moderations 以外へ広げない。"""
+        info = {
+            "supports_vision": True,
+            "supports_function_calling": False,
+            "mode": "chat",
+        }
+        assert _is_litellm_model_annotation_compatible(info, model_id="openai/gpt-4o") is False
+
     def test_function_calling_missing_is_excluded(self):
         """function_calling キー欠落でも除外 (`is True` 比較なので False/None/欠落いずれも弾く)。"""
         info = {
@@ -363,6 +383,35 @@ class TestCollectModelsPassesProviderToGetModelInfo:
         mock_info.assert_called_once_with(
             "gemini-2.0-flash-exp-image-generation", custom_llm_provider="gemini"
         )
+
+    def test_collect_models_registers_openai_moderation_without_function_calling(self):
+        """OpenAI moderation allowlist は exact prefix のみに限定される。"""
+        moderation_info = {
+            "litellm_provider": "openai",
+            "supports_vision": False,
+            "supports_function_calling": False,
+            "mode": "moderation",
+        }
+        non_tool_info = {
+            "litellm_provider": "openai",
+            "supports_vision": True,
+            "supports_function_calling": False,
+            "mode": "chat",
+        }
+        mock_cost = {
+            "omni-moderation-latest": moderation_info,
+            "gpt-non-tool": non_tool_info,
+        }
+
+        with patch("image_annotator_lib.webapi.api_model_discovery.litellm") as mock_litellm:
+            mock_litellm.model_cost = mock_cost
+            mock_litellm.get_model_info.side_effect = lambda model_id, custom_llm_provider: mock_cost[
+                model_id
+            ]
+            metadata = _collect_models(require_compatible=True, exclude_deprecated=False)
+
+        assert "openai/omni-moderation-latest" in metadata
+        assert "openai/gpt-non-tool" not in metadata
 
 
 @pytest.mark.unit

--- a/tests/unit/webapi/test_provider_manager_openai_moderations.py
+++ b/tests/unit/webapi/test_provider_manager_openai_moderations.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+from PIL import Image
+
+from image_annotator_lib.core.types import RatingPrediction
+from image_annotator_lib.exceptions.errors import MissingApiKeyError
+from image_annotator_lib.webapi.provider_manager import ProviderManager
+
+
+class _FakeModerationResponse:
+    def model_dump(self, *, mode: str = "python") -> dict:
+        assert mode == "json"
+        return {
+            "results": [
+                {
+                    "category_scores": {
+                        "sexual": 0.91,
+                        "violence": 0.05,
+                    }
+                }
+            ]
+        }
+
+
+class _FakeModerations:
+    def __init__(self, calls: list[dict], exc: Exception | None = None) -> None:
+        self._calls = calls
+        self._exc = exc
+
+    async def create(self, **kwargs):
+        self._calls.append(kwargs)
+        if self._exc is not None:
+            raise self._exc
+        return _FakeModerationResponse()
+
+
+class _FakeAsyncOpenAI:
+    calls: ClassVar[list[dict]] = []
+    exc: ClassVar[Exception | None] = None
+
+    def __init__(self, *, api_key: str, http_client) -> None:
+        assert api_key == "test-key"
+        assert http_client is not None
+        self.moderations = _FakeModerations(self.calls, self.exc)
+
+
+def _install_fake_openai(monkeypatch: pytest.MonkeyPatch, exc: Exception | None = None) -> list[dict]:
+    calls: list[dict] = []
+    fake_cls = type(
+        "FakeAsyncOpenAI",
+        (_FakeAsyncOpenAI,),
+        {"calls": calls, "exc": exc},
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "openai",
+        SimpleNamespace(AsyncOpenAI=fake_cls),
+    )
+    return calls
+
+
+def test_openai_moderation_dispatch_returns_rating(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_fake_openai(monkeypatch)
+    image = Image.new("RGB", (8, 8), color="white")
+
+    results = ProviderManager.run_inference_with_model(
+        model_name="openai/omni-moderation-latest",
+        images_list=[image],
+        litellm_model_id="openai/omni-moderation-latest",
+        api_keys={"openai": "test-key"},
+    )
+
+    result = next(iter(results.values()))
+    assert result["error"] is None
+    rating = result["formatted_output"]["ratings"][0]
+    assert isinstance(rating, RatingPrediction)
+    assert rating.raw_label == "x"
+    assert rating.source_scheme == "openai_moderation_v1"
+    assert calls[0]["model"] == "omni-moderation-latest"
+    assert calls[0]["input"][0]["image_url"]["url"].startswith("data:image/webp;base64,")
+
+
+def test_openai_moderation_requires_explicit_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_openai(monkeypatch)
+
+    with pytest.raises(MissingApiKeyError):
+        ProviderManager.run_inference_with_model(
+            model_name="openai/omni-moderation-latest",
+            images_list=[Image.new("RGB", (8, 8), color="white")],
+            litellm_model_id="openai/omni-moderation-latest",
+            api_keys={},
+        )
+
+
+def test_openai_moderation_api_error_is_wrapped_with_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cause = ValueError("socket closed")
+    exc = RuntimeError("moderation failed")
+    exc.__cause__ = cause
+    _install_fake_openai(monkeypatch, exc=exc)
+
+    results = ProviderManager.run_inference_with_model(
+        model_name="openai/omni-moderation-latest",
+        images_list=[Image.new("RGB", (8, 8), color="white")],
+        litellm_model_id="openai/omni-moderation-latest",
+        api_keys={"openai": "test-key"},
+    )
+
+    result = next(iter(results.values()))
+    assert result["tags"] == []
+    assert "RuntimeError: moderation failed" in result["error"]
+    assert "ValueError: socket closed" in result["error"]


### PR DESCRIPTION
## Summary
- dispatch openai/omni-moderation-* sync inference through OpenAI Moderations API directly
- reuse OpenAI moderation rating conversion and shared image data URL helper
- allow only OpenAI moderation models through discovery without function-calling support

## Tests
- uv run pytest tests/unit/webapi tests/unit/webapi/batch tests/unit/core/test_api_model_discovery_filter.py -q
- uv run ruff check src/image_annotator_lib/webapi/provider_manager.py src/image_annotator_lib/webapi/api_model_discovery.py src/image_annotator_lib/webapi/batch/preparation.py src/image_annotator_lib/webapi/image_payload.py tests/unit/webapi/test_provider_manager_openai_moderations.py tests/unit/core/test_api_model_discovery_filter.py