### PR TITLE
feat: support OpenAI Responses API runtime for pro-tier models (#131)

### DIFF
--- a/docs/decisions/0007-webapi-dual-endpoint-runtime.md
+++ b/docs/decisions/0007-webapi-dual-endpoint-runtime.md
@@ -1,0 +1,180 @@
+# ADR 0007: WebAPI Dual-Endpoint Runtime (Chat + Responses)
+
+- **日付**: 2026-06-01
+- **ステータス**: Accepted
+
+> **Design Authority:**
+> WebAPI 推論経路の責務分離 (PydanticAI / LiteLLM / image-annotator-lib) の上位方針は
+> LoRAIro 側 [ADR 0023 — PydanticAI / LiteLLM WebAPI Inference Boundary](https://github.com/NEXTAltair/LoRAIro/blob/main/docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md)
+> が SSoT。本 ADR は ADR 0023 の責務境界を前提に、**runtime での endpoint 選択
+> (Chat Completions / Responses) の具体 contract** を image-annotator-lib 側に記録する。
+> 上位方針は LoRAIro ADR 0023 の `Amendment (2026-06-01, iam-lib #131)` を参照。
+
+## Context
+
+OpenAI は Responses API を主軸 endpoint に位置づけ、pro ティアのモデル
+(`gpt-5-pro`, `o3-pro`, `o1-pro`, `gpt-5.x-pro` 系) は `mode=responses` 専用で
+Chat Completions (`/v1/chat/completions`) には載っていない。
+
+iam-lib の WebAPI runtime (`webapi/provider_manager.py` + `webapi/model_id.py`) は
+OpenAI provider を無条件に Chat Completions 経路 (`OpenAIChatModel` / `v1/chat/completions`)
+で構築していた。このため responses 専用モデルを指定すると実行時に provider 側で
+404 になっていた。
+
+#130 (merged, PR #132) では暫定処置として discovery 段階の endpoint-gate を
+`mode=chat` のみに絞り、responses 系モデルを registry から除外した。これは 404 を
+止めるための応急対応であり、pro ティアは「実行可能だが除外されている」状態だった。
+
+#131 では gate を反転し、`OpenAIResponsesModel` 経路を runtime に実装して
+pro ティアを実行可能にする。これに合わせて、annotation に不適なモデル群
+(codex / deep-research) の除外責務を endpoint 互換性の判定から分離して整理する。
+
+litellm 同梱 DB 実測 (2026-06-01):
+
+- gate 反転で復活する openai モデル: pro ティア 11 件
+  (`gpt-5-pro` + dated, `gpt-5.2/5.4/5.5-pro` + dated, `o1-pro` + dated, `o3-pro` + dated)。
+  全て `vision=True` / `function_calling=True`。
+- 除外維持: deep-research 系 4 件 (data-source tool 前提)。
+- 新規除外: codex 系 (openai-direct 8 件 + `openrouter/openai/gpt-5.1-codex-max`)。
+
+## Decision
+
+WebAPI 同期 runtime の OpenAI 経路を、**litellm `mode` 由来の per-model endpoint 選択**
+に拡張する。
+
+### 軸の分離
+
+endpoint 選択 (実行可否) と annotation 適性 (使うべきか) を**コード上 2 軸に分離**する。
+
+| 軸 | 意味 | #131 での扱い |
+|---|---|---|
+| 軸A: endpoint 互換性 | provider 上でそのモデルがどの endpoint で実行可能か | discovery gate を反転し `chat` + `responses` の両方を許可 |
+| 軸B: annotation 適性 | 画像 annotation 用途に向くか | denylist を維持・拡張 (codex 一律除外 / deep-research 除外維持) |
+
+軸A の gate と軸B の denylist は別ロジックとして実装し、片方の変更が他方に
+波及しないようにする。
+
+### endpoint 選択経路 (per-model)
+
+endpoint 選択は litellm registry metadata の `mode` field を source とし、
+以下の経路で per-model に配線する。
+
+```text
+litellm DB mode field
+  -> discovery / registry metadata (mode 格納)
+  -> annotator
+  -> provider_manager
+  -> resolve_model_ref(litellm_model_id, ..., mode=...)
+  -> PydanticAIModelRef.endpoint
+  -> build_pydantic_model(ref, ...) 内の endpoint 分岐
+```
+
+分岐規則:
+
+- provider が `openai` **かつ** `mode == "responses"` のとき → `OpenAIResponsesModel`
+- 上記以外の openai → `OpenAIChatModel`
+- anthropic / google / openrouter → 常に Chat 系 (endpoint 分岐なし)
+
+`OpenAIResponsesModel` 分岐は openai-direct provider に限定する。OpenRouter 経由の
+openai モデル (`openrouter/openai/...`) は OpenRouter が Chat 互換 endpoint を提供する
+ため Chat 経路のまま扱う。
+
+### codex 一律除外 (軸B / denylist)
+
+codex 系モデルは provider / endpoint を問わず **一律除外**する。
+
+- openai-direct の responses codex
+- 現在 chat で有効だった `openrouter/openai/gpt-5.1-codex-max`
+
+も含め、denylist substring `codex` で除外する。
+
+これは plan_130 の「動作可能なため openrouter codex は残す」という当初判断を
+**#131 で上書き**したものである (経緯は Rationale 参照)。
+
+### deep-research 除外維持 (軸B / denylist)
+
+deep-research 系モデルは data-source tool を前提とするため、gate 反転後も
+denylist で除外を維持する。endpoint が responses として許可されても annotation
+には使わない。
+
+### batch は chat 専用のまま (ADR 0038 不変)
+
+LoRAIro ADR 0038 (Provider Batch API Integration Strategy) が OpenAI batch 経路で
+`/v1/chat/completions` を選択する判断は **変更しない**。#131 は同期 (sync) runtime
+のみを対象とし、batch 経路の endpoint 選択には触れない。
+
+理由は LoRAIro Issue #518 の lesson と整合する: batch を chat に固定することで
+sync と batch の endpoint / tool schema / response shape を一致させ、fixture と
+refusal 分類ロジックを両経路で再利用できる。responses 専用 pro ティアは sync
+runtime でのみ実行可能になる。
+
+### refusal 契約は不変
+
+iam-lib [ADR 0006 (Annotation Outcome Contract)](0006-annotation-outcome-contract.md)
+および LoRAIro ADR 0023 Phase 1.5 の refusal 契約 (exception `body` 再帰 walk +
+type 名 + regex signature による provider 横断分類) は Responses 経路でもそのまま
+機能する想定。本 ADR で refusal 関連のコード変更は行わず、実 API smoke で確認する
+(LoRAIro [ADR 0026](https://github.com/NEXTAltair/LoRAIro/blob/main/docs/decisions/0026-on-demand-runtime-validation-strategy.md))。
+
+## Rationale
+
+### なぜ per-model endpoint 選択か
+
+OpenAI の endpoint は固定値ではなくモデルごとに異なる (一部は responses 専用、
+多くは chat)。provider 単位で endpoint を固定すると、片方の endpoint 専用モデルが
+必ず実行不能になる。litellm 同梱 DB は `mode` field を SSoT として持つため、
+これを per-model に配線すれば「どの endpoint で構築すべきか」を registry metadata
+だけで決定でき、推論層に provider 別の特例分岐を増やさずに済む。
+
+これは PydanticAI 2.0 beta の「Responses 強制全切替」を採らない plan_525 の判断とも
+**矛盾しない**。#131 は全切替ではなく、litellm `mode` 由来で chat / responses を
+per-model に選ぶだけであり、chat モデルは引き続き `OpenAIChatModel` で実行される。
+
+### なぜ codex を一律除外するか (plan_130 の上書き)
+
+plan_130 では「openrouter codex は chat で動作可能なため残す」としていた。これは
+軸A (実行可否) のみを見た判断だった。#131 で軸A / 軸B を分離した結果、codex は
+コーディング特化モデルであり画像 annotation には不適という軸B の観点が明確になった。
+そのため「動作可能か」ではなく「annotation に使うべきか」を基準に、provider /
+endpoint を問わず substring `codex` で一律除外する方針へ変更した。
+
+### 軸分離の利点
+
+- 軸A (endpoint gate) の変更は「実行可能なモデル集合」だけを動かし、annotation
+  適性の判断には影響しない。
+- 軸B (denylist) の変更は「使うべきモデル集合」だけを動かし、endpoint 構築ロジック
+  には影響しない。
+- 新しい OpenAI モード / 新しい不適モデルカテゴリが出ても、片方の軸の編集で対応でき、
+  もう片方の回帰を起こしにくい。
+
+## Consequences
+
+### 良い点
+
+- responses 専用の pro ティア (`gpt-5-pro`, `o3-pro`, `o1-pro`, `gpt-5.x-pro` 系
+  11 件) が runtime で実行可能になる。
+- endpoint 構築が litellm metadata の `mode` 由来で per-model に決まり、推論層に
+  provider 別の endpoint 特例分岐を増やさない。
+- annotation 不適モデル (codex / deep-research) の除外が軸B denylist に集約され、
+  endpoint 互換性判定 (軸A) から独立する。
+
+### トレードオフ
+
+- Responses 経路の tool 公開形式 / response shape は Chat 経路と完全一致しない
+  可能性があり、structured output と refusal 分類が pro ティアで期待通りに動くかは
+  実 API smoke での確認が必要 (ADR 0026)。
+- denylist は litellm 同梱 DB の更新でモデルが増減すると drift しうる。codex /
+  deep-research の新モデル名が substring 規則から漏れる / 過剰一致する可能性がある
+  ため、月次 dependency review (litellm bump 時) で denylist の妥当性を確認する。
+- batch は chat 専用のまま据え置くため、responses 専用 pro ティアは batch 経路では
+  利用できない (sync runtime 限定)。
+
+## Related
+
+- LoRAIro [ADR 0023 — PydanticAI / LiteLLM WebAPI Inference Boundary](https://github.com/NEXTAltair/LoRAIro/blob/main/docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md) (`Amendment (2026-06-01, iam-lib #131)` が上位方針の SSoT)
+- LoRAIro [ADR 0038 — Provider Batch API Integration Strategy](https://github.com/NEXTAltair/LoRAIro/blob/main/docs/decisions/0038-provider-batch-api-integration-strategy.md) (batch は chat 専用のまま不変)
+- LoRAIro [ADR 0026 — On-Demand Runtime Validation Strategy](https://github.com/NEXTAltair/LoRAIro/blob/main/docs/decisions/0026-on-demand-runtime-validation-strategy.md) (responses 経路の実 API smoke 方針)
+- iam-lib [ADR 0006 — Annotation Outcome Contract](0006-annotation-outcome-contract.md) (refusal 分類契約は不変)
+- image-annotator-lib #131 (gate 反転 + `OpenAIResponsesModel` 経路実装) / #130 (PR #132, 暫定 chat-only gate)
+- LoRAIro #589
+- plan_130 (openrouter codex を残す当初判断 — 本 ADR で上書き) / plan_518 (batch を chat 固定する lesson) / plan_525 (Responses 強制全切替を不採用)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -10,6 +10,7 @@ image-annotator-lib の重要な設計判断を記録するドキュメント群
 | [0004](0004-onnx-tagger-loader-and-model-selection.md) | ONNX Tagger Loader and Model Selection | 2026-05-21 | Accepted |
 | [0005](0005-provider-batch-api-contract.md) | Provider Batch API Contract | 2026-05-25 | Accepted |
 | [0006](0006-annotation-outcome-contract.md) | Annotation Outcome Contract | 2026-05-25 | Accepted |
+| [0007](0007-webapi-dual-endpoint-runtime.md) | WebAPI Dual-Endpoint Runtime (Chat + Responses) | 2026-06-01 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/image_annotator_lib/core/annotation_runner.py
+++ b/src/image_annotator_lib/core/annotation_runner.py
@@ -46,17 +46,6 @@ def _is_webapi_annotator_class(annotator_class: type) -> bool:
     return issubclass(annotator_class, WebApiAnnotator)
 
 
-def _resolve_litellm_model_id(model_name: str) -> str | None:
-    """registry 登録 WebAPI モデルから litellm_model_id を解決する。
-
-    ADR 0023 Phase 1 (Issue #35, PR #40): 旧 `api_model_id` キーへのフォールバックは
-    廃止。`_register_webapi_models_from_discovery()` が `litellm_model_id` のみで
-    metadata を構築するため、本関数も `litellm_model_id` のみを参照する。
-    """
-    metadata = get_webapi_metadata(model_name) or {}
-    return metadata.get("litellm_model_id")
-
-
 def _create_annotator_instance(model_name: str, api_keys: dict[str, str] | None = None) -> BaseAnnotator:
     """モデル名から annotator インスタンスを生成する (registry のみ参照)。
 
@@ -84,23 +73,28 @@ def _create_annotator_instance(model_name: str, api_keys: dict[str, str] | None 
     if model_result is not None:
         actual_model_name, Annotator_class = model_result
 
-        # registry 登録 WebAPI モデル: metadata の litellm_model_id で WebApiAnnotator を構築
+        # registry 登録 WebAPI モデル: metadata の litellm_model_id / mode で WebApiAnnotator を構築。
+        # litellm_model_id と mode は同一 metadata から取得するため、二重 lookup を避けて
+        # `get_webapi_metadata` を一度だけ呼ぶ。
         if _is_webapi_annotator_class(Annotator_class):
-            litellm_model_id = _resolve_litellm_model_id(actual_model_name)
+            metadata = get_webapi_metadata(actual_model_name) or {}
+            litellm_model_id = metadata.get("litellm_model_id")
             if not litellm_model_id:
                 raise KeyError(
                     f"Model '{actual_model_name}' is registered as WebAPI but has no "
                     f"`litellm_model_id` in `_WEBAPI_MODEL_METADATA`"
                 )
+            mode = metadata.get("mode", "chat")
             logger.debug(
                 f"WebApiAnnotator (registry WebAPI): model={actual_model_name}, "
-                f"litellm_model_id={litellm_model_id}"
+                f"litellm_model_id={litellm_model_id}, mode={mode}"
             )
             return WebApiAnnotator(
                 litellm_model_id=litellm_model_id,
                 api_keys=api_keys,
                 model_name=actual_model_name,
                 capabilities=get_model_capabilities(actual_model_name),
+                mode=mode,
             )
 
         # registry 登録 ローカル ML モデル: 直接インスタンス化

--- a/src/image_annotator_lib/webapi/annotator.py
+++ b/src/image_annotator_lib/webapi/annotator.py
@@ -40,6 +40,7 @@ class WebApiAnnotator(BaseAnnotator):
         api_keys: dict[str, str] | None = None,
         model_name: str | None = None,
         capabilities: set[TaskCapability] | frozenset[TaskCapability] | list[str] | None = None,
+        mode: str = "chat",
     ) -> None:
         """`WebApiAnnotator` を初期化する。
 
@@ -51,6 +52,8 @@ class WebApiAnnotator(BaseAnnotator):
                 省略時は `litellm_model_id` をモデル名として扱う (テスト stub 等の特殊用途)。
             capabilities: 明示タスク能力。`TaskCapability.RATINGS` が含まれる場合だけ
                 rating 出力を `UnifiedAnnotationResult.ratings` として公開する。
+            mode: registry metadata 由来の推論 endpoint 種別 (`"chat"` 既定 / `"responses"`)。
+                OpenAI の responses 系モデル構築のため推論時に `ProviderManager` へ伝播する。
         """
         # ADR 0023 Phase 1 / Issue #35 / Issue #45:
         # - WebAPI モデルは registry 経由でのみインスタンス化される (Issue #45 で
@@ -65,6 +68,7 @@ class WebApiAnnotator(BaseAnnotator):
         self.litellm_model_id = litellm_model_id
         self.api_keys = api_keys
         self.capabilities = self._normalize_capabilities(capabilities)
+        self.mode = mode
         self._config = None
         self.model_path = None
         self.device = "api"
@@ -79,7 +83,9 @@ class WebApiAnnotator(BaseAnnotator):
 
         normalized: set[TaskCapability] = set()
         for capability in capabilities:
-            normalized.add(capability if isinstance(capability, TaskCapability) else TaskCapability(capability))
+            normalized.add(
+                capability if isinstance(capability, TaskCapability) else TaskCapability(capability)
+            )
         return frozenset(normalized) if normalized else cls.ADVERTISED_CAPABILITIES
 
     def __enter__(self) -> Self:
@@ -110,6 +116,7 @@ class WebApiAnnotator(BaseAnnotator):
             litellm_model_id=self.litellm_model_id,
             api_keys=self.api_keys,
             capabilities=self.capabilities,
+            mode=self.mode,
         )
         ordered: list[AnnotationResult] = []
         for index, image in enumerate(processed):

--- a/src/image_annotator_lib/webapi/api_model_discovery.py
+++ b/src/image_annotator_lib/webapi/api_model_discovery.py
@@ -22,11 +22,13 @@ import litellm
 from ..core.utils import logger
 from .model_id import SUPPORTED_PROVIDERS
 
-# Issue #130: 現 runtime (`webapi/model_id.py:build_pydantic_model`) は OpenAI を常に
-# `OpenAIChatModel` (`v1/chat/completions`) で構築するため、`mode=responses` 専用モデル
-# (deep-research / codex 直 / pro ティア) は実行時に 404 になる。よって endpoint-gate は
-# `chat` のみ許可する。Responses runtime 対応 (iam-lib #131) で本 gate を反転する想定。
-_SUPPORTED_LITELLM_MODES: frozenset[str] = frozenset({"chat"})
+# Issue #131: #130 で `chat` のみに絞っていた endpoint-gate を反転する。
+# `webapi/model_id.py:build_pydantic_model` が OpenAI `mode=responses` モデルを
+# `OpenAIResponsesModel` (`v1/responses`) で構築するようになったため、pro ティア /
+# deep-research / codex 等の responses 専用モデルも実行可能になった。
+# annotation 用途に不適なモデル (deep-research / codex 等) は endpoint-gate ではなく
+# `_ANNOTATION_UNSUITABLE_SUBSTR` (軸B) で別途除外する。軸A と軸B は分離を維持する。
+_SUPPORTED_LITELLM_MODES: frozenset[str] = frozenset({"chat", "responses"})
 _OPENAI_MODERATION_PREFIX = "openai/omni-moderation-"
 
 # Issue #130 (軸B 残余): litellm metadata では判別できない (誤報 or 未populate) 専用用途
@@ -37,7 +39,9 @@ _ANNOTATION_UNSUITABLE_SUBSTR: tuple[str, ...] = (
     "-tts",  # 音声出力モデル (Gemini, supported_openai_params 未populate)
     "computer-use",  # PC 操作特化 (params 未populate)
     "-search-preview",  # tools を申告するが web 検索強制 (gpt-4o-search-preview)
-    "deep-research",  # data-source tool 前提 (#131 で gate 反転後も除外維持)
+    "deep-research",  # data-source tool 前提 (#131 で endpoint-gate 反転後も除外維持)
+    "codex",  # コーディング特化モデル。provider/endpoint 問わず annotation 不適として
+    # 一律除外 (#131)。openai-direct responses codex も openrouter chat codex も対象。
 )
 
 

--- a/src/image_annotator_lib/webapi/batch/adapters/openai.py
+++ b/src/image_annotator_lib/webapi/batch/adapters/openai.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 import json
+from collections.abc import Mapping
 from datetime import datetime
 from importlib import import_module
 from typing import Any
@@ -36,7 +36,6 @@ from ..types import (
     BatchSubmitRequest,
     BatchSubmitResult,
 )
-
 
 _PROVIDER = "openai"
 _MAX_LIBRARY_ITEMS = 500

--- a/src/image_annotator_lib/webapi/model_id.py
+++ b/src/image_annotator_lib/webapi/model_id.py
@@ -9,7 +9,7 @@ model object を構築するための情報を一箇所に集約する。
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 from ..exceptions.errors import IdMappingError, MissingApiKeyError, UnknownProviderError
@@ -29,12 +29,16 @@ class PydanticAIModelRef:
         provider_model_id: provider 上のモデル名 (`gpt-4o` 等)。
         pydantic_model_id: PydanticAI model string が利用可能な場合の文字列形式。
             provider object 経由のみで構築する場合は None。
+        endpoint: 構築すべき OpenAI 系 endpoint 種別。`"chat"` (既定) は
+            `OpenAIChatModel`、`"responses"` は `OpenAIResponsesModel` を構築する。
+            responses は OpenAI provider 限定 (anthropic/google/openrouter は常に chat)。
     """
 
     provider: str
     litellm_model_id: str
     provider_model_id: str
     pydantic_model_id: str | None = None
+    endpoint: str = "chat"
 
 
 def _split_litellm_id(litellm_model_id: str) -> tuple[str, str]:
@@ -114,12 +118,17 @@ SUPPORTED_PROVIDERS: frozenset[str] = frozenset(_BUILDER_DISPATCH.keys())
 def resolve_model_ref(
     litellm_model_id: str,
     config: dict[str, Any] | None = None,
+    *,
+    mode: str = "chat",
 ) -> PydanticAIModelRef:
     """LiteLLM model ID から `PydanticAIModelRef` を生成する。
 
     Args:
         litellm_model_id: `openai/gpt-4o` のような LiteLLM 形式 ID。
         config: 将来の per-model override 用。Phase 1 では未使用。
+        mode: registry metadata 由来の推論 endpoint 種別 (`"chat"` 既定 / `"responses"`)。
+            `provider == "openai"` かつ `mode == "responses"` の場合のみ ref の
+            `endpoint` を `"responses"` に設定する。それ以外の provider は常に chat。
 
     Returns:
         provider 別 builder で構築された descriptor。
@@ -132,7 +141,33 @@ def resolve_model_ref(
     builder = _BUILDER_DISPATCH.get(provider)
     if builder is None:
         raise UnknownProviderError(provider=provider, litellm_model_id=litellm_model_id)
-    return builder(litellm_model_id, provider_model_id)
+    ref = builder(litellm_model_id, provider_model_id)
+    # responses endpoint は OpenAI provider 限定。他 provider は builder の chat 既定のまま。
+    if provider == "openai" and mode == "responses":
+        ref = replace(ref, endpoint="responses")
+    return ref
+
+
+def _build_openai_model(
+    ref: PydanticAIModelRef,
+    api_key: str,
+    http_client: httpx.AsyncClient | None,
+) -> Model:
+    """OpenAI provider の Chat / Responses endpoint を `ref.endpoint` で選択して構築する。
+
+    `mode=responses` 専用モデル (pro ティア等) は `OpenAIResponsesModel`、それ以外は
+    従来どおり `OpenAIChatModel` を使う (iam-lib #131)。provider object は共通。
+    """
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    provider = OpenAIProvider(api_key=api_key, http_client=http_client)
+    if ref.endpoint == "responses":
+        from pydantic_ai.models.openai import OpenAIResponsesModel
+
+        return OpenAIResponsesModel(model_name=ref.provider_model_id, provider=provider)
+    from pydantic_ai.models.openai import OpenAIChatModel
+
+    return OpenAIChatModel(model_name=ref.provider_model_id, provider=provider)
 
 
 def build_pydantic_model(
@@ -166,11 +201,7 @@ def build_pydantic_model(
         raise MissingApiKeyError(provider=ref.provider, litellm_model_id=ref.litellm_model_id)
 
     if ref.provider == "openai":
-        from pydantic_ai.models.openai import OpenAIChatModel
-        from pydantic_ai.providers.openai import OpenAIProvider
-
-        provider = OpenAIProvider(api_key=api_key, http_client=http_client)
-        return OpenAIChatModel(model_name=ref.provider_model_id, provider=provider)
+        return _build_openai_model(ref, api_key, http_client)
 
     if ref.provider == "anthropic":
         from pydantic_ai.models.anthropic import AnthropicModel

--- a/src/image_annotator_lib/webapi/openai_moderations.py
+++ b/src/image_annotator_lib/webapi/openai_moderations.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 from image_annotator_lib.core.types import RatingPrediction
-
 
 OPENAI_MODERATION_SOURCE_SCHEME = "openai_moderation_v1"
 

--- a/src/image_annotator_lib/webapi/provider_manager.py
+++ b/src/image_annotator_lib/webapi/provider_manager.py
@@ -121,6 +121,7 @@ class ProviderManager:
         api_keys: dict[str, str] | None = None,
         config: dict[str, Any] | None = None,
         capabilities: set[TaskCapability] | frozenset[TaskCapability] | None = None,
+        mode: str = "chat",
         _test_agent: Agent | None = None,
     ) -> dict[str, AnnotationResult]:
         """非同期推論の中核実装。
@@ -132,6 +133,8 @@ class ProviderManager:
             api_keys: provider 名 (`openai` / `anthropic` / `google` / `openrouter`) 単位の API key dict。
             config: provider 固有の追加設定 (OpenRouter `referer` / `app_name` 等)。
             capabilities: 呼び出し元 WebAPI annotator が明示したタスク能力。
+            mode: registry metadata 由来の推論 endpoint 種別 (`"chat"` / `"responses"`)。
+                OpenAI の responses 系モデル構築のため `resolve_model_ref` に伝播する。
             _test_agent: pytest fixture からの Agent 注入専用 (本番では None)。
 
         Returns:
@@ -153,7 +156,7 @@ class ProviderManager:
         if _test_agent is not None:
             agent = _test_agent
         else:
-            ref = resolve_model_ref(litellm_model_id, config)
+            ref = resolve_model_ref(litellm_model_id, config, mode=mode)
             # ADR 0023 Phase 1 (Issue #45): capability check は discovery 段階で完結。
             # registry 経由の通常パスでは登録時に supports_vision / supports_function_calling
             # が確認済みのため、推論直前 fail-fast は冗長として削除した。
@@ -254,6 +257,7 @@ class ProviderManager:
         api_keys: dict[str, str] | None = None,
         config: dict[str, Any] | None = None,
         capabilities: set[TaskCapability] | frozenset[TaskCapability] | None = None,
+        mode: str = "chat",
         _test_agent: Agent | None = None,
     ) -> dict[str, AnnotationResult]:
         """`run_inference_with_model_async()` の sync wrapper。
@@ -278,6 +282,7 @@ class ProviderManager:
                 api_keys=api_keys,
                 config=config,
                 capabilities=capabilities,
+                mode=mode,
                 _test_agent=_test_agent,
             )
         )

--- a/tests/unit/core/test_annotation_runner.py
+++ b/tests/unit/core/test_annotation_runner.py
@@ -53,6 +53,55 @@ class TestCreateAnnotatorInstanceLookupOrder:
         assert instance.litellm_model_id == "openrouter/openai/gpt-4o"
         assert instance.model_name == "openai/gpt-4o"
 
+    def test_registry_webapi_injects_responses_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Issue #131: registry metadata の `mode=responses` が WebApiAnnotator に注入される。
+
+        gpt-5-pro / o3-pro 等の responses 系モデルは metadata の `mode` を
+        `WebApiAnnotator.mode` まで伝播させ、推論時に `OpenAIResponsesModel` を
+        構築できる必要がある。
+        """
+        monkeypatch.setattr(
+            annotation_runner,
+            "find_model_class_case_insensitive",
+            lambda name: (("openai/gpt-5-pro", WebApiAnnotator) if name == "openai/gpt-5-pro" else None),
+        )
+        monkeypatch.setattr(
+            annotation_runner,
+            "get_webapi_metadata",
+            lambda name: (
+                {"litellm_model_id": "openai/gpt-5-pro", "provider": "openai", "mode": "responses"}
+                if name == "openai/gpt-5-pro"
+                else None
+            ),
+        )
+
+        instance = annotation_runner._create_annotator_instance("openai/gpt-5-pro")
+
+        assert isinstance(instance, WebApiAnnotator)
+        assert instance.mode == "responses"
+
+    def test_registry_webapi_defaults_mode_to_chat(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Issue #131: metadata に `mode` が無い場合は `chat` を既定値とする。"""
+        monkeypatch.setattr(
+            annotation_runner,
+            "find_model_class_case_insensitive",
+            lambda name: (("openai/gpt-4o", WebApiAnnotator) if name == "openai/gpt-4o" else None),
+        )
+        monkeypatch.setattr(
+            annotation_runner,
+            "get_webapi_metadata",
+            lambda name: (
+                {"litellm_model_id": "openai/gpt-4o", "provider": "openai"}
+                if name == "openai/gpt-4o"
+                else None
+            ),
+        )
+
+        instance = annotation_runner._create_annotator_instance("openai/gpt-4o")
+
+        assert isinstance(instance, WebApiAnnotator)
+        assert instance.mode == "chat"
+
     def test_registry_webapi_missing_litellm_model_id_raises_key_error(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/core/test_api_model_discovery_filter.py
+++ b/tests/unit/core/test_api_model_discovery_filter.py
@@ -89,15 +89,25 @@ class TestIsLitellmModelAnnotationCompatible:
         }
         assert _is_litellm_model_annotation_compatible(info) is False
 
-    def test_responses_mode_is_excluded(self):
-        """Issue #130: mode=responses は除外。
+    def test_responses_mode_is_compatible(self):
+        """Issue #131: mode=responses は compatible (endpoint-gate 反転の回帰防止)。
 
-        現 runtime (`build_pydantic_model`) は OpenAI を常に OpenAIChatModel
-        (`v1/chat/completions`) で構築するため responses 専用モデルは実行不能。
-        Responses runtime 対応は #131 で gate 反転予定。
+        `build_pydantic_model` が OpenAI `mode=responses` を OpenAIResponsesModel
+        (`v1/responses`) で構築するようになったため、vision + function_calling を
+        満たす responses 専用モデルは実行可能になった。annotation 不適なモデルは
+        軸B (`_ANNOTATION_UNSUITABLE_SUBSTR`) で別途除外する。
         """
         info = {
             "supports_vision": True,
+            "supports_function_calling": True,
+            "mode": "responses",
+        }
+        assert _is_litellm_model_annotation_compatible(info) is True
+
+    def test_responses_mode_without_vision_is_excluded(self):
+        """Issue #131: responses でも vision=False なら除外 (軸A は capability も判定)。"""
+        info = {
+            "supports_vision": False,
             "supports_function_calling": True,
             "mode": "responses",
         }
@@ -171,10 +181,15 @@ class TestIsAnnotationSuitable:
             "openai/gpt-4o-mini-search-preview-2025-03-11",
             "openai/o3-deep-research",
             "openai/o4-mini-deep-research-2025-06-26",
+            # Issue #131: codex はコーディング特化で annotation 不適。
+            # provider/endpoint 問わず一律除外する (responses 直も openrouter chat も)。
+            "openai/gpt-5-codex",
+            "openai/codex-mini-latest",
+            "openrouter/openai/gpt-5.1-codex-max",
         ],
     )
     def test_unsuitable_models_excluded(self, model_id):
-        """TTS / computer-use / search-preview / deep-research は不適。"""
+        """TTS / computer-use / search-preview / deep-research / codex は不適。"""
         assert _is_annotation_suitable(model_id) is False
 
     @pytest.mark.parametrize(
@@ -184,41 +199,59 @@ class TestIsAnnotationSuitable:
             "openai/gpt-5",
             "anthropic/claude-sonnet-4-5",
             "gemini/gemini-2.5-pro",
-            # codex は denylist に入れない: OpenRouter chat codex は動作可能なため残す
-            "openrouter/openai/gpt-5.1-codex-max",
+            # Issue #131: pro ティア (responses) は endpoint-gate 反転で実行可能。
+            # codex を含まないため軸B でも除外されない。
+            "openai/gpt-5-pro",
+            "openai/o3-pro",
         ],
     )
     def test_suitable_models_kept(self, model_id):
-        """標準モデルと OpenRouter codex は適格 (除外しない)。"""
+        """標準 chat モデルと pro ティア responses モデルは適格 (除外しない)。"""
         assert _is_annotation_suitable(model_id) is True
 
 
 @pytest.mark.unit
 class TestDiscoverAvailableVisionModelsRegression:
-    """Issue #130: 実 litellm 同梱 DB に対する discovery 回帰テスト。
+    """Issue #130 / #131: 実 litellm 同梱 DB に対する discovery 回帰テスト。
 
     LITELLM_LOCAL_MODEL_COST_MAP=True (api_model_discovery import 時に設定) のため
     network には出ない。litellm DB 更新で drift し得るが、月次 dependency review で
     確認する前提の固定 (dependency-management.md)。
     """
 
-    def test_responses_and_unsuitable_models_excluded(self):
+    def test_unsuitable_models_excluded(self):
+        """Issue #131: 軸B denylist (deep-research / codex 等) は引き続き除外される。"""
         models = set(discover_available_vision_models()["models"])
+        for model_id in models:
+            # 任意の deep-research / codex 文字列を含む ID は残ってはならない。
+            assert "deep-research" not in model_id, f"{model_id} (deep-research) は除外されるべき"
+            assert "codex" not in model_id, f"{model_id} (codex) は除外されるべき"
         excluded = [
-            # 軸A: mode=responses (endpoint-gate)
-            "openai/o3-deep-research",
-            "openai/o4-mini-deep-research-2025-06-26",
-            "openai/gpt-5-pro",
-            "openai/o3-pro",
             # 軸B-1: tools 非対応 (search-api)
             "openai/gpt-5-search-api",
             # 軸B-2: name denylist
             "gemini/gemini-2.5-pro-preview-tts",
             "gemini/gemini-2.5-computer-use-preview-10-2025",
             "openai/gpt-4o-search-preview",
+            "openai/o3-deep-research",
+            "openai/o4-mini-deep-research-2025-06-26",
+            # codex (responses 直 / openrouter chat いずれも除外)
+            "openrouter/openai/gpt-5.1-codex-max",
         ]
         for model_id in excluded:
             assert model_id not in models, f"{model_id} は除外されるべき"
+
+    def test_responses_pro_tier_models_included(self):
+        """Issue #131: endpoint-gate 反転で pro ティア responses モデルが候補に入る。"""
+        models = set(discover_available_vision_models()["models"])
+        included = [
+            "openai/gpt-5-pro",
+            "openai/o3-pro",
+            "openai/o1-pro",
+            "openai/gpt-5.5-pro",
+        ]
+        for model_id in included:
+            assert model_id in models, f"{model_id} は含まれるべき"
 
     def test_standard_models_retained(self):
         """過剰除外していないこと (標準 chat モデルは残る)。"""

--- a/tests/unit/core/test_model_id.py
+++ b/tests/unit/core/test_model_id.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from image_annotator_lib.exceptions.errors import (
@@ -12,6 +14,7 @@ from image_annotator_lib.exceptions.errors import (
 from image_annotator_lib.webapi.model_id import (
     SUPPORTED_PROVIDERS,
     PydanticAIModelRef,
+    build_pydantic_model,
     resolve_model_ref,
 )
 
@@ -108,8 +111,48 @@ class TestBuildPydanticModelMissingKey:
     """`build_pydantic_model()` の API key validation を確認する (provider 構築は別の integration test で)。"""
 
     def test_empty_api_key_raises(self) -> None:
-        from image_annotator_lib.webapi.model_id import build_pydantic_model
-
         ref = resolve_model_ref("openai/gpt-4o")
         with pytest.raises(MissingApiKeyError):
             build_pydantic_model(ref, "")
+
+
+class TestResolveModelRefEndpoint:
+    """`mode` -> `PydanticAIModelRef.endpoint` 配線を確認する (Issue #131)。"""
+
+    def test_openai_responses_mode_sets_responses_endpoint(self) -> None:
+        ref = resolve_model_ref("openai/gpt-5-pro", mode="responses")
+        assert ref.endpoint == "responses"
+
+    def test_openai_default_endpoint_is_chat(self) -> None:
+        ref = resolve_model_ref("openai/gpt-4o")
+        assert ref.endpoint == "chat"
+
+    def test_openai_explicit_chat_mode_is_chat(self) -> None:
+        ref = resolve_model_ref("openai/gpt-4o", mode="chat")
+        assert ref.endpoint == "chat"
+
+    def test_anthropic_responses_mode_stays_chat(self) -> None:
+        # responses は OpenAI provider 限定。anthropic は常に chat。
+        ref = resolve_model_ref("anthropic/claude-3-5-sonnet-20241022", mode="responses")
+        assert ref.endpoint == "chat"
+
+
+class TestBuildPydanticModelEndpoint:
+    """endpoint 種別ごとに対応する OpenAI Model class が構築されることを確認する (Issue #131)。
+
+    network は不要 (provider object 構築のみ。実 API call は行わない)。
+    """
+
+    def test_responses_endpoint_builds_responses_model(self) -> None:
+        from pydantic_ai.models.openai import OpenAIResponsesModel
+
+        ref = replace(resolve_model_ref("openai/gpt-5-pro"), endpoint="responses")
+        model = build_pydantic_model(ref, "dummy-key")
+        assert isinstance(model, OpenAIResponsesModel)
+
+    def test_chat_endpoint_builds_chat_model(self) -> None:
+        from pydantic_ai.models.openai import OpenAIChatModel
+
+        ref = resolve_model_ref("openai/gpt-4o")
+        model = build_pydantic_model(ref, "dummy-key")
+        assert isinstance(model, OpenAIChatModel)

--- a/tests/unit/core/test_webapi_annotator.py
+++ b/tests/unit/core/test_webapi_annotator.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import pytest
+from PIL import Image
 
 from image_annotator_lib.core import utils
-from image_annotator_lib.core.types import TaskCapability
+from image_annotator_lib.core.types import AnnotationResult, TaskCapability
+from image_annotator_lib.webapi import annotator as annotator_module
 from image_annotator_lib.webapi.annotator import WebApiAnnotator
 
 
@@ -61,6 +63,42 @@ class TestWebApiAnnotatorBasics:
         with annotator as ctx:
             assert ctx is annotator
         # __exit__ で例外なく抜ける
+
+
+class TestWebApiAnnotatorModeWiring:
+    """Issue #131: `mode` が `ProviderManager.run_inference_with_model` まで伝播する。"""
+
+    def test_init_defaults_mode_to_chat(self) -> None:
+        annotator = WebApiAnnotator(litellm_model_id="openai/gpt-4o")
+        assert annotator.mode == "chat"
+
+    def test_init_stores_explicit_mode(self) -> None:
+        annotator = WebApiAnnotator(litellm_model_id="openai/gpt-5-pro", mode="responses")
+        assert annotator.mode == "responses"
+
+    def test_run_inference_passes_mode_to_provider_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`_run_inference` が `mode="responses"` で ProviderManager を呼ぶことを確認する。
+
+        実推論は monkeypatch で捕捉してモックする (network 不要)。
+        """
+        captured: dict[str, object] = {}
+        image = Image.new("RGB", (4, 4), color="white")
+
+        def fake_run(**kwargs: object) -> dict[str, AnnotationResult]:
+            captured.update(kwargs)
+            # _run_inference は phash でルックアップするため、空 dict を返して
+            # 「結果なし」経路 (warning + placeholder) に流す。mode の捕捉だけが目的。
+            return {}
+
+        monkeypatch.setattr(
+            annotator_module.ProviderManager, "run_inference_with_model", staticmethod(fake_run)
+        )
+
+        annotator = WebApiAnnotator(litellm_model_id="openai/gpt-5-pro", mode="responses")
+        annotator._run_inference([image])
+
+        assert captured["mode"] == "responses"
+        assert captured["litellm_model_id"] == "openai/gpt-5-pro"
 
 
 class TestWebApiAnnotatorRatings:


### PR DESCRIPTION
<!-- CI-EQUIV-TESTED: uv run --no-sync pytest -m "not downloads_and_runs_model and not calls_real_webapi" -> 821 passed, 13 deselected -->
## 概要

`mode=responses` 専用の OpenAI pro ティア (`gpt-5-pro`, `o3-pro`, `o1-pro`, `gpt-5.x-pro`) を実行可能にする。#130 (merged) で chat のみに絞った discovery endpoint-gate (軸A) を反転し、`OpenAIResponsesModel` 経路を実装する。

Closes #131

## 設計

軸A (endpoint 互換性) と軸B (annotation 適性) のコード分離を維持。

- **discovery (`api_model_discovery.py`)**: endpoint-gate を `{chat, responses}` に反転 (軸A)。annotation 不適な `codex` を denylist に追加 (軸B)、`deep-research` は除外維持。
- **`model_id.py`**: `PydanticAIModelRef.endpoint` 追加。`resolve_model_ref(mode=)` で openai + `mode=responses` のとき `endpoint="responses"`。`build_pydantic_model` は `_build_openai_model` で Chat/Responses を分岐構築。
- **配線**: registry metadata の `mode` を `annotator → provider_manager → resolve_model_ref` へ伝播 (後方互換、default `chat`)。
- **ADR 0007** (WebAPI Dual-Endpoint Runtime) を追加。batch は chat 専用維持 (ADR 0038 不変)、refusal 契約不変 (ADR 0006)。

## discovery 変化 (litellm 同梱 DB 実測)

- 復活 (pro ティア): `gpt-5-pro`(+dated), `gpt-5.2/5.4/5.5-pro`(+dated), `o1-pro`(+dated), `o3-pro`(+dated)
- 除外維持: `deep-research` ×4
- 新規除外: `codex` 全般 (openai-direct + `openrouter/openai/gpt-5.1-codex-max`、plan_130 の判断を上書き、ADR 0007 に記録)

## テスト

- CI-equivalent filter: `uv run --no-sync pytest -m "not downloads_and_runs_model and not calls_real_webapi"` → **821 passed, 13 deselected**
- discovery 検証: pro-tier 候補入り / codex・deep-research 除外 / gpt-4o・gemini-2.5-pro 保持
- LoRAIro 本体 CI-equivalent: 3703 passed (consumer 回帰なし)

## 残作業

- 実 API smoke (ADR 0026, 課金): `gpt-5-pro`/`o3-pro` で実画像 annotation。Responses 経路で構造化出力 (Tool Output) と refusal 伝搬を確認。
- merge 後: LoRAIro 側 submodule pin bump + `uv.lock` 更新 + ADR 0023 Amendment を別 PR で起票。

🤖 Generated with [Claude Code](https://claude.com/claude-code)