### PR TITLE
fix: read OpenAI Batch real status field and completed/failed counts

### DIFF
--- a/src/image_annotator_lib/webapi/batch/adapters/openai.py
+++ b/src/image_annotator_lib/webapi/batch/adapters/openai.py
@@ -694,28 +694,50 @@ def _request_counts(batch: Any) -> Any:
     return _get(batch, "request_counts") or {}
 
 
+# OpenAI Batch API の request_counts field 名 (実 API 確認 2026-05-27)。
+# 過去の adapter 実装は古い `succeeded` / `errored` を仮定していたが、現実の
+# response は `completed` / `failed` / `total` を使う (#518 runtime smoke で発覚)。
+# Legacy 名は backward compat 用に併存させる。
+_COUNT_KEY_ALIASES: dict[str, tuple[str, ...]] = {
+    "succeeded": ("completed", "succeeded"),
+    "errored": ("failed", "errored"),
+    "canceled": ("cancelled", "canceled"),
+    "expired": ("expired",),
+    "total": ("total",),
+}
+
+
 def _count(batch: Any, name: str) -> int | None:
-    value = _get(_request_counts(batch), name)
-    return int(value) if isinstance(value, (int, float)) else None
+    counts = _request_counts(batch)
+    for key in _COUNT_KEY_ALIASES.get(name, (name,)):
+        value = _get(counts, key)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return None
 
 
 def _request_count(batch: Any) -> int | None:
-    counts = [_count(batch, key) for key in ("processing", "succeeded", "errored", "canceled", "expired")]
+    total = _count(batch, "total")
+    if total is not None:
+        return total
+    counts = [_count(batch, key) for key in ("succeeded", "errored", "canceled", "expired")]
     known_counts = [count for count in counts if count is not None]
     return sum(known_counts) if known_counts else None
 
 
 def _status_from_batch(batch: Any) -> BatchStatus:
-    processing_status = str(_get(batch, "processing_status") or "").lower()
-    if processing_status in {"in_progress", "validating", "cancelling", "canceling", "finalizing", "queued"}:
+    # OpenAI は実 response で `status` field を使う。古い実装は `processing_status` を
+    # 仮定していたが現実の API では None。両方読んで最初に見つかった値を使う。
+    raw_status = str(_get(batch, "status") or _get(batch, "processing_status") or "").lower()
+    if raw_status in {"in_progress", "validating", "cancelling", "canceling", "finalizing", "queued"}:
         return BatchStatus.RUNNING
-    if processing_status == "cancelled":
+    if raw_status in {"cancelled", "canceled"}:
         return BatchStatus.CANCELED
-    if processing_status == "expired":
+    if raw_status == "expired":
         return BatchStatus.EXPIRED
-    if processing_status == "failed":
+    if raw_status == "failed":
         return BatchStatus.FAILED
-    if processing_status in {"completed", "ended"}:
+    if raw_status in {"completed", "ended"}:
         total = _request_count(batch) or 0
         succeeded = _count(batch, "succeeded") or 0
         errored = _count(batch, "errored") or 0

