### PR TITLE
feat: bound WebAPI image concurrency

### DIFF
--- a/docs/decisions/0008-webapi-bounded-image-concurrency.md
+++ b/docs/decisions/0008-webapi-bounded-image-concurrency.md
@@ -1,0 +1,29 @@
+# 0008. WebAPI Bounded Image Concurrency
+
+Date: 2026-06-03
+
+## Status
+
+Accepted
+
+## Context
+
+WebAPI inference preprocesses an image batch quickly, then sends one provider request per image.
+The previous implementation awaited each image request sequentially inside one model invocation. In GUI
+batch annotation this made progress appear stalled during the model inference phase, and total runtime
+became the sum of all provider round trips and retry budgets.
+
+## Decision
+
+Run per-image WebAPI requests concurrently with an `asyncio.Semaphore` limit. The default limit is `3`,
+and callers may override it with `max_concurrency` on `ProviderManager` or `WebApiAnnotator`.
+
+The same bounded behavior applies to the OpenAI Moderations special path so rating-only WebAPI models do
+not remain serial.
+
+## Consequences
+
+- Batch latency improves when provider requests are I/O-bound.
+- Result pHash keys, per-image error outcomes, and input-order result construction are preserved.
+- Provider rate limits are protected by a conservative default instead of unbounded `gather`.
+- `max_concurrency=1` remains available for serial behavior when a provider or caller requires it.

--- a/src/image_annotator_lib/webapi/annotator.py
+++ b/src/image_annotator_lib/webapi/annotator.py
@@ -41,6 +41,7 @@ class WebApiAnnotator(BaseAnnotator):
         model_name: str | None = None,
         capabilities: set[TaskCapability] | frozenset[TaskCapability] | list[str] | None = None,
         mode: str = "chat",
+        max_concurrency: int | None = None,
     ) -> None:
         """`WebApiAnnotator` を初期化する。
 
@@ -54,6 +55,8 @@ class WebApiAnnotator(BaseAnnotator):
                 rating 出力を `UnifiedAnnotationResult.ratings` として公開する。
             mode: registry metadata 由来の推論 endpoint 種別 (`"chat"` 既定 / `"responses"`)。
                 OpenAI の responses 系モデル構築のため推論時に `ProviderManager` へ伝播する。
+            max_concurrency: 同一モデル内で並列実行する画像 API request の最大数。
+                None の場合は `ProviderManager` の既定値を使う。
         """
         # ADR 0023 Phase 1 / Issue #35 / Issue #45:
         # - WebAPI モデルは registry 経由でのみインスタンス化される (Issue #45 で
@@ -69,6 +72,7 @@ class WebApiAnnotator(BaseAnnotator):
         self.api_keys = api_keys
         self.capabilities = self._normalize_capabilities(capabilities)
         self.mode = mode
+        self.max_concurrency = max_concurrency
         self._config = None
         self.model_path = None
         self.device = "api"
@@ -117,6 +121,7 @@ class WebApiAnnotator(BaseAnnotator):
             api_keys=self.api_keys,
             capabilities=self.capabilities,
             mode=self.mode,
+            max_concurrency=self.max_concurrency,
         )
         ordered: list[AnnotationResult] = []
         for index, image in enumerate(processed):

--- a/src/image_annotator_lib/webapi/http_retry.py
+++ b/src/image_annotator_lib/webapi/http_retry.py
@@ -18,7 +18,7 @@ PydanticAI provider 用 ``httpx.AsyncClient`` 向けにコード化する。
 
 - model fallback / LiteLLM Router retry (ADR 0023 line 313-314)
 - ``Retry-After > max_wait`` の halt-on-exceed (Phase 2 へ繰り延べ)
