### PR TITLE
fix(clip): ClipBaseAnnotator の2回目呼び出し時 components 未設定で失敗するバグを修正 (Issue #149)

### DIFF
--- a/src/image_annotator_lib/core/base/clip.py
+++ b/src/image_annotator_lib/core/base/clip.py
@@ -49,6 +49,12 @@ class ClipBaseAnnotator(BaseAnnotator):
                 raise ValueError(f"モデル '{self.model_name}' の base_model が設定されていません。")
             if self.model_path is None:
                 raise ValueError(f"モデル '{self.model_name}' の model_path が設定されていません。")
+
+            # ロード前にキャッシュ状態を確認する (Issue #149)。
+            # load_clip_components() は「キャッシュ済み」と「ロード失敗」の両方で None/空を返すため、
+            # 呼び出し前の状態で2ケースを区別する。
+            had_cached_state = ModelLoad._get_model_state(self.model_name) is not None
+
             loaded_components = ModelLoad.load_clip_components(
                 model_name=self.model_name,
                 base_model=self.base_model,
@@ -59,6 +65,35 @@ class ClipBaseAnnotator(BaseAnnotator):
             )
             if loaded_components:
                 self.components = loaded_components
+            elif not self.components:
+                if had_cached_state:
+                    # モデル状態が「キャッシュ済み」(None/空返却) だが、このインスタンスはコンポーネントを
+                    # 保持していない。api_keys={} 指定時の毎回インスタンス再生成などで発生 (Issue #149)。
+                    # 状態をリセットして強制再ロードする。
+                    logger.warning(
+                        f"モデル '{self.model_name}' は状態「キャッシュ済み」だが、"
+                        "このインスタンスはコンポーネントを保持していない。状態をリセットして再ロード。"
+                    )
+                    ModelLoad._release_model_state(self.model_name)
+                    loaded_components = ModelLoad.load_clip_components(
+                        model_name=self.model_name,
+                        base_model=self.base_model,
+                        model_path=self.model_path,
+                        device=self.device,
+                        activation_type=config_registry.get(self.model_name, "activation_type"),
+                        final_activation_type=config_registry.get(self.model_name, "final_activation_type"),
+                    )
+                    if loaded_components:
+                        self.components = loaded_components
+                    else:
+                        error_msg = f"Failed to load CLIP components for model '{self.model_name}'."
+                        logger.error(error_msg, exc_info=True)
+                        raise ModelLoadError(error_msg, model_path=self.model_path)
+                else:
+                    error_msg = f"Failed to load CLIP components for model '{self.model_name}'."
+                    logger.error(error_msg, exc_info=True)
+                    raise ModelLoadError(error_msg, model_path=self.model_path)
+
             logger.info(f"CLIP Scorer '{self.model_name}' の準備完了。")
 
         except (ModelLoadError, OutOfMemoryError, FileNotFoundError, ValueError) as e:

--- a/tests/integration/test_context_manager_robustness.py
+++ b/tests/integration/test_context_manager_robustness.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from PIL import Image
 
+from image_annotator_lib.core.base.clip import ClipBaseAnnotator
 from image_annotator_lib.core.base.pipeline import PipelineBaseAnnotator
 from image_annotator_lib.core.base.transformers import TransformersBaseAnnotator
 from image_annotator_lib.exceptions.errors import ModelLoadError
@@ -26,6 +27,14 @@ class ConcreteTestPipelineAnnotator(PipelineBaseAnnotator):
 
 class ConcreteTestTransformersAnnotator(TransformersBaseAnnotator):
     """Concrete Transformers annotator for testing."""
+
+    def _generate_tags(self, formatted_output: Any) -> list[str]:
+        """Generate tags from formatted output."""
+        return []
+
+
+class ConcreteTestClipAnnotator(ClipBaseAnnotator):
+    """Concrete CLIP annotator for testing."""
 
     def _generate_tags(self, formatted_output: Any) -> list[str]:
         """Generate tags from formatted output."""
@@ -225,3 +234,107 @@ class TestContextManagerRobustness:
             # Verify both load and restore were called
             mock_load.assert_called_once()
             mock_restore.assert_called_once()
+
+
+class TestClipContextManagerRobustness:
+    """ClipBaseAnnotator の __enter__() エラーハンドリングと2回目ロードのリグレッションテスト (Issue #149)。"""
+
+    @pytest.fixture
+    def clip_model_config(self, managed_config_registry):
+        """CLIP モデルの最小 config を登録する。"""
+        config = {
+            "class": "ImprovedAesthetic",
+            "model_path": "/dummy/improved_aesthetic.pth",
+            "device": "cpu",
+            "estimated_size_gb": 0.5,
+            "base_model": "openai/clip-vit-large-patch14",
+        }
+        managed_config_registry.set("test_clip_model", config)
+        return config
+
+    @pytest.mark.integration
+    def test_clip_load_failure_raises_model_load_error(self, clip_model_config):
+        """初回ロード失敗 (had_cached_state=False) は即 ModelLoadError を上げる。
+
+        Regression: Issue #149 修正前は None 返却をサイレントに通過し、
+        後続の _preprocess_images() で RuntimeError になっていた。
+        """
+        # アノテータは patch 外で生成して __init__ に正しい config を渡す
+        annotator = ConcreteTestClipAnnotator(model_name="test_clip_model")
+
+        with (
+            patch("image_annotator_lib.core.base.clip.ModelLoad.load_clip_components") as mock_load,
+            patch(
+                "image_annotator_lib.core.base.clip.ModelLoad._get_model_state", return_value=None
+            ),
+        ):
+            mock_load.return_value = None
+
+            with pytest.raises(ModelLoadError) as exc_info:
+                with annotator:
+                    pass
+
+            assert "Failed to load CLIP components" in str(exc_info.value)
+            assert "test_clip_model" in str(exc_info.value)
+            mock_load.assert_called_once()
+
+    @pytest.mark.integration
+    def test_clip_second_call_new_instance_with_cached_state_reloads(self, clip_model_config):
+        """キャッシュ済み状態で新インスタンスが load_clip_components() から None を受けたとき、
+        状態をリセットして強制再ロードし、正常に components を設定する。
+
+        Regression: Issue #149 — ImprovedAesthetic / WaifuAesthetic の2バッチ目で
+        `RuntimeError: CLIP プロセッサがロードされていません。` になるバグ。
+        """
+        mock_components = {
+            "clip_model": MagicMock(),
+            "model": MagicMock(),
+            "processor": MagicMock(),
+        }
+
+        call_count: dict[str, int] = {"n": 0}
+
+        def _load_side_effect(**kwargs: Any) -> dict | None:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return None  # 1回目: キャッシュ済み扱いで None を返す
+            return mock_components  # 2回目: 強制再ロードで実コンポーネントを返す
+
+        annotator = ConcreteTestClipAnnotator(model_name="test_clip_model")
+
+        with (
+            patch("image_annotator_lib.core.base.clip.ModelLoad.load_clip_components") as mock_load,
+            patch(
+                "image_annotator_lib.core.base.clip.ModelLoad._get_model_state",
+                return_value="on_cpu",  # キャッシュ済み状態をシミュレート
+            ),
+            patch("image_annotator_lib.core.base.clip.ModelLoad._release_model_state") as mock_release,
+        ):
+            mock_load.side_effect = _load_side_effect
+
+            with annotator as ctx:
+                assert ctx.components is mock_components
+
+            mock_release.assert_called_once_with("test_clip_model")
+            assert mock_load.call_count == 2
+
+    @pytest.mark.integration
+    def test_clip_second_call_retry_also_fails_raises_model_load_error(self, clip_model_config):
+        """キャッシュ済み状態でリセット後の再ロードも失敗した場合は ModelLoadError を上げる。"""
+        annotator = ConcreteTestClipAnnotator(model_name="test_clip_model")
+
+        with (
+            patch("image_annotator_lib.core.base.clip.ModelLoad.load_clip_components") as mock_load,
+            patch(
+                "image_annotator_lib.core.base.clip.ModelLoad._get_model_state",
+                return_value="on_cpu",
+            ),
+            patch("image_annotator_lib.core.base.clip.ModelLoad._release_model_state"),
+        ):
+            mock_load.return_value = None  # 両回ともNone
+
+            with pytest.raises(ModelLoadError):
+                with annotator:
+                    pass
+
+            assert mock_load.call_count == 2


### PR DESCRIPTION
## 概要

Issue #149 で報告された ImprovedAesthetic / WaifuAesthetic の2バッチ目アノテーション失敗を修正。

## 根本原因

#146/#148 で修正した `PipelineBaseAnnotator` と全く同じパターンが `ClipBaseAnnotator` にも存在していた。

`load_clip_components()` は「モデルがキャッシュ済み」のとき `None` を返すが、
2回目呼び出しで新しいインスタンスが作られると:

1. 新インスタンスは `self.components = None` の初期状態
2. `load_clip_components()` → キャッシュ済みのため `None` 返却
3. `if loaded_components:` → False、分岐せず
4. `self.components = None` のまま「準備完了」扱い
5. `_preprocess_images()` → `RuntimeError: CLIP プロセッサがロードされていません。`

## 修正内容

#148 と同じ `had_cached_state` パターンを適用:

```python
had_cached_state = ModelLoad._get_model_state(self.model_name) is not None
loaded_components = ModelLoad.load_clip_components(...)

if loaded_components:
    self.components = loaded_components
elif not self.components:
    if had_cached_state:
        # 状態リセット後に強制再ロード
        ModelLoad._release_model_state(self.model_name)
        loaded_components = ModelLoad.load_clip_components(...)
        ...
    else:
        raise ModelLoadError(...)
```

## 影響モデル

`ClipBaseAnnotator` を継承する全モデル:
- ImprovedAesthetic
- WaifuAesthetic

## テスト

`TestClipContextManagerRobustness` クラスを追加 (3テスト):
- 初回ロード失敗 → 即 `ModelLoadError`
- キャッシュ済み＆新インスタンス → リセット後に再ロード成功
- リセット後の再ロードも失敗 → `ModelLoadError`

860 passed, 51.72s

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)