### PR TITLE
fix: follow transformers 5.x for CLIP/pipeline scorer loading (#139)

### DIFF
--- a/src/image_annotator_lib/core/base/clip.py
+++ b/src/image_annotator_lib/core/base/clip.py
@@ -117,7 +117,11 @@ class ClipBaseAnnotator(BaseAnnotator):
 
         try:
             with torch.no_grad():
-                image_features = clip_model.get_image_features(**processed)
+                # transformers 5.x: CLIPModel.get_image_features は tensor ではなく
+                # BaseModelOutputWithPooling を返す。射影済み image embeds は .pooler_output に入る
+                # (旧 4.x の戻り tensor 相当)。古い tensor 戻り値にも備えて getattr で吸収する。
+                features_output = clip_model.get_image_features(**processed)
+                image_features = getattr(features_output, "pooler_output", features_output)
                 image_features = image_features / image_features.norm(p=2, dim=-1, keepdim=True)
                 raw_scores = classifier_head(image_features)
                 return raw_scores.squeeze(-1)

--- a/src/image_annotator_lib/core/loaders/transformers_loader.py
+++ b/src/image_annotator_lib/core/loaders/transformers_loader.py
@@ -58,6 +58,52 @@ class TransformersLoader(LoaderBase):
         return {"model": model, "processor": processor}
 
 
+def _resolve_pipeline_image_processor(model_path: str) -> Any | None:
+    """Pipeline 用の image processor を解決する。
+
+    transformers 5.x は feature extractor 群 (`*FeatureExtractor`) を削除した。古い repo の
+    `preprocessor_config.json` が legacy な `image_processor_type` (例: ``"ViTFeatureExtractor"``)
+    を持つ場合、``AutoImageProcessor`` の後方互換正規化は ``image_processor_type`` が None の時
+    しか発火せず、クラス解決に失敗する (Issue #139)。その場合は model の config (``model_type``)
+    から対応する ImageProcessor クラスを引いて明示構築する。
+
+    Args:
+        model_path: HuggingFace repo 名 / ローカルパス。
+
+    Returns:
+        構築できた image processor。解決不能なら None (pipeline の auto 解決に委ねる)。
+    """
+    from transformers import AutoImageProcessor
+
+    try:
+        return AutoImageProcessor.from_pretrained(model_path)
+    except (ValueError, OSError) as e:
+        logger.debug(f"AutoImageProcessor 解決失敗、model_type 経由で再試行: {model_path} ({e})")
+
+    try:
+        from transformers import AutoConfig
+        from transformers.models.auto.image_processing_auto import IMAGE_PROCESSOR_MAPPING
+
+        config = AutoConfig.from_pretrained(model_path)
+        # IMAGE_PROCESSOR_MAPPING の値型は transformers のバージョンで揺れる
+        # (5.x: backend 別 dict {"torchvision": ViTImageProcessor, "pil": ...} /
+        #  旧: (slow, fast) の tuple / 単一クラス)。型 stub と実体が一致しないため Any で受ける。
+        processor_entry: Any = IMAGE_PROCESSOR_MAPPING[type(config)]
+        if isinstance(processor_entry, dict):
+            candidates = [processor_entry.get("torchvision"), *processor_entry.values()]
+        elif isinstance(processor_entry, (tuple, list)):
+            candidates = list(processor_entry)
+        else:
+            candidates = [processor_entry]
+        processor_cls = next((cls for cls in candidates if cls is not None), None)
+        if processor_cls is None:
+            return None
+        return processor_cls.from_pretrained(model_path)
+    except (ValueError, OSError, KeyError) as e:
+        logger.warning(f"image processor の明示構築に失敗: {model_path} ({e})")
+        return None
+
+
 class TransformersPipelineLoader(LoaderBase):
     """Hugging Face Transformers Pipeline のローダー。"""
 
@@ -77,7 +123,10 @@ class TransformersPipelineLoader(LoaderBase):
         calculated_size_mb = 0.0
         temp_pipeline = None
         try:
-            temp_pipeline = pipeline(task, model=model_path, device="cpu", batch_size=1)
+            image_processor = _resolve_pipeline_image_processor(model_path)
+            temp_pipeline = pipeline(
+                task, model=model_path, image_processor=image_processor, device="cpu", batch_size=1
+            )
             if hasattr(temp_pipeline, "model") and isinstance(temp_pipeline.model, torch.nn.Module):
                 calculated_size_mb = LoaderBase._calculate_transformer_size_mb(temp_pipeline.model)
         except Exception as e:
@@ -102,5 +151,12 @@ class TransformersPipelineLoader(LoaderBase):
         if not task or not batch_size:
             raise ValueError("Pipeline loader requires 'task' and 'batch_size' kwargs.")
 
-        pipeline_obj: Pipeline = pipeline(task, model=model_path, device=self.device, batch_size=batch_size)
+        image_processor = _resolve_pipeline_image_processor(model_path)
+        pipeline_obj: Pipeline = pipeline(
+            task,
+            model=model_path,
+            image_processor=image_processor,
+            device=self.device,
+            batch_size=batch_size,
+        )
         return {"pipeline": pipeline_obj}

--- a/tests/unit/core/test_transformers_loader.py
+++ b/tests/unit/core/test_transformers_loader.py
@@ -1,0 +1,80 @@
+"""Issue #139 (A-2) regression: transformers 5.x の legacy image_processor 解決。
+
+`_resolve_pipeline_image_processor` は古い repo (preprocessor_config.json が
+legacy な `image_processor_type` を持ち AutoImageProcessor で解決できない) でも
+model_type 経由で ImageProcessor クラスを引いて構築できることを検証する。
+ネットワーク / 実モデルには触れず、transformers の auto クラスをモックする。
+
+注: ヘルパー内の `from transformers import ...` は関数ローカルかつ transformers は
+_LazyModule なので、モジュール属性の patch (`patch("transformers.AutoImageProcessor")`)
+は効かない。共有されるクラスオブジェクトの from_pretrained を patch.object で差し替える。
+IMAGE_PROCESSOR_MAPPING は通常のサブモジュール属性なので dict 差し替えで patch する。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from transformers import AutoConfig, AutoImageProcessor
+
+from image_annotator_lib.core.loaders.transformers_loader import (
+    _resolve_pipeline_image_processor,
+)
+
+_MAPPING = "transformers.models.auto.image_processing_auto.IMAGE_PROCESSOR_MAPPING"
+
+
+@pytest.mark.unit
+def test_resolve_image_processor_auto_success():
+    """AutoImageProcessor が成功する正常系はそのまま結果を返す (cafe / v2 相当)。"""
+    expected = MagicMock(name="image_processor")
+    with patch.object(AutoImageProcessor, "from_pretrained", return_value=expected) as mock_auto:
+        result = _resolve_pipeline_image_processor("some/repo")
+    assert result is expected
+    mock_auto.assert_called_once_with("some/repo")
+
+
+@pytest.mark.unit
+def test_resolve_image_processor_legacy_fallback_via_model_type():
+    """AutoImageProcessor 失敗時 (legacy image_processor_type) は model_type 経由で構築する。
+
+    Issue #139 の aesthetic_shadow_v1 (ViTFeatureExtractor) を再現。
+    """
+    built = MagicMock(name="vit_image_processor_instance")
+    vit_cls = MagicMock(name="ViTImageProcessor")
+    vit_cls.from_pretrained.return_value = built
+
+    fake_config = MagicMock(name="ViTConfig")
+    # transformers 5.x の mapping 値は backend 別 dict
+    mapping_entry = {"pil": None, "torchvision": vit_cls}
+
+    with (
+        patch.object(
+            AutoImageProcessor,
+            "from_pretrained",
+            side_effect=ValueError("Unrecognized image processor"),
+        ),
+        patch.object(AutoConfig, "from_pretrained", return_value=fake_config),
+        patch(_MAPPING, {type(fake_config): mapping_entry}),
+    ):
+        result = _resolve_pipeline_image_processor("shadowlilac/aesthetic-shadow")
+
+    assert result is built
+    vit_cls.from_pretrained.assert_called_once_with("shadowlilac/aesthetic-shadow")
+
+
+@pytest.mark.unit
+def test_resolve_image_processor_unresolvable_returns_none():
+    """AutoImageProcessor も model_type 経由も失敗するなら None (pipeline auto に委ねる)。"""
+    with (
+        patch.object(
+            AutoImageProcessor,
+            "from_pretrained",
+            side_effect=ValueError("Unrecognized image processor"),
+        ),
+        patch.object(AutoConfig, "from_pretrained", side_effect=OSError("config not found")),
+    ):
+        result = _resolve_pipeline_image_processor("broken/repo")
+
+    assert result is None

--- a/tests/unit/model_class/test_scorer_models.py
+++ b/tests/unit/model_class/test_scorer_models.py
@@ -607,3 +607,49 @@ def test_clip_scorer_feature_normalization(
             assert raw_outputs.shape == torch.Size([1])
             assert not torch.isnan(raw_outputs).any()
             assert not torch.isinf(raw_outputs).any()
+
+
+@pytest.mark.unit
+def test_clip_scorer_handles_transformers5_pooled_output(
+    mock_clip_scorer_config, mock_clip_components, test_image, mock_capabilities_regression_scorer
+):
+    """Issue #139 (A-1) regression: transformers 5.x の get_image_features 戻り値型に追従する。
+
+    transformers 5.x で CLIPModel.get_image_features は tensor ではなく
+    BaseModelOutputWithPooling を返し、射影済み image embeds は .pooler_output に入る。
+    旧実装は戻り値を直接 .norm() していたため AttributeError で落ちていた。
+    本テストは get_image_features が pooler_output 付きオブジェクトを返しても
+    _run_inference が pooler_output を取り出して正常にスコアを計算することを固定する。
+    """
+    import torch
+    from transformers.modeling_outputs import BaseModelOutputWithPooling
+
+    with patch("image_annotator_lib.core.model_factory.ModelLoad.load_clip_components") as mock_load:
+        mock_clip_model = MagicMock()
+        mock_classifier = MagicMock()
+
+        # transformers 5.x の戻り値を忠実に再現 (.pooler_output に射影済み embeds、.norm は無い)
+        pooled = torch.randn(1, 512) * 10
+        mock_clip_model.get_image_features.return_value = BaseModelOutputWithPooling(pooler_output=pooled)
+        mock_classifier.return_value = torch.tensor([[7.5]])
+
+        mock_components = {
+            "clip_model": mock_clip_model,
+            "model": mock_classifier,
+            "processor": mock_clip_components["processor"],
+            "model_path": "/fake/clip/path",
+        }
+        mock_load.return_value = mock_components
+
+        scorer = ImprovedAesthetic(mock_clip_scorer_config)
+
+        with scorer:
+            processed = scorer._preprocess_images([test_image])
+            raw_outputs = scorer._run_inference(processed)
+
+            # pooler_output が取り出され classifier に渡り、スコアが計算されること
+            mock_classifier.assert_called_once()
+            normalized = mock_classifier.call_args[0][0]
+            assert torch.allclose(torch.norm(normalized, p=2, dim=-1), torch.tensor([1.0]), atol=1e-6)
+            assert raw_outputs.shape == torch.Size([1])
+            assert raw_outputs.item() == 7.5


### PR DESCRIPTION
## 概要

Issue #139 のうち **依存関係 (transformers 5.x) 起因のロード/推論エラー 2 件** を修正する。

`score_labels` / `capabilities` drift (Issue 内 系統B) は ADR 0002 の決定反転を伴う仕様変更のため、本 PR の対象外（別セッションで対応中）。本 PR は「依存追従でモデルが動かない」部分のみに集中する。

## 修正内容

### A-1: CLIP `get_image_features` 戻り値型追従 (`ImprovedAesthetic` / `WaifuAesthetic`)

transformers 5.x で `CLIPModel.get_image_features` は tensor ではなく `BaseModelOutputWithPooling` を返すようになり、射影済み image embeds は `.pooler_output` に入る。旧実装は戻り値を直接 `.norm()` していたため `AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'norm'` で落ちていた。

- `core/base/clip.py`: `getattr(out, "pooler_output", out)` で 5.x オブジェクト / 旧 tensor 戻り値の両方に対応。

### A-2: pipeline image processor の legacy 認識失敗 (`aesthetic_shadow_v1`)

古い repo (`shadowlilac/aesthetic-shadow`) の `preprocessor_config.json` が legacy な `image_processor_type = "ViTFeatureExtractor"` を持つ。transformers 5.x は feature extractor 群を削除済みで、後方互換正規化は `image_processor_type` が `None` の時しか発火しないため、`Unrecognized image processor ...` で解決失敗していた。

- `core/loaders/transformers_loader.py`: `_resolve_pipeline_image_processor()` を追加。`AutoImageProcessor` 失敗時は `AutoConfig` の `model_type` 経由で `ImageProcessor` クラスを引いて明示構築し、`pipeline(..., image_processor=ip)` に注入する（サイズ計算 / 本ロード両経路）。`cafe_aesthetic` / `aesthetic_shadow_v2` 等の正常系は `AutoImageProcessor` 成功経路を通り無影響。

## テスト

- `test_clip_scorer_handles_transformers5_pooled_output`: 5.x の `BaseModelOutputWithPooling` 戻り値で `_run_inference` が `pooler_output` を取り出しスコア計算することを固定（旧 mock は tensor 戻りで bug を素通りさせるため別途追加）。
- `tests/unit/core/test_transformers_loader.py`: legacy fallback / auto 成功 / 解決不能の 3 ケースを検証。

### 検証

CI-equivalent filter (`-m "not downloads_and_runs_model and not calls_real_webapi"`) で **845 passed, 0 failed**。実モデルでの end-to-end は ADR 0026 (On-Demand Runtime Validation) に従い手動 smoke で確認する。

## スコープ含意

本 PR 後のモデル別状況:

| モデル | 状態 |
|---|---|
| `ImprovedAesthetic` / `WaifuAesthetic` | ✅ 完全復旧 (A-1) |
| `aesthetic_shadow_v1` | ⚠️ ロードは通る (A-2) が、その先で score_labels ValidationError (系統B) |
| `cafe_aesthetic` | ❌ 依然 score_labels ValidationError (系統B) |

pipeline 系 2 モデルの完全復旧には系統B (別セッション) の解決が必要。

Closes なし（#139 は系統B 解決まで open 継続）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)