--- a/tests/unit/webapi/batch/test_openai_adapter_status_field.py
+++ b/tests/unit/webapi/batch/test_openai_adapter_status_field.py
@@ -1,0 +1,84 @@
+"""Tests for OpenAI Batch adapter status mapping against real API response shape.
+
+OpenAI Batch API は実際には `status` field と `request_counts: {completed, failed,
+total}` を返す。古い実装は `processing_status` と `request_counts: {succeeded,
+errored}` を仮定していたが #518 runtime smoke で `BatchStatus.UNKNOWN` が出て発覚。
+本 file は実 API shape を unit test 側で固定する regression guard。
+"""
+
+from __future__ import annotations
+
+from image_annotator_lib.webapi.batch.adapters import openai as openai_adapter_module
+from image_annotator_lib.webapi.batch.types import BatchStatus
+
+# Real OpenAI Batch object shape (確認: 2026-05-27 / openai SDK 経由)。
+_REAL_CANCELLING_BATCH = {
+    "id": "batch_abc",
+    "object": "batch",
+    "endpoint": "/v1/chat/completions",
+    "status": "cancelling",
+    "processing_status": None,  # 実 API では None
+    "request_counts": {"completed": 0, "failed": 0, "total": 0},
+}
+
+_REAL_CANCELLED_BATCH = {
+    "id": "batch_abc",
+    "object": "batch",
+    "status": "cancelled",
+    "processing_status": None,
+    "request_counts": {"completed": 0, "failed": 0, "total": 0},
+}
+
+_REAL_COMPLETED_BATCH = {
+    "id": "batch_abc",
+    "object": "batch",
+    "endpoint": "/v1/chat/completions",
+    "status": "completed",
+    "processing_status": None,
+    "request_counts": {"completed": 3, "failed": 0, "total": 3},
+}
+
+_REAL_FAILED_BATCH = {
+    "id": "batch_abc",
+    "status": "failed",
+    "processing_status": None,
+    "request_counts": {"completed": 0, "failed": 2, "total": 2},
+}
+
+
+def test_status_from_batch_reads_status_field_for_cancelling() -> None:
+    """OpenAI 実 response の `status: cancelling` を RUNNING に map する。"""
+    assert openai_adapter_module._status_from_batch(_REAL_CANCELLING_BATCH) is BatchStatus.RUNNING
+
+
+def test_status_from_batch_reads_status_field_for_cancelled() -> None:
+    assert openai_adapter_module._status_from_batch(_REAL_CANCELLED_BATCH) is BatchStatus.CANCELED
+
+
+def test_status_from_batch_reads_status_field_for_completed() -> None:
+    assert openai_adapter_module._status_from_batch(_REAL_COMPLETED_BATCH) is BatchStatus.COMPLETED
+
+
+def test_status_from_batch_reads_status_field_for_failed() -> None:
+    assert openai_adapter_module._status_from_batch(_REAL_FAILED_BATCH) is BatchStatus.FAILED
+
+
+def test_request_count_reads_total_from_real_response() -> None:
+    """OpenAI 実 response の `request_counts.total` を request_count として返す。"""
+    assert openai_adapter_module._request_count(_REAL_COMPLETED_BATCH) == 3
+
+
+def test_count_succeeded_reads_completed_key_from_real_response() -> None:
+    """`succeeded` (legacy 名) は実 response の `completed` key にマップされる。"""
+    assert openai_adapter_module._count(_REAL_COMPLETED_BATCH, "succeeded") == 3
+
+
+def test_count_errored_reads_failed_key_from_real_response() -> None:
+    """`errored` (legacy 名) は実 response の `failed` key にマップされる。"""
+    assert openai_adapter_module._count(_REAL_FAILED_BATCH, "errored") == 2
+
+
+def test_status_from_batch_keeps_processing_status_backward_compat() -> None:
+    """既存 mock test との backward compat: `processing_status` だけ持つ payload も読める。"""
+    legacy = {"id": "batch_legacy", "processing_status": "in_progress", "request_counts": {}}
+    assert openai_adapter_module._status_from_batch(legacy) is BatchStatus.RUNNING


### PR DESCRIPTION
## Summary

LoRAIro #518 runtime smoke で発覚した \`OpenAIBatchAdapter\` の status mapping bug を修正。OpenAI Batch API は実 response で \`status\` field (主) と \`request_counts: {completed, failed, total}\` を返すが、adapter は古い仮定 (\`processing_status\` + \`succeeded\`/\`errored\`) を読んでいたため、\`cancel_batch\` 後の status が \`BatchStatus.UNKNOWN\` になっていた。

## Real OpenAI Batch object shape (confirmed 2026-05-27)

\`\`\`
status: \"cancelling\" / \"cancelled\" / \"completed\" / \"in_progress\" / ...
processing_status: None  (実 API では実在しない)
request_counts: {completed: int, failed: int, total: int}
\`\`\`

## Fix

- \`_status_from_batch()\`: \`status\` 優先、\`processing_status\` を backward compat fallback
- \`_count()\`: \`succeeded\`→\`completed\` / \`errored\`→\`failed\` / \`canceled\`→\`cancelled\` の alias mapping
- \`_request_count()\`: \`request_counts.total\` を優先、無い場合は legacy 合計

## Impact

- Moderations Batch (#122 / #123) 経路にも適用される (同 adapter)。Moderations smoke は billing skip だったため UNKNOWN bug を発見できなかった。本 fix で両 endpoint の status mapping が実 API と一致する。
- 既存 mock fixture (\`processing_status\` を使う) は backward compat で pass 維持。

## Verification

- \`pytest -m \"not downloads_and_runs_model and not calls_real_webapi\"\`
  - \`785 passed, 13 deselected\` (新規 8 増、既存 2 failure は main からの subprocess 環境問題 / 本 PR 影響範囲外)
- \`OPENAI_API_KEY=... pytest -m calls_real_webapi tests/runtime_validation/test_openai_chat_completions_batch_runtime.py\`
  - **1 passed in 10.16s** (実 API で submit + retrieve + cancel lifecycle PASS)

CI-EQUIV-TESTED

## Refs

- LoRAIro #518 (parent feature; runtime smoke で本 bug を検出)
- iam-lib #122 / #123 (Moderations Batch; 同 adapter)
- LoRAIro #515 (deterministic E2E は mock fixture 経由なので影響なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)