### PR TITLE
fix(loader): 2回目以降の annotate() で ModelLoadError になるバグを修正 (#146)

### DIFF
--- a/src/image_annotator_lib/core/base/pipeline.py
+++ b/src/image_annotator_lib/core/base/pipeline.py
@@ -46,13 +46,14 @@ class PipelineBaseAnnotator(BaseAnnotator):
             self.batch_size,
         )
 
-        # Load Failure Detection (致命的エラー)
-        if not loaded_components:
+        # None = 既キャッシュ済み (self.components は前回 __exit__ で設定済み)。
+        # 空コンポーネント = ロード失敗。
+        if loaded_components is not None:
+            self.components = loaded_components
+        elif not self.components:
             error_msg = f"Failed to load pipeline components for model '{self.model_name}'."
             logger.error(error_msg)
             raise ModelLoadError(error_msg, model_path=self.model_path)
-
-        self.components = loaded_components  # ← 必ず有効な components が代入される
 
         # Restoration Attempt (失敗しても継続可能)
         restored_components = ModelLoad.restore_model_to_cuda(

--- a/src/image_annotator_lib/core/base/transformers.py
+++ b/src/image_annotator_lib/core/base/transformers.py
@@ -59,14 +59,15 @@ class TransformersBaseAnnotator(BaseAnnotator):
                 str(self.device),
             )
 
-            # Load Failure Detection (致命的エラー)
-            if not loaded_components:
+            # None = 既キャッシュ済み (self.components は前回 __exit__ で設定済み)。
+            # 空コンポーネント = ロード失敗。
+            if loaded_components is not None:
+                self.components = loaded_components
+                logger.info(f"モデルコンポーネントのロード成功: {self.model_name}")
+            elif not self.components:
                 error_msg = f"Failed to load components for model '{self.model_name}'."
                 logger.error(error_msg)
                 raise ModelLoadError(error_msg, model_path=self.model_path)
-
-            self.components = loaded_components  # ← 必ず有効な components が代入される
-            logger.info(f"モデルコンポーネントのロード成功: {self.model_name}")
 
             # --- CUDAへの復元処理 ---
             logger.debug(f"モデル {self.model_name} を {self.device} へ復元試行")


### PR DESCRIPTION
## Summary

- `PipelineBaseAnnotator.__enter__` と `TransformersBaseAnnotator.__enter__` で `load_components()` が `None` を返すとモデルロード失敗と誤判定していた
- `None` はモデルが既にキャッシュ済みで `self.components` を引き続き使えることを示す正常な状態
- `if not loaded_components:` → `if loaded_components is not None: ... elif not self.components: raise` に変更し正しく区別する

## Root Cause

`LoaderBase.load_components()` はモデル状態確認後、既キャッシュ済みなら `None` を返す。

```python
if LoaderBase._get_model_state(self.model_name):
    return None  # 既キャッシュ済み
```

一方、`PipelineBaseAnnotator.__enter__` は `if not loaded_components:` でこれを検査するため `None`（正常）も空コンポーネント（失敗）も区別できず、2 回目以降の `annotate()` 呼び出しで常に `ModelLoadError` を発生させていた。

## Test plan

- [x] `make test-iam-lib` (855 passed, 13 deselected)
- [ ] 実際のモデルで `cafe_aesthetic` を同一プロセス内で 2 回連続呼び出しして regression がないことを確認 (ADR 0026 on-demand smoke)

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)