### PR TITLE
fix(loader): api_keys={} でローカル ML モデルの2回目アノテーションが ModelLoadError になるバグを修正 (Issue #146)

### DIFF
--- a/src/image_annotator_lib/core/annotation_runner.py
+++ b/src/image_annotator_lib/core/annotation_runner.py
@@ -134,8 +134,10 @@ def get_annotator_instance(model_name: str, api_keys: dict[str, str] | None = No
     Returns:
         アノテータインスタンス。
     """
-    # APIキー指定時はキャッシュを使用しない (設定が動的に変わるため)
-    if api_keys is not None:
+    # API キーが実際に指定されている場合のみキャッシュをバイパスする。
+    # api_keys={} (空 dict) は「未指定」と同義であり、ローカル ML モデルが毎回
+    # 新インスタンスを生成して 2 回目に ModelLoadError になるバグを防ぐ (Issue #146)。
+    if api_keys:
         logger.debug(f"APIキー指定のためモデル '{model_name}' の新しいインスタンスを作成")
         return _create_annotator_instance(model_name, api_keys=api_keys)
 

--- a/src/image_annotator_lib/core/base/pipeline.py
+++ b/src/image_annotator_lib/core/base/pipeline.py
@@ -38,6 +38,11 @@ class PipelineBaseAnnotator(BaseAnnotator):
         if self.batch_size is None:
             raise ValueError(f"モデル '{self.model_name}' の batch_size が設定されていません。")
 
+        # ロード前にキャッシュ状態を確認する (Issue #146)。
+        # load_components() は「キャッシュ済み」と「ロード失敗」の両方で None を返すため、
+        # 呼び出し前の状態で2ケースを区別する。
+        had_cached_state = ModelLoad._get_model_state(self.model_name) is not None
+
         loaded_components = ModelLoad.load_transformers_pipeline_components(
             self.task,
             self.model_name,
@@ -51,9 +56,28 @@ class PipelineBaseAnnotator(BaseAnnotator):
         if loaded_components is not None:
             self.components = loaded_components
         elif not self.components:
-            error_msg = f"Failed to load pipeline components for model '{self.model_name}'."
-            logger.error(error_msg)
-            raise ModelLoadError(error_msg, model_path=self.model_path)
+            if had_cached_state:
+                # モデル状態が「キャッシュ済み」(None 返却) だが、このインスタンスはコンポーネントを
+                # 保持していない。api_keys={} 指定時の毎回インスタンス再生成などで発生 (Issue #146)。
+                # 状態をリセットして強制再ロードする。
+                logger.warning(
+                    f"モデル '{self.model_name}' は状態「キャッシュ済み」だが、"
+                    "このインスタンスはコンポーネントを保持していない。状態をリセットして再ロード。"
+                )
+                ModelLoad._release_model_state(self.model_name)
+                loaded_components = ModelLoad.load_transformers_pipeline_components(
+                    self.task, self.model_name, self.model_path, self.device, self.batch_size
+                )
+                if loaded_components is not None:
+                    self.components = loaded_components
+                else:
+                    error_msg = f"Failed to load pipeline components for model '{self.model_name}'."
+                    logger.error(error_msg, exc_info=True)
+                    raise ModelLoadError(error_msg, model_path=self.model_path)
+            else:
+                error_msg = f"Failed to load pipeline components for model '{self.model_name}'."
+                logger.error(error_msg, exc_info=True)
+                raise ModelLoadError(error_msg, model_path=self.model_path)
 
         # Restoration Attempt (失敗しても継続可能)
         restored_components = ModelLoad.restore_model_to_cuda(

--- a/src/image_annotator_lib/core/base/transformers.py
+++ b/src/image_annotator_lib/core/base/transformers.py
@@ -52,6 +52,11 @@ class TransformersBaseAnnotator(BaseAnnotator):
                 raise ConfigurationError(f"モデル '{self.model_name}' の model_path が設定されていません。")
 
             # --- モデルロード処理 ---
+            # ロード前にキャッシュ状態を確認する (Issue #146)。
+            # load_components() は「キャッシュ済み」と「ロード失敗」の両方で None を返すため、
+            # 呼び出し前の状態で2ケースを区別する。
+            had_cached_state = ModelLoad._get_model_state(self.model_name) is not None
+
             logger.info(f"モデルコンポーネントのロード試行: {self.model_name} をデバイス {self.device} へ")
             loaded_components = ModelLoad.load_transformers_components(
                 self.model_name,
@@ -65,9 +70,29 @@ class TransformersBaseAnnotator(BaseAnnotator):
                 self.components = loaded_components
                 logger.info(f"モデルコンポーネントのロード成功: {self.model_name}")
             elif not self.components:
-                error_msg = f"Failed to load components for model '{self.model_name}'."
-                logger.error(error_msg)
-                raise ModelLoadError(error_msg, model_path=self.model_path)
+                if had_cached_state:
+                    # モデル状態が「キャッシュ済み」(None 返却) だが、このインスタンスはコンポーネントを
+                    # 保持していない。api_keys={} 指定時の毎回インスタンス再生成などで発生 (Issue #146)。
+                    # 状態をリセットして強制再ロードする。
+                    logger.warning(
+                        f"モデル '{self.model_name}' は状態「キャッシュ済み」だが、"
+                        "このインスタンスはコンポーネントを保持していない。状態をリセットして再ロード。"
+                    )
+                    ModelLoad._release_model_state(self.model_name)
+                    loaded_components = ModelLoad.load_transformers_components(
+                        self.model_name, str(self.model_path), str(self.device)
+                    )
+                    if loaded_components is not None:
+                        self.components = loaded_components
+                        logger.info(f"モデルコンポーネントの再ロード成功: {self.model_name}")
+                    else:
+                        error_msg = f"Failed to load components for model '{self.model_name}'."
+                        logger.error(error_msg, exc_info=True)
+                        raise ModelLoadError(error_msg, model_path=self.model_path)
+                else:
+                    error_msg = f"Failed to load components for model '{self.model_name}'."
+                    logger.error(error_msg, exc_info=True)
+                    raise ModelLoadError(error_msg, model_path=self.model_path)
 
             # --- CUDAへの復元処理 ---
             logger.debug(f"モデル {self.model_name} を {self.device} へ復元試行")

--- a/tests/unit/core/test_annotation_runner.py
+++ b/tests/unit/core/test_annotation_runner.py
@@ -160,3 +160,57 @@ class TestCreateAnnotatorInstanceLookupOrder:
 
         with pytest.raises(KeyError, match="not found in registry"):
             annotation_runner._create_annotator_instance("just-a-name")
+
+
+class TestGetAnnotatorInstanceApiKeysCacheBehavior:
+    """get_annotator_instance の api_keys={} キャッシュバイパス問題のリグレッションテスト (Issue #146)。"""
+
+    @pytest.mark.unit
+    def test_empty_api_keys_uses_instance_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """api_keys={} (空 dict) はキャッシュを使い、毎回新インスタンスを生成しない。
+
+        Regression: api_keys={} を渡すと api_keys is not None が True になり、
+        ローカル ML モデルで毎回新インスタンスが生成されて 2 回目に ModelLoadError になる
+        バグを防ぐ (Issue #146 追加確認)。
+        """
+        annotation_runner._MODEL_INSTANCE_REGISTRY.clear()
+
+        created: list[str] = []
+
+        def _fake_create(model_name: str, api_keys: dict | None = None) -> _StubLocalAnnotator:
+            created.append(model_name)
+            return _StubLocalAnnotator(model_name)
+
+        monkeypatch.setattr(annotation_runner, "_create_annotator_instance", _fake_create)
+
+        # 1 回目: インスタンスを生成してキャッシュに保存
+        inst1 = annotation_runner.get_annotator_instance("my_model", api_keys={})
+        # 2 回目: キャッシュから返すはず
+        inst2 = annotation_runner.get_annotator_instance("my_model", api_keys={})
+
+        assert inst1 is inst2, "api_keys={} でも同一インスタンスが返されるべき"
+        assert len(created) == 1, f"インスタンス生成は 1 回のみのはずだが {len(created)} 回生成された"
+
+        annotation_runner._MODEL_INSTANCE_REGISTRY.clear()
+
+    @pytest.mark.unit
+    def test_non_empty_api_keys_bypasses_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """実際に API キーが指定された場合はキャッシュをバイパスして新インスタンスを生成する。"""
+        annotation_runner._MODEL_INSTANCE_REGISTRY.clear()
+
+        created: list[str] = []
+
+        def _fake_create(model_name: str, api_keys: dict | None = None) -> _StubLocalAnnotator:
+            created.append(model_name)
+            return _StubLocalAnnotator(model_name)
+
+        monkeypatch.setattr(annotation_runner, "_create_annotator_instance", _fake_create)
+
+        api_keys = {"openai": "sk-test"}
+        inst1 = annotation_runner.get_annotator_instance("my_model", api_keys=api_keys)
+        inst2 = annotation_runner.get_annotator_instance("my_model", api_keys=api_keys)
+
+        assert inst1 is not inst2, "api_keys 指定時は新インスタンスが生成されるべき"
+        assert len(created) == 2
+
+        annotation_runner._MODEL_INSTANCE_REGISTRY.clear()


### PR DESCRIPTION
## 概要

Issue #146 の続報で報告された `cafe_aesthetic` 2回目アノテーション時の `ModelLoadError` を修正。
Pipeline 系モデルだけでなく Transformers 系モデルも同じパターンで影響を受ける。

## 根本原因

**2つのバグが連鎖していた:**

### バグ1: `api_keys={}` でインスタンスキャッシュをバイパス

`get_annotator_instance()` が `api_keys is not None` でキャッシュをバイパスする設計だったため、
空 dict `{}` も「キーあり」と判定され、毎回新インスタンスが生成されていた。

新インスタンスは `self.components = None` の初期状態なため、2回目の呼び出しで問題が発生。

### バグ2: 「キャッシュ済み＆新インスタンス」を正しく区別できない

`__enter__()` のローダー (`load_components`) は「モデルが既にキャッシュ済み」と「ロード失敗」の
両方で `None` を返す設計。`self.components=None` の新インスタンスが「キャッシュ済み」と
判断されると、`elif not self.components` → `ModelLoadError` が発生していた。

## 修正内容

### `annotation_runner.py`
```python
# Before: api_keys={} をキャッシュバイパスと判定
if api_keys is not None:
    return _create_annotator_instance(model_name, api_keys=api_keys)

# After: 実際に値があるときのみバイパス
if api_keys:
    return _create_annotator_instance(model_name, api_keys=api_keys)
```

### `pipeline.py` / `transformers.py`
ロード呼び出し**前**にキャッシュ状態を確認 (`had_cached_state`) し、
「キャッシュ済み＆self.components=None」の場合は状態リセット後に強制再ロードする。

```python
had_cached_state = ModelLoad._get_model_state(self.model_name) is not None
loaded_components = ModelLoad.load_*_components(...)

if loaded_components is not None:
    self.components = loaded_components
elif not self.components:
    if had_cached_state:
        # 新インスタンスが古いキャッシュ状態を引き継いだケース → リセットして再ロード
        ModelLoad._release_model_state(self.model_name)
        loaded_components = ModelLoad.load_*_components(...)
        ...
    else:
        raise ModelLoadError(...)  # 真の初回ロード失敗
```

## 影響範囲

- **Pipeline 系** (`cafe_aesthetic` 等): `PipelineBaseAnnotator` 修正
- **Transformers 系** (BLIP 等): `TransformersBaseAnnotator` 修正

## テスト

`TestGetAnnotatorInstanceApiKeysCacheBehavior` クラスを追加:
- `api_keys={}` でキャッシュが維持されること
- 実際に値のある `api_keys` でキャッシュをバイパスすること

857 tests pass。

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)