-- output validation retry (これは PydanticAI ``output_retries=1`` で別経路、
+- output validation retry (これは PydanticAI ``retries={"output": 1}`` で別経路、
   ``provider_manager._OUTPUT_RETRIES`` を参照)
 
 関連ドキュメント: docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md

--- a/src/image_annotator_lib/webapi/output_normalization.py
+++ b/src/image_annotator_lib/webapi/output_normalization.py
@@ -13,7 +13,7 @@ ADR 0023 Issue #47: PydanticAI `Agent.output_type` に渡す callable として
 - 各要素の trim、空文字除去
 
 補正不能 (非対応型 / list 内非文字列 / 解釈不能 score 等) は `ModelRetry`
-を raise し、PydanticAI `output_retries=1` に従って LLM 再生成へ流す。
+を raise し、PydanticAI `retries={"output": 1}` に従って LLM 再生成へ流す。
 壊れた JSON 修復 / free text からの regex 復元 / provider 別 parser は実装しない。
 """
 

--- a/src/image_annotator_lib/webapi/provider_manager.py
+++ b/src/image_annotator_lib/webapi/provider_manager.py
@@ -36,12 +36,13 @@ from .output_normalization import build_annotation_output_normalizer
 from .result_adapter import to_annotation_result
 
 # ADR 0023 retry policy:
-# - output normalization / schema validation failure: PydanticAI `output_retries=1` で 1 回再生成
+# - output normalization / schema validation failure: PydanticAI `retries={"output": 1}` で 1 回再生成
 #   (`ModelRetry` 経由)。
 # - HTTP/API transient failure: Phase 1.8 (Issue #46) で `webapi/http_retry.py` の
 #   `AsyncTenacityTransport` が provider HTTP client 層で initial+2 retries (max 3 attempts)。
 # 両 retry は独立した経路で機能し、互いに干渉しない。
 _OUTPUT_RETRIES = 1
+_DEFAULT_WEBAPI_MAX_CONCURRENCY = 3
 
 # Agent.run の user message として渡す短い指示。BASE_PROMPT は system_prompt 側で詳細を伝える。
 _USER_PROMPT_TEXT = "Analyze this image and provide annotations as specified."
@@ -63,6 +64,14 @@ _REFUSAL_ERROR_CODE: dict[type[BaseException], AnnotationErrorCode] = {
 _CORE_CAPABILITIES = frozenset(
     {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
 )
+
+
+def _resolve_max_concurrency(max_concurrency: int | None) -> int:
+    """Resolve and validate bounded WebAPI image request concurrency."""
+    resolved = _DEFAULT_WEBAPI_MAX_CONCURRENCY if max_concurrency is None else max_concurrency
+    if isinstance(resolved, bool) or not isinstance(resolved, int) or resolved < 1:
+        raise ValueError(f"max_concurrency must be a positive integer: {max_concurrency!r}")
+    return resolved
 
 
 def _build_system_prompt(capabilities: set[TaskCapability] | frozenset[TaskCapability] | None) -> str:
@@ -137,6 +146,7 @@ class ProviderManager:
         config: dict[str, Any] | None = None,
         capabilities: set[TaskCapability] | frozenset[TaskCapability] | None = None,
         mode: str = "chat",
+        max_concurrency: int | None = None,
         _test_agent: Agent | None = None,
     ) -> dict[str, AnnotationResult]:
         """非同期推論の中核実装。
@@ -150,17 +160,21 @@ class ProviderManager:
             capabilities: 呼び出し元 WebAPI annotator が明示したタスク能力。
             mode: registry metadata 由来の推論 endpoint 種別 (`"chat"` / `"responses"`)。
                 OpenAI の responses 系モデル構築のため `resolve_model_ref` に伝播する。
+            max_concurrency: 同一モデル内で並列実行する画像 API request の最大数。
+                None の場合は保守的な既定値を使う。
             _test_agent: pytest fixture からの Agent 注入専用 (本番では None)。
 
         Returns:
             `dict[phash, AnnotationResult]`。画像ごとに 1 entry。
         """
+        resolved_max_concurrency = _resolve_max_concurrency(max_concurrency)
         if _is_openai_moderation_model(litellm_model_id):
             return await cls._run_openai_moderation_inference(
                 model_name=model_name,
                 images_list=images_list,
                 litellm_model_id=litellm_model_id,
                 api_keys=api_keys,
+                max_concurrency=resolved_max_concurrency,
             )
 
         # ADR 0023 Phase 1.8 (Issue #46): transport retry 付き AsyncClient を推論呼び出しごとに
@@ -183,7 +197,7 @@ class ProviderManager:
                     model=model,
                     output_type=build_annotation_output_normalizer(capabilities),
                     system_prompt=_build_system_prompt(capabilities),
-                    output_retries=_OUTPUT_RETRIES,
+                    retries={"output": _OUTPUT_RETRIES},
                 )
             except BaseException:
                 # provider/model/Agent 構築途中で失敗した場合は、開いた AsyncClient を確実に閉じる。
@@ -192,75 +206,84 @@ class ProviderManager:
 
         try:
             binary_contents = preprocess_images_to_binary(images_list)
-            results: dict[str, AnnotationResult] = {}
-            for index, (image, binary) in enumerate(zip(images_list, binary_contents, strict=True)):
+            semaphore = asyncio.Semaphore(resolved_max_concurrency)
+
+            async def _run_one(index: int, image: Image.Image, binary: Any) -> tuple[str, AnnotationResult]:
                 phash = calculate_phash(image) or f"unknown_image_{index}"
-                try:
-                    run_result = await agent.run([_USER_PROMPT_TEXT, binary])
-                    # Issue #134: schema-valid だが全要求 capability が空の成功は、例外も
-                    # refusal シグナルも伴わず error=None で素通りする。EmptyAnnotationError
-                    # に分類して error_records 経路に乗せる (refusal contract #42 の拡張)。
-                    empty_exc = _classify_empty_output(
-                        run_result.output, capabilities, litellm_model_id, phash
+                async with semaphore:
+                    try:
+                        run_result = await agent.run([_USER_PROMPT_TEXT, binary])
+                        # Issue #134: schema-valid だが全要求 capability が空の成功は、例外も
+                        # refusal シグナルも伴わず error=None で素通りする。EmptyAnnotationError
+                        # に分類して error_records 経路に乗せる (refusal contract #42 の拡張)。
+                        empty_exc = _classify_empty_output(
+                            run_result.output, capabilities, litellm_model_id, phash
+                        )
+                        if empty_exc is not None:
+                            logger.warning(
+                                f"WebAPI empty annotation: model={model_name}, "
+                                f"litellm_model_id={litellm_model_id}, phash={phash}, "
+                                f"capabilities={empty_exc.requested_capabilities}"
+                            )
+                            return phash, to_annotation_result(
+                                None,
+                                phash,
+                                error=str(empty_exc),
+                                error_code=AnnotationErrorCode.EMPTY_ANNOTATION,
+                                retryable=False,
+                            )
+                        return phash, to_annotation_result(run_result.output, phash)
+                    except Exception as exc:
+                        refusal_exc = _classify_refusal(exc, litellm_model_id, phash)
+                        if refusal_exc is not None:
+                            # ADR 0006 amendment (#134/#599): refusal は library エラーではなく
+                            # structured outcome。error_code (UPPERCASE) + retryable=False +
+                            # message で伝搬し、LoRAIro 側で error_records に記録する。
+                            logger.warning(
+                                f"WebAPI safety refusal: model={model_name}, "
+                                f"litellm_model_id={litellm_model_id}, phash={phash}, "
+                                f"reason={refusal_exc.provider_refusal_reason or 'no reason'}"
+                            )
+                            return phash, to_annotation_result(
+                                None,
+                                phash,
+                                error=str(refusal_exc),
+                                error_code=_REFUSAL_ERROR_CODE[type(refusal_exc)],
+                                retryable=False,
+                            )
+                        # ADR 0023 Phase 1.8 (Issue #46): transport retry 枯渇時は
+                        # tenacity が httpx 例外を reraise する (RetryConfig(reraise=True))。
+                        # 既存の str(exc) 文字列伝搬経路でそのまま LoRAIro 側に流れる。
+                        #
+                        # LoRAIro #274: openai.APIConnectionError 等は str(exc) が
+                        # "Connection error." に潰れ、根本原因 (httpx の ConnectTimeout 等)
+                        # が AnnotationResult.error から失われる。cause/context chain を
+                        # 辿った診断文字列を log・result.error の双方に伝搬する。
+                        error_detail = _format_exception_chain(exc)
+                        # LoRAIro #274: traceback を logger に attach しない。loguru sink の
+                        # diagnose 設定により traceback 各フレームの変数値 (api_key 等) が
+                        # 展開され、機密情報漏洩 + 過剰ノイズになる。原因は error_detail
+                        # (cause chain: 例外各層の型 + message) で十分特定できる。
+                        #
+                        # Issue #69 / LoRAIro #275: 引数なしの `logger.error(message)` は
+                        # loguru が `message.format()` を呼ばないため、message 中の str(exc)
+                        # 由来 `{'type': ...}` dict 表現を placeholder と誤認せず、
+                        # `KeyError("'type'")` も leak しない。
+                        logger.error(
+                            f"WebAPI 推論失敗: model={model_name}, "
+                            f"litellm_model_id={litellm_model_id}, error={error_detail}"
+                        )
+                        return phash, to_annotation_result(None, phash, error=error_detail)
+
+            result_items = await asyncio.gather(
+                *(
+                    _run_one(index, image, binary)
+                    for index, (image, binary) in enumerate(
+                        zip(images_list, binary_contents, strict=True)
                     )
-                    if empty_exc is not None:
-                        logger.warning(
-                            f"WebAPI empty annotation: model={model_name}, "
-                            f"litellm_model_id={litellm_model_id}, phash={phash}, "
-                            f"capabilities={empty_exc.requested_capabilities}"
-                        )
-                        results[phash] = to_annotation_result(
-                            None,
-                            phash,
-                            error=str(empty_exc),
-                            error_code=AnnotationErrorCode.EMPTY_ANNOTATION,
-                            retryable=False,
-                        )
-                        continue
-                    results[phash] = to_annotation_result(run_result.output, phash)
-                except Exception as exc:
-                    refusal_exc = _classify_refusal(exc, litellm_model_id, phash)
-                    if refusal_exc is not None:
-                        # ADR 0006 amendment (#134/#599): refusal は library エラーではなく
-                        # structured outcome。error_code (UPPERCASE) + retryable=False +
-                        # message で伝搬し、LoRAIro 側で error_records に記録する。
-                        logger.warning(
-                            f"WebAPI safety refusal: model={model_name}, "
-                            f"litellm_model_id={litellm_model_id}, phash={phash}, "
-                            f"reason={refusal_exc.provider_refusal_reason or 'no reason'}"
-                        )
-                        results[phash] = to_annotation_result(
-                            None,
-                            phash,
-                            error=str(refusal_exc),
-                            error_code=_REFUSAL_ERROR_CODE[type(refusal_exc)],
-                            retryable=False,
-                        )
-                        continue
-                    # ADR 0023 Phase 1.8 (Issue #46): transport retry 枯渇時は
-                    # tenacity が httpx 例外を reraise する (RetryConfig(reraise=True))。
-                    # 既存の str(exc) 文字列伝搬経路でそのまま LoRAIro 側に流れる。
-                    #
-                    # LoRAIro #274: openai.APIConnectionError 等は str(exc) が
-                    # "Connection error." に潰れ、根本原因 (httpx の ConnectTimeout 等)
-                    # が AnnotationResult.error から失われる。cause/context chain を
-                    # 辿った診断文字列を log・result.error の双方に伝搬する。
-                    error_detail = _format_exception_chain(exc)
-                    # LoRAIro #274: traceback を logger に attach しない。loguru sink の
-                    # diagnose 設定により traceback 各フレームの変数値 (api_key 等) が
-                    # 展開され、機密情報漏洩 + 過剰ノイズになる。原因は error_detail
-                    # (cause chain: 例外各層の型 + message) で十分特定できる。
-                    #
-                    # Issue #69 / LoRAIro #275: 引数なしの `logger.error(message)` は
-                    # loguru が `message.format()` を呼ばないため、message 中の str(exc)
-                    # 由来 `{'type': ...}` dict 表現を placeholder と誤認せず、
-                    # `KeyError("'type'")` も leak しない。
-                    logger.error(
-                        f"WebAPI 推論失敗: model={model_name}, "
-                        f"litellm_model_id={litellm_model_id}, error={error_detail}"
-                    )
-                    results[phash] = to_annotation_result(None, phash, error=error_detail)
-            return results
+                )
+            )
+            return dict(result_items)
         finally:
             if http_client is not None:
                 await http_client.aclose()
@@ -297,6 +320,7 @@ class ProviderManager:
         config: dict[str, Any] | None = None,
         capabilities: set[TaskCapability] | frozenset[TaskCapability] | None = None,
         mode: str = "chat",
+        max_concurrency: int | None = None,
         _test_agent: Agent | None = None,
     ) -> dict[str, AnnotationResult]:
         """`run_inference_with_model_async()` の sync wrapper。
@@ -322,6 +346,7 @@ class ProviderManager:
                 config=config,
                 capabilities=capabilities,
                 mode=mode,
+                max_concurrency=max_concurrency,
                 _test_agent=_test_agent,
             )
         )
