### PR TITLE
fix: restore score_labels capability for canonical scorers (config drift) (#139)

### DIFF
--- a/config/annotator_config.toml
+++ b/config/annotator_config.toml
@@ -4,7 +4,7 @@ device = "cuda"
 class = "AestheticShadow"
 estimated_size_gb = 4.065
 type = "scorer"
-capabilities = [ "scores",]
+capabilities = [ "scores", "score_labels",]
 
 [aesthetic_shadow_v2]
 model_path = "NEXTAltair/cache_aestheic-shadow-v2"
@@ -12,7 +12,7 @@ device = "cuda"
 class = "AestheticShadow"
 estimated_size_gb = 4.065
 type = "scorer"
-capabilities = [ "scores",]
+capabilities = [ "scores", "score_labels",]
 
 [cafe_aesthetic]
 model_path = "cafeai/cafe_aesthetic"
@@ -20,7 +20,7 @@ device = "cuda"
 class = "CafePredictor"
 estimated_size_gb = 0.32
 type = "scorer"
-capabilities = [ "scores",]
+capabilities = [ "scores", "score_labels",]
 
 [ImprovedAesthetic]
 model_path = "https://github.com/christophschuhmann/improved-aesthetic-predictor/raw/main/sac+logos+ava1-l14-linearMSE.pth"

--- a/tests/unit/fast/test_config.py
+++ b/tests/unit/fast/test_config.py
@@ -406,6 +406,44 @@ def test_load_config_from_file_errors(tmp_path):
         _load_config_from_file(bad_toml_path)
 
 
+# Issue #139 (B): canonical-label scorer が config/annotator_config.toml と template
+# (resources/system/annotator_config.toml) の間で capabilities drift を起こし、
+# predictor が生成する score_labels に対し SCORE_LABELS capability が欠落して
+# ValidationError になっていた。両ファイル間で drift しないことを固定する。
+_CANONICAL_LABEL_SCORERS = ["aesthetic_shadow_v1", "aesthetic_shadow_v2", "cafe_aesthetic"]
+
+
+@pytest.mark.fast
+def test_canonical_scorer_capabilities_declare_score_labels():
+    """Issue #139 (B) regression: canonical scorer の config が score_labels capability を持つ。
+
+    AestheticShadow / CafePredictor は _format_predictions で score_labels を返すため
+    (ADR 0002), 実 load される config の capabilities に "score_labels" が無いと
+    UnifiedAnnotationResult の validator が ValidationError を投げる。
+    """
+    project_config = toml.load(Path("config/annotator_config.toml"))
+    for model_name in _CANONICAL_LABEL_SCORERS:
+        capabilities = project_config[model_name]["capabilities"]
+        assert "score_labels" in capabilities, (
+            f"{model_name}: config/annotator_config.toml の capabilities に score_labels が無い "
+            f"(現状 {capabilities})。predictor の score_labels 生成と矛盾し ValidationError になる。"
+        )
+
+
+@pytest.mark.fast
+def test_scorer_capabilities_no_drift_between_config_and_template():
+    """Issue #139 (B) regression: scorer の capabilities が config と template で一致する。
+
+    drift すると実 load される config と ADR 0002/0009 の前提がずれる。
+    """
+    project_config = toml.load(Path("config/annotator_config.toml"))
+    template_config = toml.load(Path("src/image_annotator_lib/resources/system/annotator_config.toml"))
+    for model_name in [*_CANONICAL_LABEL_SCORERS, "ImprovedAesthetic", "WaifuAesthetic"]:
+        assert sorted(project_config[model_name]["capabilities"]) == sorted(
+            template_config[model_name]["capabilities"]
+        ), f"{model_name}: config と template で capabilities が drift している"
+
+
 # ADR 0023 Phase 1 (Issue #35, PR #40): `save_available_api_models` /
 # `load_available_api_models` および `AVAILABLE_API_MODELS_CONFIG_PATH` は廃止された。
 # WebAPI モデル一覧は LiteLLM 同梱 DB から runtime 取得するため、TOML cache の


### PR DESCRIPTION
## 概要

Issue #139 のうち **(B) score_labels / capabilities drift** を修正する。`cafe_aesthetic` / `aesthetic_shadow_v1` が `score_labels provided but SCORE_LABELS not in capabilities: {SCORES}` で `ValidationError` になる原因の config drift を直す。

これは **spec を変更しない drift 修正**であり、「lib が `score_labels` を返すか consumer 側でラベル化するか」の責務境界（ADR 0009 Open Question #3）には踏み込まない。その設計判断は別セッションで策定中の ADR に委ねる。

## 原因

- runtime は `config/annotator_config.toml`（`Path.cwd()/config/`、**git追跡ファイル**）を実 load する。
- この tracked config の canonical scorer 3 種（`aesthetic_shadow_v1` / `aesthetic_shadow_v2` / `cafe_aesthetic`）の `capabilities` が `["scores"]` のみに drift していた。
- 一方 template（`resources/system/annotator_config.toml`）と **ADR 0002 (Accepted)** / **ADR 0009 Reference 3** は canonical scorer = `["scores","score_labels"]` とし、predictor（`pipeline_scorers.py:_format_predictions`）は `score_labels` を生成する。
- `config.py:_ensure_system_config_exists` は config が既存だと template を copy しないため、stale な capabilities がそのまま使われ、`types.py` の validator が `ValidationError` を投げていた。

## 修正

- `config/annotator_config.toml` の canonical scorer 3 種の `capabilities` を `["scores","score_labels"]` に復元（template / ADR 0002・0009 に整合）。CLIP 系（`ImprovedAesthetic` / `WaifuAesthetic`）は `["scores"]` のまま（label を生成しないため正しい）。

## テスト

- `test_canonical_scorer_capabilities_declare_score_labels`: 実 load config が canonical scorer に `score_labels` capability を持つことを固定。
- `test_scorer_capabilities_no_drift_between_config_and_template`: config と template の scorer capabilities が drift しないことを固定（再発防止）。

predictor 側の label 生成 + SCORE_LABELS cap での検証は既存 `test_scorer_models.py`（`mock_capabilities_canonical_scorer`）がカバー済み。

### 検証

CI-equivalent filter (`-m "not downloads_and_runs_model and not calls_real_webapi"`) で **847 passed, 0 failed**。

## #139 全体の状況（#140 + 本PR）

| モデル | 状態 |
|---|---|
| `ImprovedAesthetic` / `WaifuAesthetic` | ✅ 復旧（#140 系統A-1） |
| `aesthetic_shadow_v1` | ✅ 復旧（#140 A-2 でロード + 本PR で score_labels 検証通過） |
| `cafe_aesthetic` | ✅ 復旧（本PR） |

本 PR マージで Issue #139 の 4 モデル全てが scores を返せるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)