### PR TITLE
fix: drop filter_module_logs, demote registry/config firehose to TRACE

### DIFF
--- a/src/image_annotator_lib/core/config.py
+++ b/src/image_annotator_lib/core/config.py
@@ -61,9 +61,7 @@ class ModelConfigRegistry:
             user_config_path if user_config_path else DEFAULT_PATHS["user_config_toml"]
         )
         self._runtime_cache_path = Path(
-            runtime_cache_path
-            if runtime_cache_path
-            else DEFAULT_PATHS["model_runtime_cache_toml"]
+            runtime_cache_path if runtime_cache_path else DEFAULT_PATHS["model_runtime_cache_toml"]
         )
         logger.debug(f"システム設定パスを決定: {self._system_config_path}")
         logger.debug(f"ユーザー設定パスを決定: {self._user_config_path}")
@@ -164,9 +162,7 @@ class ModelConfigRegistry:
                 try:
                     loaded_data = _load_config_from_file(self._runtime_cache_path)
                     self._runtime_cache_data = self._filter_runtime_cache_data(loaded_data)
-                    logger.info(
-                        f"モデル runtime cache を {self._runtime_cache_path} から読み込みました。"
-                    )
+                    logger.info(f"モデル runtime cache を {self._runtime_cache_path} から読み込みました。")
                 except Exception as e:
                     logger.warning(
                         f"モデル runtime cache {self._runtime_cache_path} の読み込み中にエラー: {e}"
@@ -218,7 +214,9 @@ class ModelConfigRegistry:
                     )
             else:
                 self._merged_config_data[model_name] = copy.deepcopy(user_model_config)
-        logger.debug("システム設定とユーザー設定をディープコピーでマージしました。")
+        # 各 setter (set / set_system_value / set_runtime_cache_value) からも呼ばれ、
+        # per-model 更新で firehose 化するため TRACE (ADR 0047)。
+        logger.trace("システム設定とユーザー設定をディープコピーでマージしました。")
 
     @staticmethod
     def _merge_capabilities(system_capabilities: Any, user_capabilities: Any) -> list[Any]:
@@ -244,7 +242,7 @@ class ModelConfigRegistry:
 
     def set(self, model_name: str, key: str, value: Any) -> None:
         """指定されたモデルとキーに対応する設定値をユーザー設定として更新します。"""
-        logger.debug(f"ユーザー設定を更新: モデル '{model_name}', キー '{key}', 値 '{value}'")
+        logger.trace(f"ユーザー設定を更新: モデル '{model_name}', キー '{key}', 値 '{value}'")
         if model_name not in self._user_config_data:
             self._user_config_data[model_name] = {}
         self._user_config_data[model_name][key] = value
@@ -253,7 +251,7 @@ class ModelConfigRegistry:
 
     def set_system_value(self, model_name: str, key: str, value: Any) -> None:
         """指定されたモデルとキーに対応する設定値をシステム設定として更新します。"""
-        logger.debug(f"システム設定を更新: モデル '{model_name}', キー '{key}', 値 '{value}'")
+        logger.trace(f"システム設定を更新: モデル '{model_name}', キー '{key}', 値 '{value}'")
         if model_name not in self._system_config_data:
             self._system_config_data[model_name] = {}
         self._system_config_data[model_name][key] = value
@@ -265,7 +263,7 @@ class ModelConfigRegistry:
         if key not in RUNTIME_MODEL_METADATA_KEYS:
             logger.warning(f"モデル runtime cache に保存できないキーをスキップ: {key}")
             return
-        logger.debug(f"モデル runtime cache を更新: モデル '{model_name}', キー '{key}', 値 '{value}'")
+        logger.trace(f"モデル runtime cache を更新: モデル '{model_name}', キー '{key}', 値 '{value}'")
         if model_name not in self._runtime_cache_data:
             self._runtime_cache_data[model_name] = {}
         self._runtime_cache_data[model_name][key] = value