@@ -358,6 +383,7 @@ class ProviderManager:
         images_list: list[Image.Image],
         litellm_model_id: str,
         api_keys: dict[str, str] | None,
+        max_concurrency: int,
     ) -> dict[str, AnnotationResult]:
         """Run OpenAI Moderations directly for image rating models."""
 
@@ -369,42 +395,53 @@ class ProviderManager:
 
             client = AsyncOpenAI(api_key=api_key, http_client=http_client)
             binary_contents = preprocess_images_to_binary(images_list)
-            results: dict[str, AnnotationResult] = {}
-            for index, (image, binary) in enumerate(zip(images_list, binary_contents, strict=True)):
+            semaphore = asyncio.Semaphore(max_concurrency)
+
+            async def _run_one(index: int, image: Image.Image, binary: Any) -> tuple[str, AnnotationResult]:
                 phash = calculate_phash(image) or f"unknown_image_{index}"
-                try:
-                    response = await client.moderations.create(
-                        model=ref.provider_model_id,
-                        input=[
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": build_base64_data_url(binary.data, binary.media_type),
-                                },
-                            }
-                        ],
+                async with semaphore:
+                    try:
+                        response = await client.moderations.create(
+                            model=ref.provider_model_id,
+                            input=[
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": build_base64_data_url(binary.data, binary.media_type),
+                                    },
+                                }
+                            ],
+                        )
+                        payload = _openai_response_to_dict(response)
+                        prediction = category_scores_to_rating_prediction(payload)
+                        return phash, AnnotationResult(
+                            phash=phash,
+                            tags=[],
+                            formatted_output={
+                                "tags": [],
+                                "captions": [],
+                                "score": None,
+                                "ratings": [prediction],
+                            },
+                            error=None,
+                        )
+                    except Exception as exc:
+                        error_detail = _format_exception_chain(exc)
+                        logger.error(
+                            f"OpenAI Moderations 推論失敗: model={model_name}, "
+                            f"litellm_model_id={litellm_model_id}, error={error_detail}"
+                        )
+                        return phash, to_annotation_result(None, phash, error=error_detail)
+
+            result_items = await asyncio.gather(
+                *(
+                    _run_one(index, image, binary)
+                    for index, (image, binary) in enumerate(
+                        zip(images_list, binary_contents, strict=True)
                     )
-                    payload = _openai_response_to_dict(response)
-                    prediction = category_scores_to_rating_prediction(payload)
-                    results[phash] = AnnotationResult(
-                        phash=phash,
-                        tags=[],
-                        formatted_output={
-                            "tags": [],
-                            "captions": [],
-                            "score": None,
-                            "ratings": [prediction],
-                        },
-                        error=None,
-                    )
-                except Exception as exc:
-                    error_detail = _format_exception_chain(exc)
-                    logger.error(
-                        f"OpenAI Moderations 推論失敗: model={model_name}, "
-                        f"litellm_model_id={litellm_model_id}, error={error_detail}"
-                    )
-                    results[phash] = to_annotation_result(None, phash, error=error_detail)
-            return results
+                )
+            )
+            return dict(result_items)
         finally:
             await http_client.aclose()
 

