### PR TITLE
feat: OpenAI Batch /v1/chat/completions annotation (#518)

### DIFF
--- a/src/image_annotator_lib/webapi/batch/adapters/openai.py
+++ b/src/image_annotator_lib/webapi/batch/adapters/openai.py
@@ -8,10 +8,20 @@ from datetime import datetime
 from importlib import import_module
 from typing import Any
 
-from image_annotator_lib.core.types import RatingPrediction, TaskCapability, UnifiedAnnotationResult
+from image_annotator_lib.core.types import (
+    AnnotationSchema,
+    RatingPrediction,
+    TaskCapability,
+    UnifiedAnnotationResult,
+)
 from image_annotator_lib.webapi.model_id import resolve_model_ref
+from image_annotator_lib.webapi.output_normalization import normalize_annotation_output
 
-from ..preparation import build_openai_moderations_jsonl, prepare_items
+from ..preparation import (
+    build_openai_chat_completions_annotation_jsonl,
+    build_openai_moderations_jsonl,
+    prepare_items,
+)
 from ..types import (
     BatchErrorPhase,
     BatchFetchResult,
@@ -31,9 +41,22 @@ from ..types import (
 _PROVIDER = "openai"
 _MAX_LIBRARY_ITEMS = 500
 _SUPPORTED_PROMPT_PROFILES = frozenset({"default"})
-_SUPPORTED_ENDPOINTS = frozenset({"/v1/moderations", "/v1/moderations/"})
+_MODERATIONS_ENDPOINTS = frozenset({"/v1/moderations", "/v1/moderations/"})
+_CHAT_COMPLETIONS_ENDPOINTS = frozenset({"/v1/chat/completions", "/v1/chat/completions/"})
+_SUPPORTED_ENDPOINTS = _MODERATIONS_ENDPOINTS | _CHAT_COMPLETIONS_ENDPOINTS
 _DEFAULT_COMPLETION_WINDOW = "24h"
-_SUPPORTED_CAPABILITIES = frozenset({TaskCapability.RATINGS})
+_DEFAULT_ANNOTATION_CAPABILITIES = frozenset(
+    {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
+)
+_CAPABILITIES_BY_ENDPOINT_GROUP: dict[frozenset[str], frozenset[TaskCapability]] = {
+    _MODERATIONS_ENDPOINTS: frozenset({TaskCapability.RATINGS}),
+    _CHAT_COMPLETIONS_ENDPOINTS: _DEFAULT_ANNOTATION_CAPABILITIES,
+}
+_ANNOTATION_TOOL_NAME = "normalize_annotation_output"
+_ANNOTATION_BASE_PROMPT = (
+    "You analyze images and return structured annotations via the "
+    "`normalize_annotation_output` tool. Respect required fields per capability."
+)
 
 
 def _load_openai_converter() -> Any:
@@ -103,11 +126,20 @@ class OpenAIBatchAdapter:
 
         model_ref = self._resolve_model_ref(request.litellm_model_id)
         prepared = prepare_items(request.items, provider=_PROVIDER)
-        request_payload = build_openai_moderations_jsonl(
-            prepared,
-            endpoint=normalized_endpoint,
-            litellm_model_id=model_ref.provider_model_id,
-        )
+        if normalized_endpoint in _MODERATIONS_ENDPOINTS:
+            request_payload = build_openai_moderations_jsonl(
+                prepared,
+                endpoint=normalized_endpoint,
+                litellm_model_id=model_ref.provider_model_id,
+            )
+        else:
+            request_payload = build_openai_chat_completions_annotation_jsonl(
+                prepared,
+                endpoint=normalized_endpoint,
+                litellm_model_id=model_ref.provider_model_id,
+                system_prompt=_ANNOTATION_BASE_PROMPT,
+                capabilities=_DEFAULT_ANNOTATION_CAPABILITIES,
+            )
 
         try:
             input_file = self._client(api_key).files.create(
@@ -222,11 +254,16 @@ class OpenAIBatchAdapter:
                 retryable=False,
             )
 
+        batch_endpoint = str(_get(batch, "endpoint") or "")
+        normalized_batch_endpoint = (
+            batch_endpoint if batch_endpoint.startswith("/") else f"/{batch_endpoint}"
+        )
+
         seen: dict[str, int] = {}
         items: list[BatchResultItem] = []
         if output_file_id:
             output_lines = self._read_jsonl_lines(api_key, str(output_file_id))
-            items.extend(self._parse_output_lines(output_lines, seen))
+            items.extend(self._parse_output_lines(output_lines, seen, normalized_batch_endpoint))
         if error_file_id:
             error_lines = self._read_jsonl_lines(api_key, str(error_file_id))
             items.extend(self._parse_error_lines(error_lines, seen))
@@ -252,10 +289,12 @@ class OpenAIBatchAdapter:
             ) from exc
         return _to_status_result(batch, provider_job_id=handle.provider_job_id)
 
-    def _parse_output_lines(self, lines: list[str], seen: dict[str, int]) -> list[BatchResultItem]:
+    def _parse_output_lines(
+        self, lines: list[str], seen: dict[str, int], endpoint: str
+    ) -> list[BatchResultItem]:
         parsed: list[BatchResultItem] = []
         for raw in lines:
-            parsed_item = self._normalize_result_item(raw, line_type="output")
+            parsed_item = self._normalize_result_item(raw, line_type="output", endpoint=endpoint)
             if parsed_item is None:
                 continue
             if parsed_item.custom_id in seen:
@@ -267,7 +306,7 @@ class OpenAIBatchAdapter:
     def _parse_error_lines(self, lines: list[str], seen: dict[str, int]) -> list[BatchResultItem]:
         parsed: list[BatchResultItem] = []
         for raw in lines:
-            parsed_item = self._normalize_result_item(raw, line_type="error")
+            parsed_item = self._normalize_result_item(raw, line_type="error", endpoint="")
             if parsed_item is None:
                 continue
             if parsed_item.custom_id in seen:
@@ -276,7 +315,9 @@ class OpenAIBatchAdapter:
             parsed.append(parsed_item)
         return parsed
 
-    def _normalize_result_item(self, raw_line: str, *, line_type: str) -> BatchResultItem | None:
+    def _normalize_result_item(
+        self, raw_line: str, *, line_type: str, endpoint: str
+    ) -> BatchResultItem | None:
         if not raw_line.strip():
             return None
         try:
@@ -331,8 +372,8 @@ class OpenAIBatchAdapter:
                 retryable=_provider_item_retryable(error),
             )
 
-        moderation_response = _extract_moderation_response(response)
-        if not isinstance(moderation_response, Mapping):
+        response_body = _extract_response_body(response)
+        if not isinstance(response_body, Mapping):
             return _failed_result_item(
                 custom_id,
                 BatchProviderItemStatus.UNKNOWN,
@@ -341,12 +382,125 @@ class OpenAIBatchAdapter:
                 "OpenAI output response payload was not a mapping",
                 retryable=False,
             )
-        rating = _CATEGORY_SCORES_TO_RATING_PREDICTION(moderation_response)
+
+        if endpoint in _CHAT_COMPLETIONS_ENDPOINTS:
+            return self._build_chat_completions_item(custom_id, response_body)
+        # Moderations endpoint (default fallback for backward compatibility)
+        rating = _CATEGORY_SCORES_TO_RATING_PREDICTION(response_body)
         return BatchResultItem(
             custom_id=custom_id,
             status=BatchItemStatus.SUCCEEDED,
             provider_status=BatchProviderItemStatus.SUCCEEDED,
-            annotation=_to_unified(rating),
+            annotation=_to_unified_rating(rating),
+            error=None,
+        )
+
+    def _build_chat_completions_item(
+        self, custom_id: str, response_body: Mapping[str, Any]
+    ) -> BatchResultItem:
+        """Parse a /v1/chat/completions Batch output line into BatchResultItem.
+
+        annotation tool 出力 (`tool_calls[0].function.arguments`) を JSON parse し、
+        `normalize_annotation_output()` (output_normalization) で軽微正規化 +
+        `AnnotationSchema` validate を経て `UnifiedAnnotationResult` に包む (Issue #518)。
+
+        refusal (`message.refusal` non-null / `finish_reason == "content_filter"`) は
+        `BatchItemError(code="provider_safety_refusal")` に正規化する。
+        """
+
+        choices = response_body.get("choices") if isinstance(response_body, Mapping) else None
+        if not isinstance(choices, list) or not choices:
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.UNKNOWN,
+                BatchErrorPhase.PARSE,
+                "result_choices_missing",
+                "OpenAI chat completions output had no `choices`",
+                retryable=False,
+            )
+
+        choice = choices[0]
+        message = _get(choice, "message") if isinstance(choice, Mapping) else None
+        finish_reason = str(_get(choice, "finish_reason") or "").lower()
+        refusal = _get(message, "refusal") if isinstance(message, Mapping) else None
+
+        if finish_reason == "content_filter" or (isinstance(refusal, str) and refusal.strip()):
+            refusal_message = (
+                refusal.strip()
+                if isinstance(refusal, str) and refusal.strip()
+                else "OpenAI safety filter refused the request"
+            )
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.FAILED,
+                BatchErrorPhase.NORMALIZE,
+                "provider_safety_refusal",
+                refusal_message,
+                retryable=False,
+            )
+
+        tool_calls = _get(message, "tool_calls") if isinstance(message, Mapping) else None
+        if not isinstance(tool_calls, list) or not tool_calls:
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.UNKNOWN,
+                BatchErrorPhase.PARSE,
+                "result_tool_call_missing",
+                "OpenAI chat completions output had no tool_calls; finish_reason="
+                f"{finish_reason or 'unknown'}",
+                retryable=False,
+            )
+
+        function = _get(tool_calls[0], "function")
+        arguments_raw = _get(function, "arguments") if isinstance(function, Mapping) else None
+        if not isinstance(arguments_raw, str) or not arguments_raw.strip():
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.UNKNOWN,
+                BatchErrorPhase.PARSE,
+                "result_tool_arguments_missing",
+                "OpenAI tool_calls[0].function.arguments was empty or non-string",
+                retryable=False,
+            )
+
+        try:
+            arguments = json.loads(arguments_raw)
+        except json.JSONDecodeError as exc:
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.FAILED,
+                BatchErrorPhase.PARSE,
+                "result_tool_arguments_invalid_json",
+                f"OpenAI tool_calls arguments JSON decode failed: {exc}",
+                retryable=False,
+            )
+        if not isinstance(arguments, dict):
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.FAILED,
+                BatchErrorPhase.PARSE,
+                "result_tool_arguments_not_object",
+                "OpenAI tool_calls arguments was not a JSON object",
+                retryable=False,
+            )
+
+        try:
+            schema = normalize_annotation_output(**arguments)
+        except Exception as exc:
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.FAILED,
+                BatchErrorPhase.NORMALIZE,
+                "result_normalize_failed",
+                f"normalize_annotation_output failed: {self._format_exception(exc)}",
+                retryable=False,
+            )
+
+        return BatchResultItem(
+            custom_id=custom_id,
+            status=BatchItemStatus.SUCCEEDED,
+            provider_status=BatchProviderItemStatus.SUCCEEDED,
+            annotation=_to_unified_annotation(schema),
             error=None,
         )
 
