### PR TITLE
fix: list_batch_capable_models が非WebAPIモデルの None metadata で全件失敗する問題を修正 (#128)

### DIFF
--- a/src/image_annotator_lib/webapi/batch/service.py
+++ b/src/image_annotator_lib/webapi/batch/service.py
@@ -20,8 +20,10 @@ from .types import (
     BatchSubmitResult,
 )
 
+BatchAdapter = AnthropicBatchAdapter | OpenAIBatchAdapter
 
-def _adapter_for_provider(provider: str) -> AnthropicBatchAdapter:
+
+def _adapter_for_provider(provider: str) -> BatchAdapter:
     normalized = provider.lower()
     if normalized == "anthropic":
         return AnthropicBatchAdapter()
@@ -54,6 +56,8 @@ def list_batch_capable_models() -> list[BatchModelInfo]:
     models: list[BatchModelInfo] = []
     for model_name in list_available_annotators():
         metadata = get_webapi_metadata(model_name)
+        if metadata is None:
+            continue
         provider = str(metadata.get("provider", "")).lower()
         if provider not in {"anthropic", "openai"}:
             continue

--- a/tests/unit/webapi/batch/test_batch_public_api.py
+++ b/tests/unit/webapi/batch/test_batch_public_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import image_annotator_lib
 from image_annotator_lib.core.types import TaskCapability
 from image_annotator_lib.webapi.batch import (

--- a/tests/unit/webapi/batch/test_batch_public_api.py
+++ b/tests/unit/webapi/batch/test_batch_public_api.py
@@ -70,7 +70,9 @@ def test_list_batch_capable_models_returns_anthropic_metadata(monkeypatch) -> No
     assert models[0].metadata["zero_data_retention_eligible"] is False
 
 
-def test_list_batch_capable_models_skips_models_without_webapi_metadata(monkeypatch) -> None:
+def test_list_batch_capable_models_skips_models_without_webapi_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """ローカル ML モデルは get_webapi_metadata() が None を返す (iam-lib #128)。
 
     list_available_annotators() はローカル ML モデル (WDTagger 等) も列挙するが、

--- a/tests/unit/webapi/batch/test_batch_public_api.py
+++ b/tests/unit/webapi/batch/test_batch_public_api.py
@@ -70,6 +70,32 @@ def test_list_batch_capable_models_returns_anthropic_metadata(monkeypatch) -> No
     assert models[0].metadata["zero_data_retention_eligible"] is False
 
 
+def test_list_batch_capable_models_skips_models_without_webapi_metadata(monkeypatch) -> None:
+    """ローカル ML モデルは get_webapi_metadata() が None を返す (iam-lib #128)。
+
+    list_available_annotators() はローカル ML モデル (WDTagger 等) も列挙するが、
+    それらは _WEBAPI_MODEL_METADATA 未登録のため get_webapi_metadata() が None を返す。
+    None を skip せず .get() を呼ぶと AttributeError でループ全体が落ち、batch-capable
+    一覧が常に空になる。None メタデータのモデルは skip し WebAPI モデルだけ返すこと。
+    """
+    monkeypatch.setattr(service, "list_available_annotators", lambda: ["wd-tagger", "claude"])
+    monkeypatch.setattr(
+        service,
+        "get_webapi_metadata",
+        lambda name: {
+            "claude": {
+                "provider": "anthropic",
+                "litellm_model_id": "anthropic/claude-3-5-haiku-latest",
+                "capabilities": ["tags", "captions", "scores", "ratings"],
+            }
+        }.get(name),  # "wd-tagger" は None (ローカル ML モデルを再現)
+    )
+
+    models = list_batch_capable_models()
+
+    assert {model.litellm_model_id for model in models} == {"anthropic/claude-3-5-haiku-latest"}
+
+
 def test_list_batch_capable_models_includes_openai_ratings_model(monkeypatch) -> None:
     monkeypatch.setattr(service, "list_available_annotators", lambda: ["claude", "gpt"])
     monkeypatch.setattr(


### PR DESCRIPTION
## 概要

`webapi/batch/service.py::list_batch_capable_models()` が、ローカル ML モデル (WDTagger 等) に遭遇すると `'NoneType' object has no attribute 'get'` で例外を投げ、**batch-capable モデル一覧の取得が全件失敗**していた問題を修正する。

Closes #128

## 根本原因

```python
for model_name in list_available_annotators():   # ローカル ML モデルも列挙
    metadata = get_webapi_metadata(model_name)    # 非 WebAPI モデルには None を返す
    provider = str(metadata.get("provider", "")).lower()  # None.get() で AttributeError
```

`get_webapi_metadata()` は `_WEBAPI_MODEL_METADATA.get(name)`（registry.py）で、WebAPI モデルしか登録されていない辞書を引くため、ローカル ML モデルでは None を返す。一方 `list_available_annotators()` はローカル ML モデルも返すため、最初のローカルモデルで例外 → ループ全体が落ちる。

## 修正

```python
metadata = get_webapi_metadata(model_name)
if metadata is None:
    continue
```

## テスト

- `test_list_batch_capable_models_skips_models_without_webapi_metadata` を追加。`["wd-tagger", "claude"]` のうち `wd-tagger` を None metadata（ローカルモデル再現）にし、修正前は本番と同じ `AttributeError` で fail、修正後は anthropic モデルだけ返すことを検証。
- CI-equivalent filter (`-m "not downloads_and_runs_model and not calls_real_webapi"`) で batch 関連は全 pass。残る2件の失敗 (`test_lazy_torch_import` / `test_import_smoke`) は共有 .venv での subprocess import 環境アーティファクトで、本変更前から同一・本変更と無関係。

## 影響

LoRAIro #545 (ADR 0041) / #550 の Provider Batch UI でモデル選択が空（プレースホルダーのまま）になる root cause。LoRAIro 側は本 PR merge 後に submodule pin 更新で取り込む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)