### PR TITLE
feat(installer): モデル明示インストール API (is_model_installed / install_model)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "tf-keras>=2.19.0",
     "accelerate>=0.26.0",
     "diffusers>=0.24.0",
-    "huggingface_hub>=0.19.0",
+    "huggingface_hub>=1.1.0",  # >=1.1.0: snapshot_download の byte 集約 progress (tqdm_class) が必要 (PR #151)
     "onnxruntime>=1.16.0",
     "onnxruntime-gpu>=1.16.0;platform_system!='Darwin'",
     "safetensors>=0.4.0",

--- a/src/image_annotator_lib/__init__.py
+++ b/src/image_annotator_lib/__init__.py
@@ -22,7 +22,14 @@ from .core.registry import (
 )
 from .core.types import AnnotationResult, AnnotatorInfo, ModelType
 from .core.utils import init_logger
-from .exceptions.errors import AnnotatorError, ModelLoadError, ModelNotFoundError, OutOfMemoryError
+from .exceptions.errors import (
+    AnnotatorError,
+    ModelInstallCancelledError,
+    ModelLoadError,
+    ModelNotFoundError,
+    OutOfMemoryError,
+)
+from .model_installer import ModelInstallProgress, install_model, is_model_installed
 from .webapi.api_model_discovery import (
     discover_available_vision_models,
     get_available_models,
@@ -76,6 +83,8 @@ __all__ = [
     "BatchSubmitItem",
     "BatchSubmitRequest",
     "BatchSubmitResult",
+    "ModelInstallCancelledError",
+    "ModelInstallProgress",
     "ModelLoad",
     "ModelLoadError",
     "ModelNotFoundError",
@@ -88,7 +97,9 @@ __all__ = [
     "discover_available_vision_models",
     "fetch_batch_results",
     "get_available_models",
+    "install_model",
     "is_model_deprecated",
+    "is_model_installed",
     "list_all_models",
     "list_annotator_info",
     "list_available_annotators",
@@ -136,9 +147,7 @@ def annotate(
 
         _cached_annotate = _annotate_impl
 
-    return _cached_annotate(
-        images_list, model_name_list, phash_list, api_keys, additional_prompt
-    )
+    return _cached_annotate(images_list, model_name_list, phash_list, api_keys, additional_prompt)
 
 
 # You might want to add version information here later

--- a/src/image_annotator_lib/exceptions/errors.py
+++ b/src/image_annotator_lib/exceptions/errors.py
@@ -115,6 +115,36 @@ class ModelNotFoundError(AnnotatorError):
         )
 
 
+class ModelInstallCancelledError(AnnotatorError):
+    """モデルの明示インストール (ダウンロード) がキャンセルされた場合の例外。
+
+    `model_installer.install_model()` に渡した cancel_event がセットされた際に
+    送出される。部分ダウンロードは Hugging Face cache の resume 機構により
+    次回インストールで再利用される。
+
+    Attributes:
+        model_name: インストールがキャンセルされたモデルの名前
+        details: 追加のエラーコンテキスト
+    """
+
+    def __init__(self, model_name: str, details: dict[str, Any] | None = None):
+        """ModelInstallCancelledError を初期化します。
+
+        Args:
+            model_name: インストールがキャンセルされたモデルの名前
+            details: 追加のエラーコンテキスト（オプション）
+        """
+        self.model_name = model_name
+        error_details = details or {}
+        error_details["model_name"] = model_name
+
+        super().__init__(
+            message=f"Model install cancelled: {model_name}",
+            details=error_details,
+            ja_message=f"モデルインストールがキャンセルされました: {model_name}",
+        )
+
+
 class OutOfMemoryError(AnnotatorError):
     """主に CUDA デバイスのメモリが不足した場合の例外。
 

--- a/src/image_annotator_lib/model_installer.py
+++ b/src/image_annotator_lib/model_installer.py
@@ -1,0 +1,396 @@
+"""ローカル ML モデルの明示インストール API (LoRAIro Issue #754)。
+
+推論時の暗黙 HuggingFace ダウンロードを、進捗コールバック付きの明示
+ダウンロードとして切り出す。consumer (LoRAIro 等) はアノテーション実行前に
+`is_model_installed()` で未インストールモデルを検出し、`install_model()` を
+install ジョブとして実行できる。
+
+設計メモ:
+    - インストール済み判定は install marker ファイル (cache_dir/install_markers/)
+      で行う。実ファイルのキャッシュ走査は from_pretrained 系の部分キャッシュと
+      整合させるのが難しく、marker 方式が最も決定的で高速 (offline-safe)。
+      本 API 導入前に推論経由で暗黙ダウンロード済みのモデルは「未インストール」
+      と判定されるが、install_model() は HF cache を再利用するため再ダウンロード
+      は発生せず短時間で完了する。
+    - 進捗は huggingface_hub.snapshot_download の byte 集約進捗バー
+      (tqdm_class フック) から取得する。
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import ClassVar
+from urllib.parse import urlparse
+
+from tqdm.auto import tqdm as _base_tqdm
+
+from .core.config import config_registry
+from .core.constants import DEFAULT_PATHS
+from .core.utils import DEFAULT_TIMEOUT, logger
+from .exceptions.errors import ModelInstallCancelledError, ModelNotFoundError
+
+__all__ = [
+    "ModelInstallProgress",
+    "install_model",
+    "is_model_installed",
+]
+
+ProgressCallback = Callable[["ModelInstallProgress"], None]
+
+_INSTALL_MARKER_DIR_NAME = "install_markers"
+
+# ONNX 系クラスが実際に参照するファイルのみを取得する allow_patterns
+# (core/base/onnx.py の onnx_model_filename / onnx_metadata_* と同期)
+_ONNX_ALLOW_PATTERNS: dict[str, list[str]] = {
+    "WDTagger": ["model.onnx", "*.csv"],
+    "Z3D_E621Tagger": ["model.onnx", "*.csv"],
+    "CamieTagger": ["model_initial.onnx", "*.json"],
+}
+
+# transformers / CLIP 系の snapshot で除外する重複・不要 weight 形式
+_TRANSFORMERS_STATIC_IGNORE_PATTERNS: list[str] = [
+    "*.h5",
+    "*.msgpack",
+    "*.tflite",
+    "*.ot",
+    "*.onnx",
+    "*.md",
+    ".gitattributes",
+]
+
+# safetensors が存在する repo で重複ダウンロードを避ける追加 ignore
+_DUPLICATE_WEIGHT_PATTERNS: list[str] = ["*.bin", "*.pth", "*.ckpt"]
+
+
+@dataclass(frozen=True)
+class ModelInstallProgress:
+    """1 モデルのインストール進捗 (byte 単位)。
+
+    Attributes:
+        model_name: インストール対象のモデル名。
+        downloaded_bytes: ダウンロード済みバイト数 (累積)。
+        total_bytes: 総バイト数。メタデータ取得中は増加し得る。0 は未確定。
+    """
+
+    model_name: str
+    downloaded_bytes: int
+    total_bytes: int
+
+    @property
+    def percentage(self) -> int:
+        """0-100 の進捗率を返す。総量未確定 (total_bytes<=0) は 0。"""
+        if self.total_bytes <= 0:
+            return 0
+        return min(100, int(self.downloaded_bytes * 100 / self.total_bytes))
+
+
+class _ByteProgressAggregator:
+    """複数リソース / 複数スレッドからの byte 進捗を集約して callback へ流す。"""
+
+    def __init__(
+        self,
+        model_name: str,
+        progress_callback: ProgressCallback | None,
+        cancel_event: threading.Event | None,
+    ) -> None:
+        self._model_name = model_name
+        self._progress_callback = progress_callback
+        self._cancel_event = cancel_event
+        self._lock = threading.Lock()
+        self._downloaded = 0
+        self._total = 0
+
+    def check_cancelled(self) -> None:
+        """cancel_event がセットされていれば ModelInstallCancelledError を送出する。"""
+        if self._cancel_event is not None and self._cancel_event.is_set():
+            raise ModelInstallCancelledError(self._model_name)
+
+    def add_total(self, n: int) -> None:
+        """総バイト数を加算して進捗を通知する。"""
+        if n <= 0:
+            return
+        with self._lock:
+            self._total += n
+            snapshot = self._snapshot_locked()
+        self._emit(snapshot)
+
+    def add_downloaded(self, n: int) -> None:
+        """ダウンロード済みバイト数を加算して進捗を通知する。"""
+        if n <= 0:
+            return
+        with self._lock:
+            self._downloaded += n
+            snapshot = self._snapshot_locked()
+        self._emit(snapshot)
+
+    def _snapshot_locked(self) -> ModelInstallProgress:
+        return ModelInstallProgress(
+            model_name=self._model_name,
+            downloaded_bytes=self._downloaded,
+            total_bytes=self._total,
+        )
+
+    def _emit(self, snapshot: ModelInstallProgress) -> None:
+        if self._progress_callback is not None:
+            self._progress_callback(snapshot)
+
+
+class _SnapshotProgressTqdm(_base_tqdm):
+    """snapshot_download の byte 集約バーを aggregator へ橋渡しする tqdm。
+
+    huggingface_hub は `tqdm_class` で渡したクラスを (1) byte 集約バー
+    (unit="B")、(2) ファイル数バー (thread_map) の両方に使う。byte バーのみを
+    追跡し、コンソール表示は disable する。
+
+    Note:
+        意図的に huggingface_hub.utils.tqdm ではなく素の tqdm を継承する。
+        hf サブクラスを継承すると `_create_progress_bar` が disable/name を
+        注入してくるため、挙動を自前で制御できる素の tqdm 経路を使う。
+        aggregator は `_build_snapshot_tqdm_class()` がサブクラスの
+        ClassVar として束縛する (hf 側がクラスを直接インスタンス化するため
+        コンストラクタ経由で渡せない)。
+    """
+
+    _aggregator: ClassVar[_ByteProgressAggregator]
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self._tracks_bytes = kwargs.get("unit") == "B"
+        self._reported_total = 0
+        kwargs["disable"] = True  # 進捗は callback 経由で通知、コンソール表示は不要
+        if self._tracks_bytes:
+            initial = kwargs.get("initial")
+            if isinstance(initial, int) and initial > 0:
+                self._aggregator.add_downloaded(initial)
+        super().__init__(*args, **kwargs)
+        if self._tracks_bytes:
+            self._sync_total()
+
+    def _sync_total(self) -> None:
+        """外部から直接書き換えられる total 属性の増分を aggregator へ反映する。"""
+        current_total = int(self.total or 0)
+        delta = current_total - self._reported_total
+        if delta > 0:
+            self._reported_total = current_total
+            self._aggregator.add_total(delta)
+
+    def refresh(self, *args: object, **kwargs: object) -> bool:
+        # hf 側はファイルメタデータ取得ごとに total を直接加算して refresh() を呼ぶ
+        self._aggregator.check_cancelled()
+        if self._tracks_bytes:
+            self._sync_total()
+        return bool(super().refresh(*args, **kwargs))
+
+    def update(self, n: int | float | None = 1) -> bool | None:
+        self._aggregator.check_cancelled()
+        if self._tracks_bytes and n is not None and n > 0:
+            self._aggregator.add_downloaded(int(n))
+        return super().update(n)
+
+
+def _build_snapshot_tqdm_class(aggregator: _ByteProgressAggregator) -> type[_SnapshotProgressTqdm]:
+    """aggregator を束縛した _SnapshotProgressTqdm サブクラスを返す。"""
+    return type("_BoundSnapshotProgressTqdm", (_SnapshotProgressTqdm,), {"_aggregator": aggregator})
+
+
+def _marker_path(model_name: str) -> Path:
+    """モデルの install marker ファイルパスを返す。"""
+    # config セクション名にパス区切りは現れないが、防御的に置換する
+    safe_name = model_name.replace("/", "__").replace("\\", "__")
+    return Path(DEFAULT_PATHS["cache_dir"]) / _INSTALL_MARKER_DIR_NAME / f"{safe_name}.json"
+
+
+def _model_config(model_name: str) -> dict[str, object] | None:
+    """config registry からモデル設定を返す。未登録なら None。"""
+    all_config = config_registry.get_all_config()
+    config = all_config.get(model_name)
+    if isinstance(config, dict):
+        return config
+    return None
+
+
+def is_model_installed(model_name: str) -> bool:
+    """モデルがインストール済み (明示ダウンロード完了済み) かを判定する。
+
+    install marker ファイルの有無で判定する高速・offline-safe な操作。
+    config registry に存在しないモデル (WebAPI モデル等、ダウンロード不要) は
+    常に True を返す。
+
+    Args:
+        model_name: 判定対象のモデル名 (annotator_config.toml のセクション名)。
+
+    Returns:
+        インストール済み (またはインストール不要) なら True。
+    """
+    config = _model_config(model_name)
+    if config is None or not config.get("model_path"):
+        return True
+    return _marker_path(model_name).exists()
+
+
+def install_model(
+    model_name: str,
+    progress_callback: ProgressCallback | None = None,
+    cancel_event: threading.Event | None = None,
+) -> None:
+    """モデルを明示的にダウンロード (インストール) する。
+
+    モデルのクラス種別に応じて必要なリソース (HF repo / URL ファイル) を
+    ダウンロードし、完了時に install marker を書き込む。HF cache 済みファイルは
+    再ダウンロードされないため、暗黙ダウンロード済みモデルへの実行は短時間で
+    完了する。
+
+    Args:
+        model_name: インストール対象のモデル名。
+        progress_callback: byte 進捗の通知先 (任意)。ダウンロードスレッドから
+            呼ばれるためスレッドセーフであること。
+        cancel_event: キャンセル要求イベント (任意)。セットされると進捗更新の
+            タイミングで ModelInstallCancelledError を送出して中断する。
+
+    Raises:
+        ModelNotFoundError: config registry に存在しないモデル名の場合。
+        ModelInstallCancelledError: cancel_event によって中断された場合。
+    """
+    config = _model_config(model_name)
+    if config is None:
+        raise ModelNotFoundError(model_name)
+
+    model_path = str(config.get("model_path") or "")
+    if not model_path:
+        logger.warning(f"モデル '{model_name}' に model_path がないため install をスキップ")
+        return
+
+    aggregator = _ByteProgressAggregator(model_name, progress_callback, cancel_event)
+    model_class = str(config.get("class") or "")
+
+    logger.info(f"モデルインストール開始: {model_name} (class={model_class})")
+    parsed = urlparse(model_path)
+    if parsed.scheme in ("http", "https"):
+        _install_url_resource(model_path, aggregator)
+    else:
+        _install_hf_repo(model_path, aggregator, _hf_patterns_for_class(config, model_class))
+
+    base_model = str(config.get("base_model") or "")
+    if base_model:
+        # CLIP 系: 分類 head (URL) に加えて base CLIP repo が必要
+        _install_hf_repo(base_model, aggregator, _HfPatterns(transformers_weights=True))
+
+    _write_marker(model_name, model_path)
+    logger.info(f"モデルインストール完了: {model_name}")
+
+
+@dataclass(frozen=True)
+class _HfPatterns:
+    """HF repo ダウンロードのファイル選択パターン。"""
+
+    allow_patterns: list[str] | None = None
+    transformers_weights: bool = False
+
+
+def _hf_patterns_for_class(config: dict[str, object], model_class: str) -> _HfPatterns:
+    """モデルクラスに応じた HF ダウンロードパターンを返す。"""
+    if model_class in _ONNX_ALLOW_PATTERNS:
+        return _HfPatterns(allow_patterns=list(_ONNX_ALLOW_PATTERNS[model_class]))
+    if model_class == "AnimeRatingAnnotator":
+        variant = str(config.get("model_variant") or "")
+        if variant:
+            return _HfPatterns(allow_patterns=[f"{variant}/model.onnx", f"{variant}/meta.json"])
+    # transformers / pipeline 系: from_pretrained 相当の snapshot (重複 weight 除外)
+    return _HfPatterns(transformers_weights=True)
+
+
+def _transformers_ignore_patterns(repo_id: str) -> list[str]:
+    """transformers 系 repo の ignore_patterns を返す。
+
+    safetensors が存在する repo では .bin/.pth/.ckpt を除外して重複ダウンロードを
+    避ける (from_pretrained は safetensors を優先するため)。repo 一覧の取得に
+    失敗した場合は静的パターンのみ返す。
+    """
+    import huggingface_hub
+    from huggingface_hub.errors import HfHubHTTPError
+
+    patterns = list(_TRANSFORMERS_STATIC_IGNORE_PATTERNS)
+    try:
+        repo_files = huggingface_hub.list_repo_files(repo_id)
+    except (HfHubHTTPError, OSError) as e:
+        logger.debug(f"repo ファイル一覧の取得失敗 ({repo_id}): {e} — 静的 ignore のみ適用")
+        return patterns
+    if any(name.endswith(".safetensors") for name in repo_files):
+        patterns.extend(_DUPLICATE_WEIGHT_PATTERNS)
+    return patterns
+
+
+def _install_hf_repo(repo_id: str, aggregator: _ByteProgressAggregator, patterns: _HfPatterns) -> None:
+    """HF repo を進捗付きで snapshot ダウンロードする。"""
+    import huggingface_hub
+
+    ignore_patterns: list[str] | None = None
+    if patterns.allow_patterns is None and patterns.transformers_weights:
+        ignore_patterns = _transformers_ignore_patterns(repo_id)
+
+    aggregator.check_cancelled()
+    huggingface_hub.snapshot_download(
+        repo_id,
+        allow_patterns=patterns.allow_patterns,
+        ignore_patterns=ignore_patterns,
+        tqdm_class=_build_snapshot_tqdm_class(aggregator),
+    )
+
+
+def _install_url_resource(url: str, aggregator: _ByteProgressAggregator) -> None:
+    """URL リソースを進捗・キャンセル対応でダウンロードする。
+
+    `core/utils.py` の URL キャッシュ規約 (_get_cache_path) と同じ配置に保存する
+    ため、インストール後の推論はキャッシュをそのまま再利用する。zip は推論時
+    (`load_file`) に解凍されるためここでは展開しない。
+    """
+    import requests
+
+    from .core import utils
+
+    cache_dir = Path(DEFAULT_PATHS["cache_dir"])
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    is_cached, local_path = utils._is_cached(url, cache_dir)
+    if is_cached:
+        logger.debug(f"URL リソースはキャッシュ済み: {local_path}")
+        return
+
+    aggregator.check_cancelled()
+    response = requests.get(url, stream=True, timeout=DEFAULT_TIMEOUT)
+    response.raise_for_status()
+    total_size = int(response.headers.get("content-length", 0))
+    aggregator.add_total(total_size)
+
+    # キャンセル時に壊れたキャッシュを残さないよう一時ファイルに書いて rename する
+    tmp_path = local_path.with_suffix(local_path.suffix + ".part")
+    try:
+        with open(tmp_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                aggregator.check_cancelled()
+                if chunk:
+                    f.write(chunk)
+                    aggregator.add_downloaded(len(chunk))
+        tmp_path.replace(local_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _write_marker(model_name: str, model_path: str) -> None:
+    """install 完了 marker を書き込む。"""
+    marker = _marker_path(model_name)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(
+        json.dumps(
+            {
+                "model_name": model_name,
+                "model_path": model_path,
+                "installed_at": datetime.now().isoformat(),
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )

--- a/src/image_annotator_lib/model_installer.py
+++ b/src/image_annotator_lib/model_installer.py
@@ -216,9 +216,10 @@ def _model_config(model_name: str) -> dict[str, object] | None:
 def is_model_installed(model_name: str) -> bool:
     """モデルがインストール済み (明示ダウンロード完了済み) かを判定する。
 
-    install marker ファイルの有無で判定する高速・offline-safe な操作。
-    config registry に存在しないモデル (WebAPI モデル等、ダウンロード不要) は
-    常に True を返す。
+    install marker ファイルで判定する高速・offline-safe な操作。marker に
+    記録された model_path が現在の config と異なる場合 (config の付け替え) は
+    stale とみなし False を返す。config registry に存在しないモデル
+    (WebAPI モデル等、ダウンロード不要) は常に True を返す。
 
     Args:
         model_name: 判定対象のモデル名 (annotator_config.toml のセクション名)。
@@ -229,7 +230,16 @@ def is_model_installed(model_name: str) -> bool:
     config = _model_config(model_name)
     if config is None or not config.get("model_path"):
         return True
-    return _marker_path(model_name).exists()
+    marker = _marker_path(model_name)
+    try:
+        marker_data = json.loads(marker.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return False
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning(f"install marker の読み込み失敗 ({model_name}): {e} — 未インストール扱い")
+        return False
+    # Codex P2 (PR #151): config の model_path 付け替えで stale になった marker を拒否する
+    return marker_data.get("model_path") == str(config.get("model_path"))
 
 
 def install_model(
@@ -271,6 +281,10 @@ def install_model(
     parsed = urlparse(model_path)
     if parsed.scheme in ("http", "https"):
         _install_url_resource(model_path, aggregator)
+    elif Path(model_path).exists():
+        # Codex P2 (PR #151): ローカルファイル/ディレクトリ指定はダウンロード不要。
+        # 既存 loader (get_file_path / from_pretrained) がそのまま解決できる。
+        logger.debug(f"model_path はローカルパスのため DL をスキップ: {model_path}")
     else:
         _install_hf_repo(model_path, aggregator, _hf_patterns_for_class(config, model_class))
 
@@ -327,6 +341,10 @@ def _transformers_ignore_patterns(repo_id: str) -> list[str]:
 def _install_hf_repo(repo_id: str, aggregator: _ByteProgressAggregator, patterns: _HfPatterns) -> None:
     """HF repo を進捗付きで snapshot ダウンロードする。"""
     import huggingface_hub
+
+    # Codex P2 (PR #151): ignore patterns 計算 (list_repo_files の network call) の
+    # 前にキャンセルを確認し、キャンセル済みの場合に network へ出ないようにする
+    aggregator.check_cancelled()
 
     ignore_patterns: list[str] | None = None
     if patterns.allow_patterns is None and patterns.transformers_weights:

--- a/tests/unit/test_model_installer.py
+++ b/tests/unit/test_model_installer.py
@@ -1,0 +1,255 @@
+"""model_installer (明示モデルインストール API) のユニットテスト (LoRAIro Issue #754)"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from image_annotator_lib.exceptions.errors import ModelInstallCancelledError, ModelNotFoundError
+from image_annotator_lib.model_installer import (
+    ModelInstallProgress,
+    _build_snapshot_tqdm_class,
+    _ByteProgressAggregator,
+    _hf_patterns_for_class,
+    _transformers_ignore_patterns,
+    install_model,
+    is_model_installed,
+)
+
+
+@pytest.fixture
+def fake_paths(tmp_path):
+    """cache_dir を tmp_path に差し替える。"""
+    paths = {"cache_dir": tmp_path / "models"}
+    with patch("image_annotator_lib.model_installer.DEFAULT_PATHS", paths):
+        yield paths
+
+
+def _patch_config(config: dict):
+    """model_installer が参照する config_registry を差し替える。
+
+    config_registry はプロキシオブジェクトで属性単位の patch teardown が
+    効かないため、プロキシごと Mock に差し替える。
+    """
+    registry = MagicMock()
+    registry.get_all_config.return_value = config
+    return patch("image_annotator_lib.model_installer.config_registry", registry)
+
+
+class TestModelInstallProgress:
+    def test_percentage_normal(self):
+        progress = ModelInstallProgress(model_name="m", downloaded_bytes=50, total_bytes=200)
+        assert progress.percentage == 25
+
+    def test_percentage_unknown_total_returns_zero(self):
+        progress = ModelInstallProgress(model_name="m", downloaded_bytes=50, total_bytes=0)
+        assert progress.percentage == 0
+
+    def test_percentage_capped_at_100(self):
+        progress = ModelInstallProgress(model_name="m", downloaded_bytes=300, total_bytes=200)
+        assert progress.percentage == 100
+
+
+class TestIsModelInstalled:
+    def test_unknown_model_returns_true(self, fake_paths):
+        with _patch_config({}):
+            assert is_model_installed("openai/gpt-4o") is True
+
+    def test_model_without_model_path_returns_true(self, fake_paths):
+        with _patch_config({"some_model": {"class": "WDTagger"}}):
+            assert is_model_installed("some_model") is True
+
+    def test_known_model_without_marker_returns_false(self, fake_paths):
+        config = {"wd-vit-tagger-v3": {"model_path": "SmilingWolf/wd-vit-tagger-v3", "class": "WDTagger"}}
+        with _patch_config(config):
+            assert is_model_installed("wd-vit-tagger-v3") is False
+
+    def test_install_then_installed(self, fake_paths):
+        config = {"wd-vit-tagger-v3": {"model_path": "SmilingWolf/wd-vit-tagger-v3", "class": "WDTagger"}}
+        with (
+            _patch_config(config),
+            patch("huggingface_hub.snapshot_download") as mock_snapshot,
+        ):
+            install_model("wd-vit-tagger-v3")
+            assert mock_snapshot.call_count == 1
+            assert is_model_installed("wd-vit-tagger-v3") is True
+
+
+class TestInstallModel:
+    def test_unknown_model_raises(self, fake_paths):
+        with _patch_config({}), pytest.raises(ModelNotFoundError):
+            install_model("no_such_model")
+
+    def test_onnx_tagger_uses_allow_patterns(self, fake_paths):
+        config = {"wd-vit-tagger-v3": {"model_path": "SmilingWolf/wd-vit-tagger-v3", "class": "WDTagger"}}
+        with (
+            _patch_config(config),
+            patch("huggingface_hub.snapshot_download") as mock_snapshot,
+        ):
+            install_model("wd-vit-tagger-v3")
+        _, kwargs = mock_snapshot.call_args
+        assert kwargs["allow_patterns"] == ["model.onnx", "*.csv"]
+        assert kwargs["ignore_patterns"] is None
+
+    def test_cancel_before_download_raises_without_marker(self, fake_paths):
+        config = {"wd-vit-tagger-v3": {"model_path": "SmilingWolf/wd-vit-tagger-v3", "class": "WDTagger"}}
+        cancel_event = threading.Event()
+        cancel_event.set()
+        with (
+            _patch_config(config),
+            patch("huggingface_hub.snapshot_download") as mock_snapshot,
+            pytest.raises(ModelInstallCancelledError),
+        ):
+            install_model("wd-vit-tagger-v3", cancel_event=cancel_event)
+        assert mock_snapshot.call_count == 0
+        with _patch_config(config):
+            assert is_model_installed("wd-vit-tagger-v3") is False
+
+    def test_clip_model_installs_url_and_base_model(self, fake_paths, tmp_path):
+        config = {
+            "ImprovedAesthetic": {
+                "model_path": "https://example.com/sac+logos+ava1-l14-linearMSE.pth",
+                "base_model": "openai/clip-vit-large-patch14",
+                "class": "ImprovedAesthetic",
+            }
+        }
+        received: list[ModelInstallProgress] = []
+        with (
+            _patch_config(config),
+            patch("requests.get") as mock_get,
+            patch("huggingface_hub.snapshot_download") as mock_snapshot,
+            patch(
+                "image_annotator_lib.model_installer._transformers_ignore_patterns",
+                return_value=["*.h5"],
+            ),
+        ):
+            mock_get.return_value.headers = {"content-length": "10"}
+            mock_get.return_value.iter_content.return_value = iter([b"0123456789"])
+            install_model("ImprovedAesthetic", progress_callback=received.append)
+
+        # URL リソースがキャッシュ規約どおりに保存される
+        cached = fake_paths["cache_dir"] / "sac+logos+ava1-l14-linearMSE.pth"
+        assert cached.read_bytes() == b"0123456789"
+        # base_model の snapshot も実行される
+        args, kwargs = mock_snapshot.call_args
+        assert args[0] == "openai/clip-vit-large-patch14"
+        assert kwargs["ignore_patterns"] == ["*.h5"]
+        # byte 進捗が通知される
+        assert received[-1].downloaded_bytes == 10
+        assert received[-1].total_bytes == 10
+        assert received[-1].percentage == 100
+
+    def test_url_download_cancel_leaves_no_cache_file(self, fake_paths):
+        config = {
+            "WaifuAesthetic": {
+                "model_path": "https://example.com/aes-B32-v0.pth",
+                "class": "WaifuAesthetic",
+            }
+        }
+        cancel_event = threading.Event()
+
+        def chunks():
+            yield b"01234"
+            cancel_event.set()
+            yield b"56789"
+
+        with (
+            _patch_config(config),
+            patch("requests.get") as mock_get,
+            pytest.raises(ModelInstallCancelledError),
+        ):
+            mock_get.return_value.headers = {"content-length": "10"}
+            mock_get.return_value.iter_content.return_value = chunks()
+            install_model("WaifuAesthetic", cancel_event=cancel_event)
+
+        cache_dir = fake_paths["cache_dir"]
+        assert not (cache_dir / "aes-B32-v0.pth").exists()
+        assert not (cache_dir / "aes-B32-v0.pth.part").exists()
+
+    def test_model_without_model_path_skips(self, fake_paths):
+        with (
+            _patch_config({"odd_model": {"class": "WDTagger"}}),
+            patch("huggingface_hub.snapshot_download") as mock_snapshot,
+        ):
+            install_model("odd_model")
+        assert mock_snapshot.call_count == 0
+
+
+class TestHfPatternsForClass:
+    def test_anime_rating_uses_variant_files(self):
+        config = {"model_variant": "mobilenetv3_sce_dist"}
+        patterns = _hf_patterns_for_class(config, "AnimeRatingAnnotator")
+        assert patterns.allow_patterns == [
+            "mobilenetv3_sce_dist/model.onnx",
+            "mobilenetv3_sce_dist/meta.json",
+        ]
+
+    def test_camie_tagger_uses_initial_files(self):
+        patterns = _hf_patterns_for_class({}, "CamieTagger")
+        assert patterns.allow_patterns == ["model_initial.onnx", "*.json"]
+
+    def test_transformers_class_falls_back_to_snapshot(self):
+        patterns = _hf_patterns_for_class({}, "BLIPTagger")
+        assert patterns.allow_patterns is None
+        assert patterns.transformers_weights is True
+
+
+class TestTransformersIgnorePatterns:
+    def test_safetensors_repo_ignores_duplicate_weights(self):
+        with patch("huggingface_hub.list_repo_files", return_value=["model.safetensors", "config.json"]):
+            patterns = _transformers_ignore_patterns("org/repo")
+        assert "*.bin" in patterns
+        assert "*.pth" in patterns
+
+    def test_bin_only_repo_keeps_bin(self):
+        with patch("huggingface_hub.list_repo_files", return_value=["pytorch_model.bin", "config.json"]):
+            patterns = _transformers_ignore_patterns("org/repo")
+        assert "*.bin" not in patterns
+        assert "*.h5" in patterns
+
+    def test_listing_failure_falls_back_to_static(self):
+        with patch("huggingface_hub.list_repo_files", side_effect=OSError("offline")):
+            patterns = _transformers_ignore_patterns("org/repo")
+        assert "*.bin" not in patterns
+        assert "*.h5" in patterns
+
+
+class TestSnapshotProgressTqdm:
+    """snapshot_download の tqdm_class フック挙動 (byte バーのみ追跡) を検証する。"""
+
+    def _aggregator(self, received, cancel_event=None):
+        return _ByteProgressAggregator("m", received.append, cancel_event)
+
+    def test_bytes_bar_reports_progress(self):
+        received: list[ModelInstallProgress] = []
+        tqdm_cls = _build_snapshot_tqdm_class(self._aggregator(received))
+
+        # hf の bytes_progress 相当: unit="B" で作成され total が外部加算される
+        bar = tqdm_cls(desc="Downloading", total=0, initial=0, unit="B", unit_scale=True)
+        bar.total += 100  # _AggregatedTqdm.__init__ 相当
+        bar.refresh()
+        bar.update(40)
+        bar.update(60)
+
+        assert received[-1].downloaded_bytes == 100
+        assert received[-1].total_bytes == 100
+        assert received[-1].percentage == 100
+
+    def test_file_count_bar_is_ignored(self):
+        received: list[ModelInstallProgress] = []
+        tqdm_cls = _build_snapshot_tqdm_class(self._aggregator(received))
+
+        # thread_map の外側バー相当 (unit 指定なし): byte 集計に混入しない
+        bar = tqdm_cls(total=3, desc="Fetching 3 files")
+        bar.update(1)
+        assert received == []
+
+    def test_update_raises_when_cancelled(self):
+        received: list[ModelInstallProgress] = []
+        cancel_event = threading.Event()
+        tqdm_cls = _build_snapshot_tqdm_class(self._aggregator(received, cancel_event))
+        bar = tqdm_cls(desc="Downloading", total=0, initial=0, unit="B", unit_scale=True)
+
+        cancel_event.set()
+        with pytest.raises(ModelInstallCancelledError):
+            bar.update(10)

--- a/tests/unit/test_model_installer.py
+++ b/tests/unit/test_model_installer.py
@@ -253,3 +253,54 @@ class TestSnapshotProgressTqdm:
         cancel_event.set()
         with pytest.raises(ModelInstallCancelledError):
             bar.update(10)
+
+
+class TestCodexReviewFixes:
+    """PR #151 Codex P2 指摘への対応 (stale marker / local path / cancel 前倒し)"""
+
+    def test_stale_marker_with_different_model_path_returns_false(self, fake_paths):
+        """config の model_path 付け替え後は古い marker を stale として拒否する"""
+        config_v1 = {"m": {"model_path": "org/repo-v1", "class": "WDTagger"}}
+        config_v2 = {"m": {"model_path": "org/repo-v2", "class": "WDTagger"}}
+        with _patch_config(config_v1), patch("huggingface_hub.snapshot_download"):
+            install_model("m")
+            assert is_model_installed("m") is True
+        with _patch_config(config_v2):
+            assert is_model_installed("m") is False
+
+    def test_malformed_marker_returns_false(self, fake_paths):
+        """壊れた marker ファイルは未インストール扱いにする"""
+        config = {"m": {"model_path": "org/repo", "class": "WDTagger"}}
+        marker_dir = fake_paths["cache_dir"] / "install_markers"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / "m.json").write_text("{not json", encoding="utf-8")
+        with _patch_config(config):
+            assert is_model_installed("m") is False
+
+    def test_local_path_model_skips_download(self, fake_paths, tmp_path):
+        """ローカルパス指定の model_path は DL せず marker のみ書く"""
+        local_model = tmp_path / "local_model.onnx"
+        local_model.write_bytes(b"onnx")
+        config = {"m": {"model_path": str(local_model), "class": "WDTagger"}}
+        with (
+            _patch_config(config),
+            patch("huggingface_hub.snapshot_download") as mock_snapshot,
+        ):
+            install_model("m")
+            assert mock_snapshot.call_count == 0
+            assert is_model_installed("m") is True
+
+    def test_cancel_prevents_repo_listing_for_transformers_class(self, fake_paths):
+        """キャンセル済みなら transformers 系の repo 一覧取得 (network) にも出ない"""
+        config = {"blip": {"model_path": "Salesforce/blip", "class": "BLIPTagger"}}
+        cancel_event = threading.Event()
+        cancel_event.set()
+        with (
+            _patch_config(config),
+            patch("huggingface_hub.list_repo_files") as mock_list,
+            patch("huggingface_hub.snapshot_download") as mock_snapshot,
+            pytest.raises(ModelInstallCancelledError),
+        ):
+            install_model("blip", cancel_event=cancel_event)
+        assert mock_list.call_count == 0
+        assert mock_snapshot.call_count == 0


### PR DESCRIPTION
## 概要

LoRAIro Issue [NEXTAltair/LoRAIro#754](https://github.com/NEXTAltair/LoRAIro/issues/754) のバックエンド対応。ローカル ML モデル (WD Tagger / aesthetic scorer 等) の初回使用時に推論の最中で暗黙に走る HuggingFace ダウンロードを、進捗コールバック + キャンセル対応の明示インストール API として切り出す。

## 変更内容

- **`model_installer.py` 新設** (公開 API):
  - `is_model_installed(model_name)` — install marker ファイル (`cache_dir/install_markers/`) による高速・offline-safe な判定。config 未登録モデル (WebAPI 等) は常に True
  - `install_model(model_name, progress_callback, cancel_event)` — モデルクラス種別に応じたリソース解決と明示ダウンロード
  - `ModelInstallProgress` — byte 単位の進捗 (downloaded / total / percentage)
- **クラス種別ごとのダウンロード戦略**:
  - ONNX taggers (WDTagger / Z3D / Camie): `allow_patterns` で必要ファイルのみ
  - AnimeRatingAnnotator: variant ディレクトリのみ
  - transformers / pipeline 系: snapshot + 重複 weight 除外 (safetensors 優先時は `*.bin` / `*.pth` を ignore)
  - URL リソース (DeepDanbooru / CLIP head): 既存キャッシュ規約と同配置にストリーミング DL、CLIP は base repo も install
- **進捗フック**: `snapshot_download(tqdm_class=...)` の byte 集約バーを素の tqdm サブクラスで捕捉 (huggingface_hub 1.x の `_AggregatedTqdm` 集約に対応)
- **`ModelInstallCancelledError`** 追加: `cancel_event` セットで進捗更新タイミングに中断。部分 DL は HF cache の resume で再利用

## 設計メモ

- インストール済み判定は marker 方式。`from_pretrained` 系の部分キャッシュ走査は決定的でないため採らない。本 API 導入前に暗黙 DL 済みのモデルは「未インストール」と判定されるが、install 実行は HF cache を再利用するため短時間で完了する

## テスト

- `tests/unit/test_model_installer.py` 22 件追加 (marker 判定 / パターン解決 / URL DL + キャンセル / tqdm フック / 進捗集約)
- CI-equivalent filter: torch 依存モジュールは devcontainer の libcudnn 欠如で local 実行不可 (main でも同一 baseline、26 failed / 17 passed で一致 = regression なし)。最終確認は CI を SSoT とする

🤖 Generated with [Claude Code](https://claude.com/claude-code)