--- a/tests/unit/core/test_provider_manager_concurrency.py
+++ b/tests/unit/core/test_provider_manager_concurrency.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from image_annotator_lib.core.types import AnnotationSchema, TaskCapability
+from image_annotator_lib.webapi import provider_manager as provider_manager_module
+from image_annotator_lib.webapi.provider_manager import ProviderManager
+
+
+def _images(count: int) -> list[Image.Image]:
+    images: list[Image.Image] = []
+    for index in range(count):
+        image = Image.new("RGB", (8, 8), color=(index, index, index))
+        image.info["phash"] = f"phash-{index}"
+        images.append(image)
+    return images
+
+
+def _patch_phash(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        provider_manager_module,
+        "calculate_phash",
+        lambda image: image.info["phash"],
+    )
+
+
+class _DelayedAgent:
+    def __init__(self, delays: list[float]) -> None:
+        self._delays = delays
+        self._next_index = 0
+        self.active = 0
+        self.peak_active = 0
+        self.started: list[int] = []
+
+    async def run(self, *_args: object, **_kwargs: object) -> object:
+        index = self._next_index
+        self._next_index += 1
+        self.started.append(index)
+        self.active += 1
+        self.peak_active = max(self.peak_active, self.active)
+        try:
+            await asyncio.sleep(self._delays[index])
+            return SimpleNamespace(
+                output=AnnotationSchema(tags=[f"tag-{index}"], captions=[], score=None, ratings=[])
+            )
+        finally:
+            self.active -= 1
+
+
+class _ScriptedAgent:
+    def __init__(self, outcomes: list[Any]) -> None:
+        self._outcomes = outcomes
+        self._next_index = 0
+
+    async def run(self, *_args: object, **_kwargs: object) -> object:
+        index = self._next_index
+        self._next_index += 1
+        outcome = self._outcomes[index]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return SimpleNamespace(output=outcome)
+
+
+def test_webapi_requests_are_bounded_concurrently(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_phash(monkeypatch)
+    agent = _DelayedAgent([0.03, 0.03, 0.03, 0.03, 0.03])
+
+    results = ProviderManager.run_inference_with_model(
+        model_name="test-webapi",
+        images_list=_images(5),
+        litellm_model_id="openai/gpt-4o-mini",
+        capabilities={TaskCapability.TAGS},
+        max_concurrency=2,
+        _test_agent=agent,
+    )
+
+    assert agent.peak_active == 2
+    assert list(results) == [f"phash-{index}" for index in range(5)]
+    assert [results[f"phash-{index}"]["tags"][0] for index in range(5)] == [
+        f"tag-{index}" for index in range(5)
+    ]
+
+
+def test_webapi_result_order_is_stable_when_completion_order_differs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_phash(monkeypatch)
+    agent = _DelayedAgent([0.04, 0.01, 0.02])
+
+    results = ProviderManager.run_inference_with_model(
+        model_name="test-webapi",
+        images_list=_images(3),
+        litellm_model_id="openai/gpt-4o-mini",
+        capabilities={TaskCapability.TAGS},
+        max_concurrency=3,
+        _test_agent=agent,
+    )
+
+    assert list(results) == ["phash-0", "phash-1", "phash-2"]
+    assert results["phash-0"]["tags"] == ["tag-0"]
+    assert results["phash-1"]["tags"] == ["tag-1"]
+    assert results["phash-2"]["tags"] == ["tag-2"]
+
+
+def test_webapi_concurrent_path_preserves_per_image_outcomes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_phash(monkeypatch)
+    agent = _ScriptedAgent(
+        [
+            AnnotationSchema(tags=["ok"], captions=[], score=None, ratings=[]),
+            AnnotationSchema(tags=[], captions=[], score=None, ratings=[]),
+            RuntimeError("stop_reason=refusal"),
+            RuntimeError("network timeout"),
+        ]
+    )
+
+    results = ProviderManager.run_inference_with_model(
+        model_name="test-webapi",
+        images_list=_images(4),
+        litellm_model_id="openai/gpt-4o-mini",
+        capabilities={TaskCapability.TAGS},
+        max_concurrency=4,
+        _test_agent=agent,
+    )
+
+    assert results["phash-0"]["error"] is None
+    assert results["phash-0"]["tags"] == ["ok"]
+    assert results["phash-1"]["error_code"] == "EMPTY_ANNOTATION"
+    assert results["phash-1"]["retryable"] is False
+    assert results["phash-2"]["error_code"] == "SAFETY_REFUSAL"
+    assert results["phash-2"]["retryable"] is False
+    assert "RuntimeError: network timeout" in results["phash-3"]["error"]
+
+
+@pytest.mark.parametrize("max_concurrency", [0, -1, True, 1.5])
+def test_webapi_rejects_invalid_max_concurrency(max_concurrency: Any) -> None:
+    with pytest.raises(ValueError, match="max_concurrency"):
+        ProviderManager.run_inference_with_model(
+            model_name="test-webapi",
+            images_list=_images(1),
+            litellm_model_id="openai/gpt-4o-mini",
+            max_concurrency=max_concurrency,
+            _test_agent=_DelayedAgent([0]),
+        )
+
+
+def test_webapi_max_concurrency_one_allows_serial_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_phash(monkeypatch)
+    agent = _DelayedAgent([0, 0, 0])
+
+    results = ProviderManager.run_inference_with_model(
+        model_name="test-webapi",
+        images_list=_images(3),
+        litellm_model_id="openai/gpt-4o-mini",
+        capabilities={TaskCapability.TAGS},
+        max_concurrency=1,
+        _test_agent=agent,
+    )
+
+    assert agent.peak_active == 1
+    assert list(results) == ["phash-0", "phash-1", "phash-2"]

--- a/tests/unit/core/test_provider_manager_empty_annotation.py
+++ b/tests/unit/core/test_provider_manager_empty_annotation.py
@@ -17,7 +17,7 @@ from pydantic_ai.models.test import TestModel
 from image_annotator_lib.core.types import AnnotationSchema, TaskCapability
 from image_annotator_lib.exceptions.errors import EmptyAnnotationError
 from image_annotator_lib.webapi.output_normalization import build_annotation_output_normalizer
-from image_annotator_lib.webapi.provider_manager import _classify_empty_output, ProviderManager
+from image_annotator_lib.webapi.provider_manager import ProviderManager, _classify_empty_output
 
 _TAGS_CAPTIONS = frozenset({TaskCapability.TAGS, TaskCapability.CAPTIONS})
 
@@ -26,7 +26,7 @@ def _run(custom_output_args: dict[str, object], capabilities: frozenset[TaskCapa
     agent = Agent(
         model=TestModel(custom_output_args=custom_output_args),
         output_type=build_annotation_output_normalizer(capabilities),
-        output_retries=1,
+        retries={"output": 1},
     )
     image = Image.new("RGB", (8, 8), color="white")
     results = ProviderManager.run_inference_with_model(

--- a/tests/unit/core/test_provider_manager_output_normalization.py
+++ b/tests/unit/core/test_provider_manager_output_normalization.py
@@ -20,7 +20,7 @@ def test_provider_manager_returns_normalized_annotation_result() -> None:
             }
         ),
         output_type=normalize_annotation_output,
-        output_retries=1,
+        retries={"output": 1},
     )
     image = Image.new("RGB", (8, 8), color="white")
 

--- a/tests/unit/core/test_webapi_annotator.py
+++ b/tests/unit/core/test_webapi_annotator.py
@@ -76,6 +76,10 @@ class TestWebApiAnnotatorModeWiring:
         annotator = WebApiAnnotator(litellm_model_id="openai/gpt-5-pro", mode="responses")
         assert annotator.mode == "responses"
 
+    def test_init_stores_explicit_max_concurrency(self) -> None:
+        annotator = WebApiAnnotator(litellm_model_id="openai/gpt-4o", max_concurrency=2)
+        assert annotator.max_concurrency == 2
+
     def test_run_inference_passes_mode_to_provider_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """`_run_inference` が `mode="responses"` で ProviderManager を呼ぶことを確認する。
 
@@ -99,6 +103,25 @@ class TestWebApiAnnotatorModeWiring:
 
         assert captured["mode"] == "responses"
         assert captured["litellm_model_id"] == "openai/gpt-5-pro"
+
+    def test_run_inference_passes_max_concurrency_to_provider_manager(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, object] = {}
+        image = Image.new("RGB", (4, 4), color="white")
+
+        def fake_run(**kwargs: object) -> dict[str, AnnotationResult]:
+            captured.update(kwargs)
+            return {}
+
+        monkeypatch.setattr(
+            annotator_module.ProviderManager, "run_inference_with_model", staticmethod(fake_run)
+        )
+
+        annotator = WebApiAnnotator(litellm_model_id="openai/gpt-4o", max_concurrency=2)
+        annotator._run_inference([image])
+
+        assert captured["max_concurrency"] == 2
 
 
 class TestWebApiAnnotatorRatings:

--- a/tests/unit/webapi/test_provider_manager_openai_moderations.py
+++ b/tests/unit/webapi/test_provider_manager_openai_moderations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import ClassVar
 
@@ -27,33 +28,58 @@ class _FakeModerationResponse:
 
 
 class _FakeModerations:
-    def __init__(self, calls: list[dict], exc: Exception | None = None) -> None:
+    def __init__(
+        self,
+        calls: list[dict],
+        exc: Exception | None = None,
+        delay: float = 0,
+        tracker: dict[str, int] | None = None,
+    ) -> None:
         self._calls = calls
         self._exc = exc
+        self._delay = delay
+        self._tracker = tracker
 
     async def create(self, **kwargs):
         self._calls.append(kwargs)
-        if self._exc is not None:
-            raise self._exc
-        return _FakeModerationResponse()
+        if self._tracker is not None:
+            self._tracker["active"] += 1
+            self._tracker["peak"] = max(self._tracker["peak"], self._tracker["active"])
+        try:
+            if self._delay:
+                await asyncio.sleep(self._delay)
+            if self._exc is not None:
+                raise self._exc
+            return _FakeModerationResponse()
+        finally:
+            if self._tracker is not None:
+                self._tracker["active"] -= 1
 
 
 class _FakeAsyncOpenAI:
     calls: ClassVar[list[dict]] = []
     exc: ClassVar[Exception | None] = None
+    delay: ClassVar[float] = 0
+    tracker: ClassVar[dict[str, int] | None] = None
 
     def __init__(self, *, api_key: str, http_client) -> None:
         assert api_key == "test-key"
         assert http_client is not None
-        self.moderations = _FakeModerations(self.calls, self.exc)
+        self.moderations = _FakeModerations(self.calls, self.exc, self.delay, self.tracker)
 
 
-def _install_fake_openai(monkeypatch: pytest.MonkeyPatch, exc: Exception | None = None) -> list[dict]:
+def _install_fake_openai(
+    monkeypatch: pytest.MonkeyPatch,
+    exc: Exception | None = None,
+    *,
+    delay: float = 0,
+    tracker: dict[str, int] | None = None,
+) -> list[dict]:
     calls: list[dict] = []
     fake_cls = type(
         "FakeAsyncOpenAI",
         (_FakeAsyncOpenAI,),
-        {"calls": calls, "exc": exc},
+        {"calls": calls, "exc": exc, "delay": delay, "tracker": tracker},
     )
     monkeypatch.setitem(
         __import__("sys").modules,
@@ -115,3 +141,29 @@ def test_openai_moderation_api_error_is_wrapped_with_diagnostic(
     assert result["tags"] == []
     assert "RuntimeError: moderation failed" in result["error"]
     assert "ValueError: socket closed" in result["error"]
+
+
+def test_openai_moderation_respects_max_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracker = {"active": 0, "peak": 0}
+    calls = _install_fake_openai(monkeypatch, delay=0.02, tracker=tracker)
+    images = [Image.new("RGB", (8, 8), color=(index, index, index)) for index in range(5)]
+    for index, image in enumerate(images):
+        image.info["phash"] = f"moderation-{index}"
+    monkeypatch.setattr(
+        "image_annotator_lib.webapi.provider_manager.calculate_phash",
+        lambda image: image.info["phash"],
+    )
+
+    results = ProviderManager.run_inference_with_model(
+        model_name="openai/omni-moderation-latest",
+        images_list=images,
+        litellm_model_id="openai/omni-moderation-latest",
+        api_keys={"openai": "test-key"},
+        max_concurrency=2,
+    )
+
+    assert tracker["peak"] == 2
+    assert len(calls) == 5
+    assert list(results) == [f"moderation-{index}" for index in range(5)]


### PR DESCRIPTION
## Summary
- Fixes #136
- Run per-image WebAPI requests with bounded asyncio concurrency instead of serial awaits
- Apply the same bounded behavior to OpenAI Moderations and expose max_concurrency via ProviderManager/WebApiAnnotator
- Migrate library/test Agent construction from deprecated output_retries to retries={"output": 1}
- Add ADR 0008 documenting the concurrency decision

## Verification
- uv run --no-sync ruff check src/image_annotator_lib/webapi/provider_manager.py src/image_annotator_lib/webapi/annotator.py src/image_annotator_lib/webapi/http_retry.py src/image_annotator_lib/webapi/output_normalization.py tests/unit/core/test_provider_manager_concurrency.py tests/unit/core/test_provider_manager_empty_annotation.py tests/unit/core/test_provider_manager_output_normalization.py tests/unit/core/test_webapi_annotator.py tests/unit/webapi/test_provider_manager_openai_moderations.py
- uv run --no-sync pytest tests/unit/core/test_provider_manager_concurrency.py tests/unit/core/test_provider_manager_output_normalization.py tests/unit/core/test_provider_manager_empty_annotation.py tests/unit/core/test_provider_manager_refusal.py tests/unit/core/test_provider_manager_exception_chain.py tests/unit/core/test_provider_manager_event_loop_context.py tests/unit/webapi/test_provider_manager_openai_moderations.py tests/unit/core/test_webapi_annotator.py -q
- uv run --no-sync pytest tests/unit/core tests/unit/webapi -q