--- a/src/image_annotator_lib/core/registry.py
+++ b/src/image_annotator_lib/core/registry.py
@@ -47,7 +47,7 @@ def _import_module_from_file(module_file: Path, base_module_path: str) -> Module
     full_module_path = f"{base_module_path}.{module_path}"
     try:
         module = importlib.import_module(full_module_path)
-        logger.debug(f"モジュールのインポート成功: {full_module_path}")
+        logger.trace(f"モジュールのインポート成功: {full_module_path}")
         return module
     except ImportError as e:
         logger.error(f"モジュール {full_module_path} のインポート中にエラー: {e}", exc_info=True)
@@ -234,13 +234,13 @@ def _try_register_model(
 
     if model_name in registry:
         if registry[model_name] is model_cls:
-            logger.debug(f"モデル名 '{model_name}' は既に登録されています(同一クラス)。スキップします。")
+            logger.trace(f"モデル名 '{model_name}' は既に登録されています(同一クラス)。スキップします。")
             return True
         logger.warning(
             f"モデル名 '{model_name}' は既に登録されています。クラス '{model_cls.__name__}' で上書きします。"
         )
     registry[model_name] = model_cls
-    logger.debug(f"モデル '{model_name}' をクラス '{model_cls.__name__}' でレジストリに登録しました。")
+    logger.trace(f"モデル '{model_name}' をクラス '{model_cls.__name__}' でレジストリに登録しました。")
     return True
 
 
@@ -361,20 +361,20 @@ def find_model_class_case_insensitive(model_name: str) -> tuple[str, ModelClass]
     Returns:
         tuple[str, ModelClass] | None: (実際のキー名, モデルクラス) のタプル。見つからない場合はNone
     """
-    # デバッグ情報を追加
-    logger.debug(f"モデル検索: '{model_name}' を {len(_MODEL_CLASS_OBJ_REGISTRY)} 個のモデルから検索")
-    logger.debug(f"利用可能なモデル: {list(_MODEL_CLASS_OBJ_REGISTRY.keys())[:10]}...")
+    # デバッグ情報を追加 (モデル解決ごとに呼ばれる per-lookup firehose のため TRACE)
+    logger.trace(f"モデル検索: '{model_name}' を {len(_MODEL_CLASS_OBJ_REGISTRY)} 個のモデルから検索")
+    logger.trace(f"利用可能なモデル: {list(_MODEL_CLASS_OBJ_REGISTRY.keys())[:10]}...")
 
     # 最初に正確なマッチを試す
     if model_name in _MODEL_CLASS_OBJ_REGISTRY:
-        logger.debug(f"正確なマッチ: '{model_name}'")
+        logger.trace(f"正確なマッチ: '{model_name}'")
         return (model_name, _MODEL_CLASS_OBJ_REGISTRY[model_name])
 
     # 大文字・小文字を区別しない検索
     model_name_lower = model_name.lower()
     for key, value in _MODEL_CLASS_OBJ_REGISTRY.items():
         if key.lower() == model_name_lower:
-            logger.debug(f"モデル名を正規化: '{model_name}' -> '{key}'")
+            logger.trace(f"モデル名を正規化: '{model_name}' -> '{key}'")
             return (key, value)
 
     # 部分マッチを試す(ハイフンやスペースを無視)
@@ -382,7 +382,7 @@ def find_model_class_case_insensitive(model_name: str) -> tuple[str, ModelClass]
     for key, value in _MODEL_CLASS_OBJ_REGISTRY.items():
         normalized_key = key.lower().replace("-", "").replace(" ", "")
         if normalized_search in normalized_key or normalized_key in normalized_search:
-            logger.debug(f"部分マッチでモデル名を正規化: '{model_name}' -> '{key}'")
+            logger.trace(f"部分マッチでモデル名を正規化: '{model_name}' -> '{key}'")
             return (key, value)
 
     logger.warning(
@@ -714,8 +714,8 @@ def _register_webapi_models_from_discovery() -> None:
     """
     logger.debug("LiteLLM 同梱 DB から WebAPI モデルの直接登録を開始します...")
     try:
-        from ..webapi.api_model_discovery import discover_available_vision_models
         from ..webapi.annotator import WebApiAnnotator
+        from ..webapi.api_model_discovery import discover_available_vision_models
 
         result = discover_available_vision_models()
         api_models: dict[str, dict[str, Any]] = result.get("metadata", {})

--- a/src/image_annotator_lib/core/utils.py
+++ b/src/image_annotator_lib/core/utils.py
@@ -61,18 +61,9 @@ def init_logger() -> None:
         diagnose=True,
     )
 