@@ -449,10 +603,10 @@ class OpenAIBatchAdapter:
         return str(error_type).lower() in {"api_error", "server_error", "overloaded_error", "rate_limit_error"}
 
 
-def _to_unified(prediction: RatingPrediction) -> UnifiedAnnotationResult:
+def _to_unified_rating(prediction: RatingPrediction) -> UnifiedAnnotationResult:
     return UnifiedAnnotationResult(
         model_name="openai_batch",
-        capabilities=_SUPPORTED_CAPABILITIES,
+        capabilities=frozenset({TaskCapability.RATINGS}),
         ratings=[prediction],
         provider_name=_PROVIDER,
         framework="openai_batch",
@@ -460,7 +614,33 @@ def _to_unified(prediction: RatingPrediction) -> UnifiedAnnotationResult:
     )
 
 
-def _extract_moderation_response(response: Mapping[str, Any] | Any) -> Any:
+def _to_unified_annotation(schema: AnnotationSchema) -> UnifiedAnnotationResult:
+    """Wrap a validated `AnnotationSchema` into `UnifiedAnnotationResult` for the chat
+    completions Batch path. capability は output された実 field の集合から推定する。
+    """
+    capabilities: set[TaskCapability] = set()
+    if schema.tags:
+        capabilities.add(TaskCapability.TAGS)
+    if schema.captions:
+        capabilities.add(TaskCapability.CAPTIONS)
+    if schema.score is not None:
+        capabilities.add(TaskCapability.SCORES)
+    if schema.ratings:
+        capabilities.add(TaskCapability.RATINGS)
+    return UnifiedAnnotationResult(
+        model_name="openai_batch",
+        capabilities=frozenset(capabilities) if capabilities else _DEFAULT_ANNOTATION_CAPABILITIES,
+        tags=list(schema.tags) if schema.tags else None,
+        captions=list(schema.captions) if schema.captions else None,
+        scores={"score": float(schema.score)} if schema.score is not None else None,
+        ratings=list(schema.ratings) if schema.ratings else None,
+        provider_name=_PROVIDER,
+        framework="openai_batch",
+        raw_output=None,
+    )
+
+
+def _extract_response_body(response: Mapping[str, Any] | Any) -> Any:
     body = _get(response, "body")
     if isinstance(body, dict):
         return body

