### PR TITLE
fix: exclude annotation-incompatible models from WebAPI discovery (#130)

### DIFF
--- a/src/image_annotator_lib/webapi/api_model_discovery.py
+++ b/src/image_annotator_lib/webapi/api_model_discovery.py
@@ -22,8 +22,23 @@ import litellm
 from ..core.utils import logger
 from .model_id import SUPPORTED_PROVIDERS
 
-_SUPPORTED_LITELLM_MODES: frozenset[str] = frozenset({"chat", "responses"})
+# Issue #130: 現 runtime (`webapi/model_id.py:build_pydantic_model`) は OpenAI を常に
+# `OpenAIChatModel` (`v1/chat/completions`) で構築するため、`mode=responses` 専用モデル
+# (deep-research / codex 直 / pro ティア) は実行時に 404 になる。よって endpoint-gate は
+# `chat` のみ許可する。Responses runtime 対応 (iam-lib #131) で本 gate を反転する想定。
+_SUPPORTED_LITELLM_MODES: frozenset[str] = frozenset({"chat"})
 _OPENAI_MODERATION_PREFIX = "openai/omni-moderation-"
+
+# Issue #130 (軸B 残余): litellm metadata では判別できない (誤報 or 未populate) 専用用途
+# モデルを名前 substring で除外する。endpoint-gate (`_SUPPORTED_LITELLM_MODES`) とは独立。
+# #131 で endpoint-gate を反転しても本 denylist は維持する (deep-research は data-source
+# tool 前提のため Responses runtime 対応後も annotation 候補には含めない)。
+_ANNOTATION_UNSUITABLE_SUBSTR: tuple[str, ...] = (
+    "-tts",  # 音声出力モデル (Gemini, supported_openai_params 未populate)
+    "computer-use",  # PC 操作特化 (params 未populate)
+    "-search-preview",  # tools を申告するが web 検索強制 (gpt-4o-search-preview)
+    "deep-research",  # data-source tool 前提 (#131 で gate 反転後も除外維持)
+)
 
 
 def _canonicalize_litellm_id(
@@ -100,16 +115,44 @@ def _is_litellm_model_annotation_compatible(
     で得るため、`supports_response_schema` ではなく `supports_function_calling` を
     主条件にする。`supports_response_schema` は NativeOutput 最適化の参考用 metadata
     として LiteLLM 側にあるが、本判定では使わない。
+
+    Issue #130: 2 点を是正する。
+    1. endpoint-gate を `chat` のみに絞る (`_SUPPORTED_LITELLM_MODES`)。
+    2. `supports_function_calling` boolean が `supported_openai_params` と矛盾する
+       litellm の不正確さを是正する。params が populate されている場合は `tools` の
+       実在を要求し、未populate (Gemini/Anthropic 等) の場合のみ boolean を信頼する。
+       これにより gpt-5-search-api 族 (fc=True だが tools 非対応) を名前非依存で弾く。
     """
     if _is_openai_moderation_model(model_id):
         return True
 
     mode = info.get("mode", "chat")
-    return (
-        info.get("supports_vision") is True
-        and info.get("supports_function_calling") is True
-        and mode in _SUPPORTED_LITELLM_MODES
-    )
+    if mode not in _SUPPORTED_LITELLM_MODES:
+        return False
+    if info.get("supports_vision") is not True or info.get("supports_function_calling") is not True:
+        return False
+    # supported_openai_params が populate されているなら tools 実在を要求 (ground truth 優先)。
+    params = info.get("supported_openai_params")
+    if params and "tools" not in params:
+        return False
+    return True
+
+
+def _is_annotation_suitable(model_id: str) -> bool:
+    """画像アノテーション用途に不適な専用モデルを名前 substring で除外する (Issue #130 軸B)。
+
+    litellm metadata では判別できない (誤報 or 未populate) TTS / computer-use /
+    web 検索強制 / deep-research 系を `_ANNOTATION_UNSUITABLE_SUBSTR` で弾く。
+    endpoint-gate (`_is_litellm_model_annotation_compatible` の mode 条件) とは独立。
+
+    Args:
+        model_id: 正規化後の `provider/model` 形式 ID (`model_name_short`)。
+
+    Returns:
+        annotation 候補として適切なら True。denylist substring に一致したら False。
+    """
+    lowered = model_id.lower()
+    return not any(token in lowered for token in _ANNOTATION_UNSUITABLE_SUBSTR)
 
 
 def _format_litellm_metadata(model_id: str, info: dict[str, Any]) -> dict[str, Any] | None:
@@ -200,6 +243,10 @@ def _collect_models(
         if require_compatible and not _is_litellm_model_annotation_compatible(
             info, model_id=formatted["model_name_short"]
         ):
+            continue
+        # Issue #130 軸B: capability OK でも用途不適 (TTS / computer-use / search /
+        # deep-research) は annotation 候補から除外する。
+        if require_compatible and not _is_annotation_suitable(formatted["model_name_short"]):
             continue
         if exclude_deprecated and info.get("deprecation_date"):
             continue

--- a/tests/unit/core/test_api_model_discovery_filter.py
+++ b/tests/unit/core/test_api_model_discovery_filter.py
@@ -19,7 +19,9 @@ from image_annotator_lib.webapi.api_model_discovery import (
     _canonicalize_litellm_id,
     _collect_models,
     _format_litellm_metadata,
+    _is_annotation_suitable,
     _is_litellm_model_annotation_compatible,
+    discover_available_vision_models,
     is_allowed_provider,
     is_model_deprecated,
 )
@@ -87,23 +89,148 @@ class TestIsLitellmModelAnnotationCompatible:
         }
         assert _is_litellm_model_annotation_compatible(info) is False
 
-    def test_responses_mode_is_compatible(self):
-        """mode=responses も chat と同様に compatible (Phase 1 仕様)。"""
+    def test_responses_mode_is_excluded(self):
+        """Issue #130: mode=responses は除外。
+
+        現 runtime (`build_pydantic_model`) は OpenAI を常に OpenAIChatModel
+        (`v1/chat/completions`) で構築するため responses 専用モデルは実行不能。
+        Responses runtime 対応は #131 で gate 反転予定。
+        """
         info = {
             "supports_vision": True,
             "supports_function_calling": True,
             "mode": "responses",
         }
-        assert _is_litellm_model_annotation_compatible(info) is True
+        assert _is_litellm_model_annotation_compatible(info) is False
 
     def test_completion_mode_is_excluded(self):
-        """mode=completion 等は除外 (Phase 1 は chat / responses のみ)。"""
+        """mode=completion 等は除外 (Issue #130 以降 chat のみ)。"""
         info = {
             "supports_vision": True,
             "supports_function_calling": True,
             "mode": "completion",
         }
         assert _is_litellm_model_annotation_compatible(info) is False
+
+    def test_chat_with_tools_in_supported_openai_params_is_compatible(self):
+        """Issue #130: supported_openai_params に tools があれば compatible。"""
+        info = {
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "mode": "chat",
+            "supported_openai_params": ["max_tokens", "tools", "tool_choice", "response_format"],
+        }
+        assert _is_litellm_model_annotation_compatible(info) is True
+
+    def test_chat_without_tools_in_supported_openai_params_is_excluded(self):
+        """Issue #130: params が populate されているのに tools が無いモデルは除外。
+
+        gpt-5-search-api 族は litellm が supports_function_calling=True と報告するが
+        supported_openai_params に tools を持たないため構造化 tool 出力が不可能。
+        params (ground truth) を boolean より優先して弾く。
+        """
+        info = {
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "mode": "chat",
+            "supported_openai_params": ["max_tokens", "web_search_options", "response_format"],
+        }
+        assert _is_litellm_model_annotation_compatible(info) is False
+
+    def test_unpopulated_supported_openai_params_trusts_function_calling(self):
+        """Issue #130: params が未populate (Gemini/Anthropic等) なら boolean を信頼する。
+
+        空リスト / キー欠落で tools 必須にすると Gemini/Anthropic を全滅させるため、
+        params が無い場合は従来どおり supports_function_calling のみで判定する。
+        """
+        info_missing = {
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "mode": "chat",
+        }
+        assert _is_litellm_model_annotation_compatible(info_missing) is True
+        info_empty = {
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "mode": "chat",
+            "supported_openai_params": [],
+        }
+        assert _is_litellm_model_annotation_compatible(info_empty) is True
+
+
+@pytest.mark.unit
+class TestIsAnnotationSuitable:
+    """Issue #130 軸B: 用途不適モデルの名前 denylist 検証。"""
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "gemini/gemini-2.5-pro-preview-tts",
+            "gemini/gemini-2.5-computer-use-preview-10-2025",
+            "openai/gpt-4o-search-preview",
+            "openai/gpt-4o-mini-search-preview-2025-03-11",
+            "openai/o3-deep-research",
+            "openai/o4-mini-deep-research-2025-06-26",
+        ],
+    )
+    def test_unsuitable_models_excluded(self, model_id):
+        """TTS / computer-use / search-preview / deep-research は不適。"""
+        assert _is_annotation_suitable(model_id) is False
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "openai/gpt-4o",
+            "openai/gpt-5",
+            "anthropic/claude-sonnet-4-5",
+            "gemini/gemini-2.5-pro",
+            # codex は denylist に入れない: OpenRouter chat codex は動作可能なため残す
+            "openrouter/openai/gpt-5.1-codex-max",
+        ],
+    )
+    def test_suitable_models_kept(self, model_id):
+        """標準モデルと OpenRouter codex は適格 (除外しない)。"""
+        assert _is_annotation_suitable(model_id) is True
+
+
+@pytest.mark.unit
+class TestDiscoverAvailableVisionModelsRegression:
+    """Issue #130: 実 litellm 同梱 DB に対する discovery 回帰テスト。
+
+    LITELLM_LOCAL_MODEL_COST_MAP=True (api_model_discovery import 時に設定) のため
+    network には出ない。litellm DB 更新で drift し得るが、月次 dependency review で
+    確認する前提の固定 (dependency-management.md)。
+    """
+
+    def test_responses_and_unsuitable_models_excluded(self):
+        models = set(discover_available_vision_models()["models"])
+        excluded = [
+            # 軸A: mode=responses (endpoint-gate)
+            "openai/o3-deep-research",
+            "openai/o4-mini-deep-research-2025-06-26",
+            "openai/gpt-5-pro",
+            "openai/o3-pro",
+            # 軸B-1: tools 非対応 (search-api)
+            "openai/gpt-5-search-api",
+            # 軸B-2: name denylist
+            "gemini/gemini-2.5-pro-preview-tts",
+            "gemini/gemini-2.5-computer-use-preview-10-2025",
+            "openai/gpt-4o-search-preview",
+        ]
+        for model_id in excluded:
+            assert model_id not in models, f"{model_id} は除外されるべき"
+
+    def test_standard_models_retained(self):
+        """過剰除外していないこと (標準 chat モデルは残る)。"""
+        models = set(discover_available_vision_models()["models"])
+        retained = [
+            "openai/gpt-4o",
+            "openai/gpt-5",
+            "anthropic/claude-sonnet-4-5",
+            "gemini/gemini-2.5-pro",
+        ]
+        for model_id in retained:
+            assert model_id in models, f"{model_id} は残るべき"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #130

## 背景
現 runtime (`webapi/model_id.py:build_pydantic_model`) は OpenAI を常に `OpenAIChatModel` (`v1/chat/completions`) で構築するため、`mode=responses` 専用モデル (deep-research / codex 直 / pro ティア) は実行時に 404。加えて litellm metadata の不正確さ・用途不適モデルが annotation 候補に紛れ込んでいた (LoRAIro #589 で deep-research が選択され 404)。

設計の SSoT: [LoRAIro ADR 0048](https://github.com/NEXTAltair/LoRAIro/blob/main/docs/decisions/0048-webapi-annotation-candidate-filtering.md)。

## 変更 (3 直交軸、コード上分離)
- **軸A endpoint-gate**: `_SUPPORTED_LITELLM_MODES = {"chat"}` (responses 削除)。responses は #131 (Responses runtime) 待ちとして位置づけ。
- **軸B capability 正確化**: `supports_function_calling` boolean が `supported_openai_params` と矛盾する litellm の不正確さを是正。params populate 時は `tools` 実在を要求 (未populate は boolean 信頼)。`gpt-5-search-api` 族 (fc=True だが tools 非対応) を名前非依存で除外。
- **軸C suitability denylist**: metadata で判別不能な用途不適モデルを名前 substring で除外 (`-tts` / `computer-use` / `-search-preview` / `deep-research`)。endpoint-gate とは独立した定数/関数で、#131 で gate 反転後も維持。
- codex は denylist 不採用: OpenAI 直は endpoint-gate で除外、OpenRouter chat codex は動作可能なため残す。

## テスト
- `tests/unit/core/test_api_model_discovery_filter.py` に endpoint-gate / tools 正確化 / denylist / 実 litellm DB 回帰 (除外 + 標準モデル残存) を追加。
- CI-equivalent filter: `-m "not downloads_and_runs_model and not calls_real_webapi"` → **804 passed**。

## 関連
- #131 (Responses runtime 対応、次段階で本 gate 反転)
- LoRAIro #589 (consumer 側 de-list、既存 DB の stale 行除去)

🤖 Generated with [Claude Code](https://claude.com/claude-code)