-    # 特定のモジュールのDEBUGログをフィルタするための関数
-    def filter_module_logs(record: Any) -> bool:  # loguru.Record type (dict-like access)
-        # 'registry' または 'config' モジュールからのDEBUGログをフィルタ
-        if record["name"].startswith("image_annotator_lib.core.registry") or record["name"].startswith(
-            "image_annotator_lib.core.config"
-        ):
-            # INFOレベル以上のログだけを許可する (DEBUGレベルは除外)
-            return bool(record["level"].no >= logger.level("INFO").no)
-        # その他のモジュールのログはすべて通す
-        return True
-
-    # ファイルシンク (DEFAULT_PATHS["log_file"] を使用) - フィルタを追加
+    # ファイルシンク (DEFAULT_PATHS["log_file"] を使用)
+    # registry / config の per-item firehose は logger.trace に降格済み (ADR 0047)。
+    # sink は level="DEBUG" のため TRACE は既定で抑制され、有用な DEBUG は出力される。
     try:
         log_file_path = Path(DEFAULT_PATHS["log_file"])
         log_file_path.parent.mkdir(parents=True, exist_ok=True)  # フォルダ作成
@@ -85,10 +76,8 @@ def init_logger() -> None:
             encoding="utf-8",
             backtrace=True,
             diagnose=True,
-            filter=filter_module_logs,  # フィルタ関数を追加
         )
         logger.info(f"Logging to file: {log_file_path}")
-        logger.info("registry と config モジュールのDEBUGログは出力されません (INFO以上のみ出力)")
     except Exception as e:
         logger.error(f"Failed to configure file logging to '{DEFAULT_PATHS['log_file']}': {e}")
         logger.error("File logging disabled.")


### PR DESCRIPTION
## 概要

`init_logger()` のログノイズ暫定対応 (`filter_module_logs`) を本対応に置き換える。LoRAIro ADR 0047（per-item firehose は TRACE）と同方針。

## 背景

`init_logger()` は registry / config モジュールの DEBUG ログを一律 INFO 未満として file sink から遮断する `filter_module_logs` を持っていた（ブラントハンマー）。さらに「registry と config モジュールのDEBUGログは出力されません」という遮断告知 INFO 自体もノイズになっていた。これにより registry/config の**有用な DEBUG まで一律に失われる**副作用があった。

## 変更

1. **`filter_module_logs` 関数・file sink の `filter=` 引数・遮断告知 INFO を撤去**（`core/utils.py`）
2. **registry/config の per-item firehose DEBUG を `logger.trace` に降格**:
   - `core/registry.py`: モジュールごと import 成功、モデルごと登録 (`_try_register_model`)、モデル解決ごとの検索/正規化 (`find_model_class_case_insensitive`)
   - `core/config.py`: per-update setter（`set` / `set_system_value` / `set_runtime_cache_value`）、setter 経由で per-model 化する `_merge_configs`
3. **init 一回きり・操作単位の DEBUG は維持**（件数サマリー、パス決定、registry 初期化ログ等）

file sink は `level="DEBUG"` のまま。TRACE は既定で抑制されるため firehose は出力されず、撤去したフィルタが本来通すべきだった registry/config の有用な DEBUG は復活する。

## 検証

- ruff format/check: pass
- mypy: 本変更による新規エラーなし（既存の `registry.py` 型エラーは origin/main 由来で本PR対象外）
- pytest（`-m "not downloads_and_runs_model and not calls_real_webapi"`）: **841 passed, 13 deselected**

## 関連

- LoRAIro ADR 0047（TRACE Level for Per-Item Diagnostics）
- LoRAIro Issue #606（本体側の対応と同時実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