--- a/src/image_annotator_lib/webapi/batch/preparation.py
+++ b/src/image_annotator_lib/webapi/batch/preparation.py
@@ -6,12 +6,36 @@ import json
 import mimetypes
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
+from image_annotator_lib.core.types import AnnotationSchema, TaskCapability
 from image_annotator_lib.webapi.image_payload import build_base64_data_url
 
 from .types import BatchErrorPhase, BatchJobError, BatchSubmitItem
 
 SUPPORTED_IMAGE_MIME_TYPES = frozenset({"image/jpeg", "image/png", "image/webp"})
+
+# /v1/chat/completions Batch で扱う標準 annotation capability。Ratings は
+# /v1/moderations 経路でカバーするため本 builder のデフォルトには含めない。
+_DEFAULT_ANNOTATION_CAPABILITIES = frozenset(
+    {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
+)
+
+# AnnotationSchema property → TaskCapability への対応 (output_normalization 側と整合)。
+_PROPERTY_TO_CAPABILITY: dict[str, TaskCapability] = {
+    "tags": TaskCapability.TAGS,
+    "captions": TaskCapability.CAPTIONS,
+    "score": TaskCapability.SCORES,
+}
+
+_ANNOTATION_TOOL_NAME = "normalize_annotation_output"
+_ANNOTATION_TOOL_DESCRIPTION = (
+    "Provide image annotation results as structured data. Required fields depend on "
+    "the requested capabilities (tags / captions / score). Ratings are optional."
+)
+
+# Agent 同期経路と揃えるための短い user instruction。
+_USER_PROMPT_TEXT = "Analyze this image and provide annotations as specified."
 
 
 @dataclass(frozen=True)
@@ -91,6 +115,122 @@ def build_openai_moderations_jsonl(
                             }
                         ],
                     },
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        )
+
+    return "\n".join(lines)
+
+
+def build_annotation_tool_schema(
+    capabilities: frozenset[TaskCapability] = _DEFAULT_ANNOTATION_CAPABILITIES,
+) -> dict[str, Any]:
+    """Build an OpenAI function-tool schema for AnnotationSchema (Issue #518).
+
+    Pydantic の ``AnnotationSchema.model_json_schema()`` を SSoT として、capability に
+    応じて required fields を filter する。
+
+    - ``TAGS`` / ``CAPTIONS`` / ``SCORES`` が required かは引数 ``capabilities`` で決まる
+    - ``ratings`` は best-effort 出力のため常に optional
+    - ``$defs`` (RatingPrediction 等の nested schema) はそのまま保持
+
+    Args:
+        capabilities: 出力 schema 上で required にする core capability の集合。
+            空集合の場合は all-optional schema (LLM 側でゼロ field 出力も valid)。
+
+    Returns:
+        OpenAI function-tool ``parameters`` に渡せる JSON schema 相当の dict。
+    """
+
+    schema = AnnotationSchema.model_json_schema()
+    required = sorted(
+        prop
+        for prop, capability in _PROPERTY_TO_CAPABILITY.items()
+        if capability in capabilities
+    )
+    if required:
+        schema["required"] = required
+    else:
+        schema.pop("required", None)
+    return schema
+
+
+def build_openai_chat_completions_annotation_jsonl(
+    items: list[PreparedBatchItem],
+    *,
+    endpoint: str,
+    litellm_model_id: str,
+    system_prompt: str,
+    capabilities: frozenset[TaskCapability] = _DEFAULT_ANNOTATION_CAPABILITIES,
+) -> str:
+    """Build OpenAI batch input JSONL for /v1/chat/completions annotation requests.
+
+    structured output schema は ``AnnotationSchema`` (Pydantic) を SSoT とし、
+    function tool として LLM に publish する (Issue #518 / ADR 0038)。同期側
+    PydanticAI 経路が生成する Chat Completions request と同等の shape を作る。
+
+    Args:
+        items: ``prepare_items()`` の出力。
+        endpoint: ``"/v1/chat/completions"`` (検証は adapter 側で実施)。
+        litellm_model_id: ``"openai/gpt-4o-mini"`` 等の registry model id。
+        system_prompt: capability に応じた system prompt (同期側 ``_build_system_prompt`` 由来)。
+        capabilities: 出力 schema 上で required にする core capability の集合。
+
+    Returns:
+        OpenAI Batch input JSONL (各 line = 1 request)。
+
+    Raises:
+        BatchJobError: 画像読み込み失敗時。
+    """
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": _ANNOTATION_TOOL_NAME,
+            "description": _ANNOTATION_TOOL_DESCRIPTION,
+            "parameters": build_annotation_tool_schema(capabilities),
+        },
+    }
+    tool_choice = {"type": "function", "function": {"name": _ANNOTATION_TOOL_NAME}}
+
+    lines: list[str] = []
+    for item in items:
+        try:
+            payload_bytes = item.image_path.read_bytes()
+        except OSError as exc:
+            raise BatchJobError(
+                phase=BatchErrorPhase.PREPARE,
+                provider="openai",
+                provider_job_id=None,
+                code="image_read_failed",
+                message=f"Failed to read image for OpenAI batch input: {item.image_path}: {exc}",
+                retryable=False,
+            ) from exc
+        data_url = build_base64_data_url(payload_bytes, item.image_mime_type)
+        body = {
+            "model": litellm_model_id,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": _USER_PROMPT_TEXT},
+                        {"type": "image_url", "image_url": {"url": data_url}},
+                    ],
+                },
+            ],
+            "tools": [tool],
+            "tool_choice": tool_choice,
+        }
+        lines.append(
+            json.dumps(
+                {
+                    "custom_id": item.custom_id,
+                    "method": "POST",
+                    "url": endpoint,
+                    "body": body,
                 },
                 ensure_ascii=False,
                 separators=(",", ":"),

--- a/tests/runtime_validation/test_openai_chat_completions_batch_runtime.py
+++ b/tests/runtime_validation/test_openai_chat_completions_batch_runtime.py
@@ -1,0 +1,131 @@
+"""OpenAI Chat Completions Batch API runtime smoke (Issue #518, ADR 0001 amended).
+
+LoRAIro #518 / iam-lib annotation Batch: PydanticAI 同期経路と同じ structured-output
+(function_calling) contract が `/v1/chat/completions` Batch JSONL + output JSONL parse
+で動作するかを開発者ローカルで検証する on-demand validation。
+
+Runtime cost:
+    1 batch submit + 即時 cancel ≒ $0 (batch 課金は completed 時のみ。cancel された
+    batch は課金されない)。input file upload は 1 image / 数 KB。
+
+Skip 仕様:
+    `OPENAI_API_KEY` が未設定なら skip。resource image が存在しない環境でも skip。
+    billing hard limit / quota 等の environment 起因失敗も explicit skip。
+
+Marker:
+    `@pytest.mark.calls_real_webapi` (CI 不経由、ローカル only)。
+
+Coverage:
+    Full lifecycle (poll until completed → fetch_batch_results → tool_call parse) は
+    OpenAI Batch SLA が最大 24h のため smoke 内では実施しない。tool_calls JSONL parse
+    は `tests/unit/webapi/batch/test_openai_adapter_chat_completions.py` の mocked
+    fixture で別途検証する。
+
+Related:
+    iam-lib #118 / #119 / #120 / #122 / #123 (rating preflight infrastructure)
+    LoRAIro #507 / #518 (Provider Batch annotation pipeline)
+    ADR 0001 amended (runtime_validation lane)
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from image_annotator_lib.webapi.batch.adapters.openai import OpenAIBatchAdapter
+from image_annotator_lib.webapi.batch.types import (
+    BatchJobError,
+    BatchJobHandle,
+    BatchStatus,
+    BatchSubmitItem,
+    BatchSubmitRequest,
+)
+
+_RESOURCE_IMG = Path(__file__).parent.parent / "resources" / "img" / "1_img" / "file07.webp"
+_MODEL_ID = "openai/gpt-4o-mini"
+_PROVIDER = "openai"
+
+
+def _api_key_or_skip() -> str:
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        pytest.skip("OPENAI_API_KEY not set (LoRAIro runtime validation lane)")
+    return api_key
+
+
+def _build_request(image_path: Path, api_key: str) -> BatchSubmitRequest:
+    return BatchSubmitRequest(
+        provider=_PROVIDER,
+        endpoint="/v1/chat/completions",
+        litellm_model_id=_MODEL_ID,
+        prompt_profile="default",
+        description="iam-lib #518 chat completions runtime smoke",
+        api_keys={_PROVIDER: api_key},
+        items=[
+            BatchSubmitItem(
+                custom_id="img-annot-smoke-1",
+                image_id=1,
+                image_path=image_path,
+            ),
+        ],
+    )
+
+
+@pytest.mark.calls_real_webapi
+def test_openai_chat_completions_batch_submit_retrieve_cancel() -> None:
+    """submit → retrieve → cancel の最小 lifecycle で実 OpenAI Batch contract を検証。
+
+    確認項目:
+        1. `submit_batch()` が input JSONL upload + batch create を完走し
+           `provider_job_id` を返す (annotation tool 込みの request payload)
+        2. `retrieve_batch()` で初期 status (`submitted` / `running` / `completed` /
+           `unknown`) を取得できる
+        3. `cancel_batch()` で課金回避 (smoke は full lifecycle を待たない)
+
+    Full lifecycle (poll until completed → `fetch_batch_results` で tool_call parse)
+    は OpenAI Batch SLA (最大 24h) のため smoke では実施しない。
+    """
+    api_key = _api_key_or_skip()
+    if not _RESOURCE_IMG.exists():
+        pytest.skip(f"resource image not found: {_RESOURCE_IMG}")
+
+    adapter = OpenAIBatchAdapter()
+    try:
+        submission = adapter.submit_batch(_build_request(_RESOURCE_IMG, api_key))
+    except BatchJobError as exc:
+        # billing / quota / file upload 等の environment 起因失敗は smoke の対象外
+        msg = str(exc).lower()
+        if any(keyword in msg for keyword in ("billing", "quota", "limit", "insufficient")):
+            pytest.skip(f"OpenAI environment limit reached, skipping smoke: {exc}")
+        raise
+
+    assert submission.provider_job_id, "submit_batch did not return provider_job_id"
+    assert submission.provider == _PROVIDER
+    assert submission.request_count >= 1
+
+    handle = BatchJobHandle(
+        provider=_PROVIDER,
+        provider_job_id=submission.provider_job_id,
+        api_keys={_PROVIDER: api_key},
+    )
+
+    try:
+        status = adapter.retrieve_batch(handle)
+        assert status.provider_job_id == submission.provider_job_id
+        assert status.status in {
+            BatchStatus.SUBMITTED,
+            BatchStatus.RUNNING,
+            BatchStatus.COMPLETED,
+            BatchStatus.UNKNOWN,
+        }, f"unexpected initial status: {status.status}"
+    finally:
+        # 課金回避のため cancel を確実に呼ぶ
+        canceled = adapter.cancel_batch(handle)
+        assert canceled.provider_job_id == submission.provider_job_id
+        assert canceled.status in {
+            BatchStatus.CANCELED,
+            BatchStatus.COMPLETED,
+            BatchStatus.FAILED,
+            BatchStatus.EXPIRED,
+            BatchStatus.RUNNING,
+        }, f"unexpected cancel status: {canceled.status}"

--- a/tests/unit/webapi/batch/test_openai_adapter_chat_completions.py
+++ b/tests/unit/webapi/batch/test_openai_adapter_chat_completions.py
@@ -1,0 +1,338 @@
+"""Tests for OpenAI Batch adapter `/v1/chat/completions` annotation path (Issue #518)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from image_annotator_lib.core.types import TaskCapability
+from image_annotator_lib.webapi.batch import (
+    BatchItemStatus,
+    BatchProviderItemStatus,
+    BatchStatus,
+    BatchSubmitItem,
+    BatchSubmitRequest,
+    BatchJobHandle,
+)
+from image_annotator_lib.webapi.batch.adapters.openai import OpenAIBatchAdapter
+
+
+def _jsonl(lines: list[object]) -> str:
+    return "\n".join(json.dumps(line, separators=(",", ":")) for line in lines)
+
+
+@dataclass
+class FakeOpenAIFiles:
+    uploaded_file_content: str | None = None
+    contents: dict[str, str] | None = None
+
+    def create(self, *, file: tuple[str, str], purpose: str) -> dict[str, str]:
+        self.uploaded_file_content = file[1]
+        return {"id": "file_001"}
+
+    def content(self, file_id: str) -> str:
+        if not self.contents or file_id not in self.contents:
+            raise RuntimeError(f"missing content for {file_id}")
+        return self.contents[file_id]
+
+
+@dataclass
+class FakeOpenAIBatches:
+    created_input_file_id: str | None = None
+    created_endpoint: str | None = None
+    output_file_id: str = "file_out"
+
+    def create(self, *, input_file_id: str, endpoint: str, completion_window: str) -> dict[str, object]:
+        self.created_input_file_id = input_file_id
+        self.created_endpoint = endpoint
+        return {
+            "id": "batch_001",
+            "processing_status": "in_progress",
+            "endpoint": endpoint,
+            "request_counts": {
+                "processing": 1,
+                "succeeded": 0,
+                "errored": 0,
+                "canceled": 0,
+                "expired": 0,
+            },
+        }
+
+    def retrieve(self, batch_id: str) -> dict[str, object]:
+        return {
+            "id": batch_id,
+            "processing_status": "completed",
+            "endpoint": "/v1/chat/completions",
+            "request_counts": {
+                "processing": 0,
+                "succeeded": 1,
+                "errored": 0,
+                "canceled": 0,
+                "expired": 0,
+            },
+            "output_file_id": self.output_file_id,
+        }
+
+
+def _install_fake_openai(
+    monkeypatch: pytest.MonkeyPatch, files: FakeOpenAIFiles, batches: FakeOpenAIBatches
+) -> None:
+    class FakeOpenAIFactory:
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+            self.files = files
+            self.batches = batches
+
+    from image_annotator_lib.webapi.batch.adapters import openai as openai_adapter_module
+
+    monkeypatch.setattr(
+        openai_adapter_module.OpenAIBatchAdapter,
+        "_client",
+        lambda self, api_key: FakeOpenAIFactory(api_key),
+    )
+
+
+def _make_request(tmp_path: Path) -> BatchSubmitRequest:
+    image_path = tmp_path / "annot_input.png"
+    # minimal PNG header (1x1)
+    image_path.write_bytes(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f"
+        b"\x15\xc4\x89\x00\x00\x00\rIDAT\x78\x9c\x62\x00\x01\x00\x00\x05\x00\x01\x0d\x0a\x2d\xb4"
+        b"\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    return BatchSubmitRequest(
+        provider="openai",
+        endpoint="/v1/chat/completions",
+        litellm_model_id="openai/gpt-4o-mini",
+        prompt_profile="default",
+        description="annotation batch smoke",
+        api_keys={"openai": "sk-test"},
+        items=[
+            BatchSubmitItem(custom_id="img-1", image_id=1, image_path=image_path),
+        ],
+    )
+
+
+def _success_output_line() -> dict[str, object]:
+    arguments = {
+        "tags": ["1girl", "blue_eyes", "school_uniform"],
+        "captions": ["A girl with blue eyes wearing a school uniform."],
+        "score": 7.5,
+    }
+    return {
+        "custom_id": "img-1",
+        "response": {
+            "status_code": 200,
+            "body": {
+                "choices": [
+                    {
+                        "finish_reason": "tool_calls",
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "normalize_annotation_output",
+                                        "arguments": json.dumps(arguments),
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ]
+            },
+        },
+    }
+
+
+def test_submit_batch_uploads_chat_completions_jsonl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    files = FakeOpenAIFiles()
+    batches = FakeOpenAIBatches()
+    _install_fake_openai(monkeypatch, files, batches)
+    adapter = OpenAIBatchAdapter()
+
+    result = adapter.submit_batch(_make_request(tmp_path))
+
+    assert result.provider_job_id == "batch_001"
+    assert batches.created_endpoint == "/v1/chat/completions"
+    assert files.uploaded_file_content is not None
+    payload = json.loads(files.uploaded_file_content.splitlines()[0])
+    assert payload["url"] == "/v1/chat/completions"
+    body = payload["body"]
+    assert body["model"] == "gpt-4o-mini"
+    assert body["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "normalize_annotation_output"},
+    }
+    assert body["tools"][0]["function"]["parameters"]["required"] == [
+        "captions",
+        "score",
+        "tags",
+    ]
+
+
+def test_fetch_batch_results_parses_tool_call_arguments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    files = FakeOpenAIFiles(contents={"file_out": _jsonl([_success_output_line()])})
+    batches = FakeOpenAIBatches()
+    _install_fake_openai(monkeypatch, files, batches)
+    adapter = OpenAIBatchAdapter()
+    adapter.submit_batch(_make_request(tmp_path))
+
+    fetch = adapter.fetch_batch_results(
+        BatchJobHandle(
+            provider="openai",
+            provider_job_id="batch_001",
+            api_keys={"openai": "sk-test"},
+        )
+    )
+
+    assert fetch.status is BatchStatus.COMPLETED
+    assert len(fetch.items) == 1
+    item = fetch.items[0]
+    assert item.custom_id == "img-1"
+    assert item.status is BatchItemStatus.SUCCEEDED
+    annotation = item.annotation
+    assert annotation is not None
+    assert annotation.tags == ["1girl", "blue_eyes", "school_uniform"]
+    assert annotation.captions == ["A girl with blue eyes wearing a school uniform."]
+    assert annotation.scores == {"score": 7.5}
+    assert TaskCapability.TAGS in annotation.capabilities
+    assert TaskCapability.SCORES in annotation.capabilities
+
+
+def test_fetch_batch_results_normalizes_content_filter_as_safety_refusal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    refusal_line = {
+        "custom_id": "img-1",
+        "response": {
+            "status_code": 200,
+            "body": {
+                "choices": [
+                    {
+                        "finish_reason": "content_filter",
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": None,
+                        },
+                    }
+                ]
+            },
+        },
+    }
+    files = FakeOpenAIFiles(contents={"file_out": _jsonl([refusal_line])})
+    batches = FakeOpenAIBatches()
+    _install_fake_openai(monkeypatch, files, batches)
+    adapter = OpenAIBatchAdapter()
+    adapter.submit_batch(_make_request(tmp_path))
+
+    fetch = adapter.fetch_batch_results(
+        BatchJobHandle(
+            provider="openai",
+            provider_job_id="batch_001",
+            api_keys={"openai": "sk-test"},
+        )
+    )
+
+    assert len(fetch.items) == 1
+    item = fetch.items[0]
+    assert item.status is BatchItemStatus.FAILED
+    assert item.provider_status is BatchProviderItemStatus.FAILED
+    assert item.error is not None
+    assert item.error.code == "provider_safety_refusal"
+
+
+def test_fetch_batch_results_handles_missing_tool_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing_line = {
+        "custom_id": "img-1",
+        "response": {
+            "status_code": 200,
+            "body": {
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "message": {"role": "assistant", "content": "no tool used"},
+                    }
+                ]
+            },
+        },
+    }
+    files = FakeOpenAIFiles(contents={"file_out": _jsonl([missing_line])})
+    batches = FakeOpenAIBatches()
+    _install_fake_openai(monkeypatch, files, batches)
+    adapter = OpenAIBatchAdapter()
+    adapter.submit_batch(_make_request(tmp_path))
+
+    fetch = adapter.fetch_batch_results(
+        BatchJobHandle(
+            provider="openai",
+            provider_job_id="batch_001",
+            api_keys={"openai": "sk-test"},
+        )
+    )
+
+    item = fetch.items[0]
+    assert item.status is BatchItemStatus.FAILED
+    assert item.error is not None
+    assert item.error.code == "result_tool_call_missing"
+
+
+def test_fetch_batch_results_handles_invalid_json_arguments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    broken_line = {
+        "custom_id": "img-1",
+        "response": {
+            "status_code": 200,
+            "body": {
+                "choices": [
+                    {
+                        "finish_reason": "tool_calls",
+                        "message": {
+                            "role": "assistant",
+                            "tool_calls": [
+                                {
+                                    "type": "function",
+                                    "function": {
+                                        "name": "normalize_annotation_output",
+                                        "arguments": "not-a-json",
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ]
+            },
+        },
+    }
+    files = FakeOpenAIFiles(contents={"file_out": _jsonl([broken_line])})
+    batches = FakeOpenAIBatches()
+    _install_fake_openai(monkeypatch, files, batches)
+    adapter = OpenAIBatchAdapter()
+    adapter.submit_batch(_make_request(tmp_path))
+
+    fetch = adapter.fetch_batch_results(
+        BatchJobHandle(
+            provider="openai",
+            provider_job_id="batch_001",
+            api_keys={"openai": "sk-test"},
+        )
+    )
+
+    item = fetch.items[0]
+    assert item.status is BatchItemStatus.FAILED
+    assert item.error is not None
+    assert item.error.code == "result_tool_arguments_invalid_json"

--- a/tests/unit/webapi/batch/test_preparation_annotation.py
+++ b/tests/unit/webapi/batch/test_preparation_annotation.py
@@ -1,0 +1,154 @@
+"""Unit tests for the /v1/chat/completions annotation Batch JSONL builder (Issue #518)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from image_annotator_lib.core.types import AnnotationSchema, TaskCapability
+from image_annotator_lib.webapi.batch.preparation import (
+    PreparedBatchItem,
+    build_annotation_tool_schema,
+    build_openai_chat_completions_annotation_jsonl,
+)
+from image_annotator_lib.webapi.batch.types import BatchErrorPhase, BatchJobError
+
+
+def _make_item(image_path: Path, custom_id: str = "img-1", image_id: int = 1) -> PreparedBatchItem:
+    return PreparedBatchItem(
+        custom_id=custom_id,
+        image_id=image_id,
+        image_path=image_path,
+        image_mime_type="image/png",
+    )
+
+
+@pytest.fixture
+def png_image(tmp_path: Path) -> Path:
+    path = tmp_path / "sample.png"
+    # 1x1 PNG (minimal valid PNG header + IDAT)
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f"
+        b"\x15\xc4\x89\x00\x00\x00\rIDAT\x78\x9c\x62\x00\x01\x00\x00\x05\x00\x01\x0d\x0a\x2d\xb4"
+        b"\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    return path
+
+
+class TestBuildAnnotationToolSchema:
+    def test_default_capabilities_make_tags_captions_score_required(self) -> None:
+        schema = build_annotation_tool_schema()
+        assert schema["required"] == ["captions", "score", "tags"]
+
+    def test_only_tags_capability(self) -> None:
+        schema = build_annotation_tool_schema(frozenset({TaskCapability.TAGS}))
+        assert schema["required"] == ["tags"]
+        # ratings property は ratings capability に関係なく schema 自体には残る (optional)
+        assert "ratings" in schema["properties"]
+
+    def test_empty_capabilities_drops_required(self) -> None:
+        schema = build_annotation_tool_schema(frozenset())
+        assert "required" not in schema
+        # AnnotationSchema 本体の properties はすべて維持
+        assert set(schema["properties"]) == {"tags", "captions", "score", "ratings"}
+
+    def test_schema_carries_pydantic_defs_for_rating_prediction(self) -> None:
+        schema = build_annotation_tool_schema()
+        assert "$defs" in schema
+        assert "RatingPrediction" in schema["$defs"]
+
+    def test_schema_is_consistent_with_annotation_schema_properties(self) -> None:
+        schema = build_annotation_tool_schema()
+        # `AnnotationSchema.model_json_schema()` の properties をそのまま運ぶことを保証
+        canonical = AnnotationSchema.model_json_schema()
+        assert schema["properties"] == canonical["properties"]
+
+
+class TestBuildOpenAIChatCompletionsAnnotationJsonl:
+    def test_single_item_produces_chat_completions_request(self, png_image: Path) -> None:
+        items = [_make_item(png_image)]
+        jsonl = build_openai_chat_completions_annotation_jsonl(
+            items,
+            endpoint="/v1/chat/completions",
+            litellm_model_id="openai/gpt-4o-mini",
+            system_prompt="System prompt body",
+        )
+        lines = jsonl.splitlines()
+        assert len(lines) == 1
+        payload = json.loads(lines[0])
+        assert payload["custom_id"] == "img-1"
+        assert payload["method"] == "POST"
+        assert payload["url"] == "/v1/chat/completions"
+
+        body = payload["body"]
+        assert body["model"] == "openai/gpt-4o-mini"
+        assert body["messages"][0] == {"role": "system", "content": "System prompt body"}
+        user = body["messages"][1]
+        assert user["role"] == "user"
+        text_part, image_part = user["content"]
+        assert text_part["type"] == "text"
+        assert image_part["type"] == "image_url"
+        assert image_part["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_tool_choice_pins_normalize_annotation_output(self, png_image: Path) -> None:
+        items = [_make_item(png_image)]
+        jsonl = build_openai_chat_completions_annotation_jsonl(
+            items,
+            endpoint="/v1/chat/completions",
+            litellm_model_id="openai/gpt-4o-mini",
+            system_prompt="System prompt body",
+        )
+        body = json.loads(jsonl)["body"]
+        assert body["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "normalize_annotation_output"},
+        }
+        tools = body["tools"]
+        assert len(tools) == 1
+        assert tools[0]["type"] == "function"
+        assert tools[0]["function"]["name"] == "normalize_annotation_output"
+        assert tools[0]["function"]["parameters"]["required"] == ["captions", "score", "tags"]
+
+    def test_capabilities_override_filters_required_fields(self, png_image: Path) -> None:
+        items = [_make_item(png_image)]
+        jsonl = build_openai_chat_completions_annotation_jsonl(
+            items,
+            endpoint="/v1/chat/completions",
+            litellm_model_id="openai/gpt-4o-mini",
+            system_prompt="System prompt body",
+            capabilities=frozenset({TaskCapability.TAGS}),
+        )
+        body = json.loads(jsonl)["body"]
+        assert body["tools"][0]["function"]["parameters"]["required"] == ["tags"]
+
+    def test_multiple_items_emit_one_line_per_request(self, tmp_path: Path, png_image: Path) -> None:
+        second = tmp_path / "second.png"
+        second.write_bytes(png_image.read_bytes())
+        items = [
+            _make_item(png_image, custom_id="img-1", image_id=1),
+            _make_item(second, custom_id="img-2", image_id=2),
+        ]
+        jsonl = build_openai_chat_completions_annotation_jsonl(
+            items,
+            endpoint="/v1/chat/completions",
+            litellm_model_id="openai/gpt-4o-mini",
+            system_prompt="System prompt body",
+        )
+        lines = jsonl.splitlines()
+        assert len(lines) == 2
+        assert [json.loads(line)["custom_id"] for line in lines] == ["img-1", "img-2"]
+
+    def test_missing_image_raises_batch_job_error(self, tmp_path: Path) -> None:
+        missing = tmp_path / "missing.png"
+        items = [_make_item(missing)]
+        with pytest.raises(BatchJobError) as excinfo:
+            build_openai_chat_completions_annotation_jsonl(
+                items,
+                endpoint="/v1/chat/completions",
+                litellm_model_id="openai/gpt-4o-mini",
+                system_prompt="System prompt body",
+            )
+        assert excinfo.value.phase is BatchErrorPhase.PREPARE
+        assert excinfo.value.code == "image_read_failed"


### PR DESCRIPTION
## Summary

ADR 0038 Phase 1 OpenAI MVP の \"annotation 用 Batch JSONL 生成\" を実装。Pydantic \`AnnotationSchema\` を SSoT として、PydanticAI 同期経路と等価な structured-output (function calling) contract を Batch JSONL に展開する。LoRAIro #518 の中核実装。

## What this adds

### preparation.py
- \`build_openai_chat_completions_annotation_jsonl(items, *, endpoint, litellm_model_id, system_prompt, capabilities)\`: \`/v1/chat/completions\` 用 Batch input JSONL を生成。AnnotationSchema を function tool として埋め込む。
- \`build_annotation_tool_schema(capabilities)\`: \`AnnotationSchema.model_json_schema()\` を SSoT として、capability に応じて required fields (tags/captions/score) を filter。

### adapters/openai.py
- \`_SUPPORTED_ENDPOINTS\` に \`/v1/chat/completions\` 追加。
- \`submit_batch\` を endpoint 別に dispatch (moderations / chat completions)。
- \`_build_chat_completions_item()\`: \`tool_calls[0].function.arguments\` → JSON parse → \`normalize_annotation_output()\` (軽微正規化 + AnnotationSchema validate) → \`UnifiedAnnotationResult\`。
- refusal detection: \`finish_reason=content_filter\` / \`message.refusal\` non-null を \`BatchItemError(code=\"provider_safety_refusal\")\` に正規化。
- backward compatible: 既存 \`/v1/moderations\` 経路は endpoint 不在時の default fallback で維持。

### Schema 経路 (ADR 0023 / 0038 整合)
- 同期: PydanticAI が \`Agent(output_type=normalize_annotation_output)\` で tool 化
- Batch: \`AnnotationSchema.model_json_schema()\` で純粋 Pydantic 経由生成
- 両経路で同じ \`AnnotationSchema\` validation contract を共有

## QC

- \`UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv pytest -m \"not downloads_and_runs_model and not calls_real_webapi\"\`
  - 結果: \`777 passed, 12 deselected\` (15 test 追加、regression なし)
  - 既存 2 failure (\`test_lazy_torch_import\` / \`test_import_smoke\`) は subprocess 環境問題で本 PR 影響範囲外 (main でも同じ failure)
- 新規 unit tests:
  - \`tests/unit/webapi/batch/test_preparation_annotation.py\` (10 test): tool schema 構築 + JSONL 生成
  - \`tests/unit/webapi/batch/test_openai_adapter_chat_completions.py\` (5 test): submit / success parse / refusal / missing tool_calls / invalid JSON arguments
- 既存 \`test_openai_adapter.py\` (moderations 6 test) 全 pass
- runtime smoke (\`tests/runtime_validation/test_openai_chat_completions_batch_runtime.py\`): submit + retrieve + cancel lifecycle。私の dev 環境では \`billing_hard_limit_reached\` で expected skip path をたどる。

## Refs

- LoRAIro #518 (parent)
- LoRAIro #507 / iam-lib #118-#122 (Moderations Batch infrastructure、本 PR で同 adapter を annotation にも拡張)
- LoRAIro #517 / iam-lib #124 (同期 Moderations) — 設計境界 (Pydantic schema SSoT / PydanticAI 同期のみ) と整合
- ADR 0023 Phase 1 (PydanticAI / LiteLLM WebAPI Inference Boundary)
- ADR 0038 (Provider Batch API Integration Strategy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)