### PR TITLE
fix: mark OpenAI moderation models as ratings

### DIFF
--- a/src/image_annotator_lib/webapi/api_model_discovery.py
+++ b/src/image_annotator_lib/webapi/api_model_discovery.py
@@ -141,7 +141,7 @@ def _format_litellm_metadata(model_id: str, info: dict[str, Any]) -> dict[str, A
     provider_raw, _ = canonical.split("/", 1)
     provider = "OpenAI" if provider_raw == "openai" else provider_raw.capitalize()
 
-    return {
+    metadata = {
         "provider": provider,
         "model_name_short": canonical,
         "display_name": canonical,
@@ -157,6 +157,9 @@ def _format_litellm_metadata(model_id: str, info: dict[str, Any]) -> dict[str, A
         "output_cost_per_token": info.get("output_cost_per_token"),
         "deprecation_date": info.get("deprecation_date"),
     }
+    if _is_openai_moderation_model(canonical):
+        metadata["capabilities"] = ["ratings"]
+    return metadata
 
 
 def _collect_models(

--- a/tests/unit/core/test_api_model_discovery_filter.py
+++ b/tests/unit/core/test_api_model_discovery_filter.py
@@ -167,6 +167,18 @@ class TestFormatLitellmMetadata:
         assert metadata["model_name_short"] == "openai/gpt-4o"
         assert metadata["display_name"] == "openai/gpt-4o"
         assert metadata["provider"] == "OpenAI"
+        assert "capabilities" not in metadata
+
+    def test_openai_moderation_metadata_declares_ratings_capability(self):
+        """OpenAI Moderations must preserve ratings through WebApiAnnotator formatting."""
+        info = {
+            "supports_vision": False,
+            "supports_function_calling": False,
+            "mode": "moderation",
+        }
+        metadata = _format_litellm_metadata("openai/omni-moderation-latest", info)
+        assert metadata is not None
+        assert metadata["capabilities"] == ["ratings"]
 
     def test_claude_bare_canonicalized(self):
         """Issue #52 / #60: bare ``claude-*`` は ``anthropic/<bare>`` に正規化される。
@@ -411,6 +423,7 @@ class TestCollectModelsPassesProviderToGetModelInfo:
             metadata = _collect_models(require_compatible=True, exclude_deprecated=False)
 
         assert "openai/omni-moderation-latest" in metadata
+        assert metadata["openai/omni-moderation-latest"]["capabilities"] == ["ratings"]
         assert "openai/gpt-non-tool" not in metadata
 
 


### PR DESCRIPTION
## Summary
- adds capabilities=[ratings] metadata for openai/omni-moderation-* discovery entries
- keeps normal non-tool OpenAI models excluded and normal OpenAI WebAPI metadata unchanged

## Tests
- uv run pytest tests/unit/webapi tests/unit/webapi/batch tests/unit/core/test_api_model_discovery_filter.py -q
- uv run ruff check src/image_annotator_lib/webapi/api_model_discovery.py tests/unit/core/test_api_model_discovery_filter.py