### PR TITLE
fix: WaifuAesthetic fc{n}キー検出失敗と重みサイレント無視を修正 (#142)

### DIFF
--- a/src/image_annotator_lib/core/loaders/clip_loader.py
+++ b/src/image_annotator_lib/core/loaders/clip_loader.py
@@ -10,6 +10,7 @@ Dependencies:
 from __future__ import annotations
 
 import gc
+import re
 from typing import TYPE_CHECKING, Any, cast, override
 
 from ..types import CLIPComponents
@@ -59,6 +60,15 @@ class CLIPLoader(LoaderBase):
                 break
 
         hidden_sizes = hidden_features[:-1] if hidden_features else []
+
+        if not hidden_sizes:
+            fc_weight_keys = sorted(
+                [k for k in state_dict if re.match(r"^fc\d+\.weight$", k)],
+                key=lambda x: int(x[2 : x.index(".")]),
+            )
+            if len(fc_weight_keys) >= 2:
+                hidden_sizes = [state_dict[k].shape[0] for k in fc_weight_keys[:-1]]
+
         if not hidden_sizes:
             logger.warning(
                 f"CLIP分類器 '{self.model_name}' 構造推測失敗。デフォルト [1024, 128, 64, 16] 使用。"
@@ -66,6 +76,40 @@ class CLIPLoader(LoaderBase):
             hidden_sizes = [1024, 128, 64, 16]
         logger.info(f"推測された隠れ層サイズ: {hidden_sizes}")
         return hidden_sizes
+
+    def _remap_state_dict_keys(
+        self, state_dict: dict[str, Any], classifier: nn.Module
+    ) -> dict[str, Any]:
+        """fc{n} 形式のキーを classifier の layers.{n} 形式にリネームする。
+
+        WaifuAesthetic 等の fc{n}.weight/bias 命名の重みファイルに対応。
+        キー数が一致しない場合はリネームせずに元の state_dict を返す。
+        """
+        fc_weight_keys = sorted(
+            [k for k in state_dict if re.match(r"^fc\d+\.weight$", k)],
+            key=lambda x: int(x[2 : x.index(".")]),
+        )
+        if not fc_weight_keys:
+            return state_dict
+
+        clf_weight_keys = [k for k in classifier.state_dict() if k.endswith(".weight")]
+        if len(fc_weight_keys) != len(clf_weight_keys):
+            logger.warning(
+                f"fc キー数 ({len(fc_weight_keys)}) と分類器線形層数 ({len(clf_weight_keys)}) が不一致。"
+                " キーリネームをスキップします。"
+            )
+            return state_dict
+
+        remapped: dict[str, Any] = {}
+        for fc_w_key, clf_w_key in zip(fc_weight_keys, clf_weight_keys):
+            remapped[clf_w_key] = state_dict[fc_w_key]
+            fc_b_key = fc_w_key.replace(".weight", ".bias")
+            clf_b_key = clf_w_key.replace(".weight", ".bias")
+            if fc_b_key in state_dict:
+                remapped[clf_b_key] = state_dict[fc_b_key]
+
+        logger.debug(f"state_dict キーリネーム: {list(zip(fc_weight_keys, clf_weight_keys))}")
+        return remapped
 
     def _load_base_clip_components(self, base_model: str) -> tuple[CLIPProcessor, CLIPModel, int]:
         """CLIP プロセッサとベースモデルをロードし、特徴量次元を返す。"""
@@ -125,7 +169,8 @@ class CLIPLoader(LoaderBase):
             use_final_activation=use_final_activation,
             final_activation=final_activation_func,
         )
-        classifier_head.load_state_dict(state_dict, strict=False)
+        state_dict_to_load = self._remap_state_dict_keys(state_dict, classifier_head)
+        classifier_head.load_state_dict(state_dict_to_load, strict=False)
         classifier_head = classifier_head.to(self.device).eval()
         logger.debug(f"CLIP分類器ヘッド '{model_path_for_log}' ロード完了 (デバイス: {self.device})")
         return classifier_head

--- a/tests/unit/model_class/test_scorer_models.py
+++ b/tests/unit/model_class/test_scorer_models.py
@@ -653,3 +653,104 @@ def test_clip_scorer_handles_transformers5_pooled_output(
             assert torch.allclose(torch.norm(normalized, p=2, dim=-1), torch.tensor([1.0]), atol=1e-6)
             assert raw_outputs.shape == torch.Size([1])
             assert raw_outputs.item() == 7.5
+
+
+# ==============================================================================
+# Issue #142 回帰テスト: WaifuAesthetic fc{n} キー対応
+# ==============================================================================
+
+
+@pytest.mark.unit
+def test_infer_classifier_structure_fc_pattern():
+    """Issue #142 回帰: fc{n}.weight パターンから隠れ層サイズを正しく推測する。
+
+    WaifuAesthetic の重みファイルは fc1/fc2/fc3 命名を使用するため、
+    layers.{n} パターン検索が失敗してデフォルト [1024, 128, 64, 16] が使用されていた。
+    fc パターンへのフォールバックで [256, 128] が返ることを確認する。
+    """
+    import torch
+    from image_annotator_lib.core.loaders.clip_loader import CLIPLoader
+
+    loader = CLIPLoader("WaifuAesthetic", "cpu")
+    state_dict = {
+        "fc1.weight": torch.zeros(256, 512),
+        "fc1.bias": torch.zeros(256),
+        "fc2.weight": torch.zeros(128, 256),
+        "fc2.bias": torch.zeros(128),
+        "fc3.weight": torch.zeros(1, 128),
+        "fc3.bias": torch.zeros(1),
+    }
+    hidden_sizes = loader._infer_classifier_structure(state_dict)
+    assert hidden_sizes == [256, 128]
+
+
+@pytest.mark.unit
+def test_remap_state_dict_fc_keys():
+    """Issue #142 回帰: fc{n} キーが classifier の layers.{n} キーに正しくリネームされる。
+
+    リネーム後、fc プレフィックスのキーが消え、layers プレフィックスのキーが生成され、
+    テンソルの内容は元の値と同一であることを確認する。
+    """
+    import torch
+    import torch.nn as nn
+    from image_annotator_lib.core.classifier import Classifier
+    from image_annotator_lib.core.loaders.clip_loader import CLIPLoader
+
+    loader = CLIPLoader("WaifuAesthetic", "cpu")
+    original_fc1_weight = torch.zeros(256, 512)
+    fc_state_dict = {
+        "fc1.weight": original_fc1_weight,
+        "fc1.bias": torch.zeros(256),
+        "fc2.weight": torch.zeros(128, 256),
+        "fc2.bias": torch.zeros(128),
+        "fc3.weight": torch.zeros(1, 128),
+        "fc3.bias": torch.zeros(1),
+    }
+    classifier = Classifier(
+        512,
+        [256, 128],
+        1,
+        use_activation=True,
+        activation=nn.ReLU,
+        use_final_activation=True,
+        final_activation=nn.Sigmoid,
+    )
+    remapped = loader._remap_state_dict_keys(fc_state_dict, classifier)
+
+    assert "layers.0.weight" in remapped
+    assert "layers.0.bias" in remapped
+    assert not any(k.startswith("fc") for k in remapped)
+    assert torch.equal(remapped["layers.0.weight"], original_fc1_weight)
+
+
+@pytest.mark.unit
+def test_waifuaesthetic_classifier_loads_fc_weights():
+    """Issue #142 回帰: fc 形式の重みが classifier に正しくロードされる（ランダム初期化ではない）。
+
+    修正前は load_state_dict(strict=False) でキー不一致により全重みが無視され、
+    ランダム初期化のまま固定値 0.5565 を返していた。
+    修正後は fc{n} → layers.{n} のリネームが行われ、元の重みが反映されることを確認する。
+    """
+    import torch
+    from image_annotator_lib.core.loaders.clip_loader import CLIPLoader
+
+    loader = CLIPLoader("WaifuAesthetic", "cpu")
+    expected_weight = torch.randn(256, 512)
+    fc_state_dict = {
+        "fc1.weight": expected_weight.clone(),
+        "fc1.bias": torch.randn(256),
+        "fc2.weight": torch.randn(128, 256),
+        "fc2.bias": torch.randn(128),
+        "fc3.weight": torch.randn(1, 128),
+        "fc3.bias": torch.randn(1),
+    }
+    classifier_head = loader._create_and_load_classifier_head(
+        input_size=512,
+        hidden_sizes=[256, 128],
+        state_dict=fc_state_dict,
+        activation_type="ReLU",
+        final_activation_type="Sigmoid",
+        model_path_for_log="test/aes-B32-v0.pth",
+    )
+    loaded_state = classifier_head.state_dict()
+    assert torch.equal(loaded_state["layers.0.weight"], expected_weight)


### PR DESCRIPTION
## Summary

- `_infer_classifier_structure` に `fc{n}.weight` パターン検出を追加。`layers.{n}` 検索が空の場合に `fc1/fc2/fc3` 形式へフォールバックし、正しい hidden_sizes `[256, 128]` を返す
- `_remap_state_dict_keys` メソッドを新規追加。`fc{n}.weight/bias` キーを Classifier 実際の `layers.{n}` キーにリネームし、`load_state_dict(strict=False)` による全重みサイレント無視を解消
- Issue #142 回帰テスト 3 本追加（fc パターン推測・キーリネーム・end-to-end 重みロード）

## 根本原因

2 層構造のバグ:

1. `_infer_classifier_structure` が `fc{n}` パターン未対応 → デフォルト `[1024, 128, 64, 16]` 使用（正しくは `[256, 128]`）
2. `Classifier(nn.Sequential)` のキー (`layers.0`, `layers.3`, ...) と重みファイルのキー (`fc1`, `fc2`, `fc3`) が完全不一致 → `strict=False` で全重み無視 → ランダム初期化のまま Sigmoid 出力が常に `0.5565`

## Test plan

- [x] `test_infer_classifier_structure_fc_pattern` — fc パターン推測が `[256, 128]` を返す
- [x] `test_remap_state_dict_fc_keys` — fc キーが layers キーに正しくリネームされる
- [x] `test_waifuaesthetic_classifier_loads_fc_weights` — ロード後の重みが元の fc 重みと一致する
- [x] 既存 CLIP scorer テスト 4 本すべて回帰なし (`test_clip_scorer_*`)
- [x] `make test-iam-lib` 850 passed, 0 failed

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)