### PR TITLE
fix(batch): eligibility を adapter-availability gate に確定 (Closes #152)

### DIFF
--- a/docs/decisions/0005-provider-batch-api-contract.md
+++ b/docs/decisions/0005-provider-batch-api-contract.md
@@ -60,35 +60,49 @@ metadata や deprecation metadata は stable contract に含めない。
 
 ### Model eligibility
 
-Batch-capable model は以下を満たす model とする。
+Batch-capable model は以下を満たす model とする (#152 で adapter-availability gate に確定)。
 
 - direct provider route である
+- **batch adapter が実装済みの provider に属する** (現状: `anthropic` / `openai`)
 - annotation に必要な vision / tool calling / structured output 相当の capability を満たす
-- LiteLLM 同梱 DB に batch pricing field がある
-  - `input_cost_per_token_batches`
-  - `output_cost_per_token_batches`
 - OpenAI `gpt-5.5-pro` family denylist に含まれない
 
-`cache_read_input_token_cost_batches` は補助 metadata であり、単独では batch 対応判定に使わない。
 OpenRouter route は対象外である。
 
-#### 実装状況 / 設計からの逸脱 (2026-06-25 追記、#152)
+#### eligibility を adapter-availability gate とする理由 (#152、2026-06-26 確定)
 
-上記 eligibility 条件は本 ADR の設計意図であり、現行実装はこれをそのまま満たしていない。
-`list_batch_capable_models()` (`webapi/batch/service.py`) は **LiteLLM batch pricing field を見ず**、
-registry metadata の provider が **openai / anthropic** のモデルだけを返す (provider 名ハードコードの
-whitelist)。OpenAI は追加で **RATINGS capability 必須**。Google adapter と `gpt-5.5-pro` denylist は未実装。
+ADR accept 時点 (2026-05-25) の当初設計は「LiteLLM 同梱 DB に batch pricing field
+(`input_cost_per_token_batches` / `output_cost_per_token_batches`) があるか」を eligibility 判定に
+使う方針だった。しかし実装と運用で次の 2 点が判明し、pricing-field 判定を撤回して
+**adapter 実装の有無を gate** とすることに確定した。
 
-逸脱の理由 (経緯): eligibility の本質は「実際に dispatch できる」ことで、`submit_batch` →
-`_adapter_for_provider` は adapter 実装済み provider しか扱えない。pricing field があっても adapter が
-無ければ送信不能なため、MVP では「adapter が実装済みの provider か」を実質ゲートにした (送れないモデルを
-batch-capable と偽らない、という妥当な判断)。provider を 1 社ずつ追加 (Anthropic #103 → OpenAI
-moderation #128) したため whitelist のまま育ち、OpenAI は moderation endpoint 専用 adapter として
-追加された経緯から RATINGS を要求する (chat-completions 対応後も条件が残存し過剰気味)。
+1. **eligibility の本質は「実際に dispatch できる」こと。** `submit_batch` → `_adapter_for_provider`
+   は adapter 実装済み provider しか扱えない。pricing field があっても adapter が無ければ送信不能なので、
+   pricing-field を gate にすると「送れないのに batch-capable」と偽る model を一覧に出してしまう。
+2. **LiteLLM 同梱 DB の batch pricing データが direct provider route で不完全。** 検証時点で
+   `litellm_provider == "anthropic"` の direct route 22 model は batch pricing field を 1 件も持たない
+   (`vertex_ai/claude-*` route のみ field 有り。Vertex は MVP 対象外)。Anthropic Message Batches API は
+   実在し `AnthropicBatchAdapter` も稼働するため、pricing-field を一律 gate にすると Anthropic を丸ごと
+   誤除外する (false negative)。OpenAI direct route は batch pricing を持つ model があるが、判定を
+   provider 間で非対称にするより adapter-availability に統一する方が単純で予測可能。
 
-「pricing field 有無 = batch 対応」へ寄せる移行・Google adapter・denylist・OpenAI RATINGS フィルタ
-見直しは follow-up とする (#152)。当面は本 ADR の eligibility 条件を「設計上の到達目標」、実装の
-adapter-availability gate を「現状の実態」として扱う。
+このため LiteLLM batch pricing field は今回**例外的に eligibility 判定に使わない**。判定は
+`webapi/batch/service.py` の `_BATCH_ADAPTERS` registry (adapter 実装済み provider の SSoT) を参照する。
+`_BATCH_ADAPTERS` は `list_batch_capable_models()` の gate と `_adapter_for_provider()` の dispatch の
+両方が共有し、provider 名ハードコードの重複を持たない。
+
+`gpt-5.5-pro` family は cost-safety denylist (`_DENYLISTED_MODEL_SUBSTRINGS`) として実装済み。
+`litellm_model_id` に `gpt-5.5-pro` を含む model を除外する (非 pro の `gpt-5.5` は対象外)。
+
+旧実装にあった **OpenAI の RATINGS capability 必須フィルタは撤去した** (#152)。これは OpenAI adapter が
+当初 moderation endpoint 専用 (#128) として追加された経緯の残存で、chat-completions endpoint 対応後は
+過剰制約だった。adapter-availability gate では capability に依らず provider の adapter があれば返す。
+
+Google Vertex AI / Gemini batch adapter (Phase 3) は本 ADR では未実装で、#154 に defer する
+(`_BATCH_ADAPTERS` 未登録のため自動的に eligibility 対象外)。
+
+将来 pricing-aware な選別 (コスト上限・割引率提示など) が必要になった場合は、eligibility gate ではなく
+表示・選択補助の別レイヤーとして追加する。
 
 ### Provider transport
 

--- a/src/image_annotator_lib/webapi/batch/service.py
+++ b/src/image_annotator_lib/webapi/batch/service.py
@@ -22,21 +22,41 @@ from .types import (
 
 BatchAdapter = AnthropicBatchAdapter | OpenAIBatchAdapter
 
+# adapter 実装済み provider の単一情報源 (SSoT)。eligibility gate と dispatch の両方が
+# この registry を参照するため、provider 名のハードコード重複が生じない。
+# ADR 0005 "Model eligibility": batch eligibility は LiteLLM batch pricing field ではなく
+# adapter 実装の有無を gate とする (LiteLLM 同梱 DB が direct anthropic route の
+# batch pricing field を持たないため、pricing-field を一律ゲートにすると Anthropic を
+# 誤って除外してしまう。実 dispatch 可否 = adapter 実装の有無)。
+_BATCH_ADAPTERS: dict[str, type[BatchAdapter]] = {
+    "anthropic": AnthropicBatchAdapter,
+    "openai": OpenAIBatchAdapter,
+}
+
+# OpenAI `gpt-5.5-pro` family cost-safety denylist (ADR 0005)。
+# `gpt-5.5-pro` / `gpt-5.5-pro-2026-04-23` 等を除外する。非 pro の `gpt-5.5` は対象外。
+_DENYLISTED_MODEL_SUBSTRINGS: frozenset[str] = frozenset({"gpt-5.5-pro"})
+
 
 def _adapter_for_provider(provider: str) -> BatchAdapter:
     normalized = provider.lower()
-    if normalized == "anthropic":
-        return AnthropicBatchAdapter()
-    if normalized == "openai":
-        return OpenAIBatchAdapter()
-    raise BatchJobError(
-        phase=BatchErrorPhase.PREPARE,
-        provider=normalized,
-        provider_job_id=None,
-        code="unsupported_provider",
-        message=f"Provider Batch API is not implemented for provider: {provider}",
-        retryable=False,
-    )
+    adapter_cls = _BATCH_ADAPTERS.get(normalized)
+    if adapter_cls is None:
+        raise BatchJobError(
+            phase=BatchErrorPhase.PREPARE,
+            provider=normalized,
+            provider_job_id=None,
+            code="unsupported_provider",
+            message=f"Provider Batch API is not implemented for provider: {provider}",
+            retryable=False,
+        )
+    return adapter_cls()
+
+
+def _is_denylisted(litellm_model_id: str) -> bool:
+    """ADR 0005 cost-safety denylist (`gpt-5.5-pro` family) に該当するか判定する。"""
+    lowered = litellm_model_id.lower()
+    return any(token in lowered for token in _DENYLISTED_MODEL_SUBSTRINGS)
 
 
 def _capabilities_from_metadata(value: object) -> frozenset[TaskCapability]:
@@ -52,32 +72,34 @@ def _capabilities_from_metadata(value: object) -> frozenset[TaskCapability]:
 
 
 def list_batch_capable_models() -> list[BatchModelInfo]:
-    """Return direct Anthropic and OpenAI models usable with the provider batch route."""
+    """Provider batch route で使える direct provider モデルを返す。
+
+    eligibility = adapter 実装済み provider か (`_BATCH_ADAPTERS`)。ADR 0005 の通り
+    LiteLLM batch pricing field は判定に使わない (direct anthropic route に同 field が
+    無く false negative を招くため)。`gpt-5.5-pro` family は cost-safety denylist で除外する。
+    """
     models: list[BatchModelInfo] = []
     for model_name in list_available_annotators():
         metadata = get_webapi_metadata(model_name)
         if metadata is None:
             continue
         provider = str(metadata.get("provider", "")).lower()
-        if provider not in {"anthropic", "openai"}:
+        adapter_cls = _BATCH_ADAPTERS.get(provider)
+        if adapter_cls is None:
             continue
         litellm_model_id = metadata.get("litellm_model_id")
         if not isinstance(litellm_model_id, str) or not litellm_model_id:
             continue
-        capabilities = _capabilities_from_metadata(metadata.get("capabilities"))
-        if provider == "openai" and TaskCapability.RATINGS not in capabilities:
+        if _is_denylisted(litellm_model_id):
             continue
+        capabilities = _capabilities_from_metadata(metadata.get("capabilities"))
         models.append(
             BatchModelInfo(
                 provider=provider,
                 litellm_model_id=litellm_model_id,
                 display_name=model_name,
                 capabilities=capabilities,
-                metadata=(
-                    OpenAIBatchAdapter.batch_metadata()
-                    if provider == "openai"
-                    else AnthropicBatchAdapter.batch_metadata()
-                ),
+                metadata=adapter_cls.batch_metadata(),
             )
         )
     return models

--- a/src/image_annotator_lib/webapi/batch/service.py
+++ b/src/image_annotator_lib/webapi/batch/service.py
@@ -106,6 +106,18 @@ def list_batch_capable_models() -> list[BatchModelInfo]:
 
 
 def submit_batch(request: BatchSubmitRequest) -> BatchSubmitResult:
+    # cost-safety denylist は submit 経路でも強制する。list_batch_capable_models() から
+    # 隠すだけでは、BatchSubmitRequest を直接組み立てる呼び出しや、一覧更新前に選択を
+    # キャッシュした呼び出しが denylisted model を素通りで dispatch できてしまう。
+    if _is_denylisted(request.litellm_model_id):
+        raise BatchJobError(
+            phase=BatchErrorPhase.PREPARE,
+            provider=request.provider.lower(),
+            provider_job_id=None,
+            code="denylisted_model",
+            message=f"Model is denylisted for batch dispatch (cost-safety): {request.litellm_model_id}",
+            retryable=False,
+        )
     return _adapter_for_provider(request.provider).submit_batch(request)
 
 

--- a/tests/unit/webapi/batch/test_batch_public_api.py
+++ b/tests/unit/webapi/batch/test_batch_public_api.py
@@ -43,6 +43,32 @@ def test_submit_rejects_unsupported_provider() -> None:
         raise AssertionError("Expected BatchJobError")
 
 
+def test_submit_rejects_denylisted_model() -> None:
+    """#152: cost-safety denylist は submit 経路でも強制する (Codex P2)。
+
+    list_batch_capable_models() から隠すだけでは、BatchSubmitRequest を直接組み立てる
+    呼び出しや一覧更新前のキャッシュ選択が denylisted model を素通りで dispatch できる。
+    `gpt-5.5-pro` 系は submit_batch() でも PREPARE phase で拒否する。
+    """
+    request = BatchSubmitRequest(
+        provider="openai",
+        endpoint="/v1/chat/completions",
+        litellm_model_id="openai/gpt-5.5-pro",
+        prompt_profile="default",
+        description=None,
+        api_keys={"openai": "sk-test"},
+        items=[],
+    )
+
+    try:
+        submit_batch(request)
+    except BatchJobError as exc:
+        assert exc.phase is BatchErrorPhase.PREPARE
+        assert exc.code == "denylisted_model"
+    else:
+        raise AssertionError("Expected BatchJobError")
+
+
 def test_list_batch_capable_models_returns_anthropic_metadata(monkeypatch) -> None:
     monkeypatch.setattr(service, "list_available_annotators", lambda: ["claude"])
     monkeypatch.setattr(

--- a/tests/unit/webapi/batch/test_batch_public_api.py
+++ b/tests/unit/webapi/batch/test_batch_public_api.py
@@ -44,7 +44,7 @@ def test_submit_rejects_unsupported_provider() -> None:
 
 
 def test_list_batch_capable_models_returns_anthropic_metadata(monkeypatch) -> None:
-    monkeypatch.setattr(service, "list_available_annotators", lambda: ["claude", "gpt"])
+    monkeypatch.setattr(service, "list_available_annotators", lambda: ["claude"])
     monkeypatch.setattr(
         service,
         "get_webapi_metadata",
@@ -53,11 +53,6 @@ def test_list_batch_capable_models_returns_anthropic_metadata(monkeypatch) -> No
                 "provider": "anthropic",
                 "litellm_model_id": "anthropic/claude-3-5-haiku-latest",
                 "capabilities": ["tags", "captions", "scores", "ratings"],
-            },
-            "gpt": {
-                "provider": "openai",
-                "litellm_model_id": "openai/gpt-4o",
-                "capabilities": ["tags"],
             },
         }.get(name),
     )
@@ -70,6 +65,71 @@ def test_list_batch_capable_models_returns_anthropic_metadata(monkeypatch) -> No
     assert TaskCapability.RATINGS in models[0].capabilities
     assert models[0].metadata["result_retention_days"] == 29
     assert models[0].metadata["zero_data_retention_eligible"] is False
+
+
+def test_list_batch_capable_models_includes_openai_non_ratings_model(monkeypatch) -> None:
+    """#152: RATINGS 必須フィルタ撤去後、chat-completions 系 OpenAI モデルも一覧に含む。
+
+    旧実装は OpenAI に RATINGS capability を要求し、tags/captions/scores しか持たない
+    chat-completions モデルを誤って除外していた (moderation endpoint 専用 adapter として
+    追加された経緯の残存)。adapter-availability gate では provider に adapter があれば
+    capability に依らず batch-capable として返す。
+    """
+    monkeypatch.setattr(service, "list_available_annotators", lambda: ["gpt"])
+    monkeypatch.setattr(
+        service,
+        "get_webapi_metadata",
+        lambda name: {
+            "gpt": {
+                "provider": "openai",
+                "litellm_model_id": "openai/gpt-4o",
+                "capabilities": ["tags", "captions", "scores"],
+            },
+        }.get(name),
+    )
+
+    models = list_batch_capable_models()
+
+    assert len(models) == 1
+    assert models[0].provider == "openai"
+    assert models[0].litellm_model_id == "openai/gpt-4o"
+    assert TaskCapability.RATINGS not in models[0].capabilities
+    assert models[0].metadata["provider_batch_api"] == "openai_batch"
+
+
+def test_list_batch_capable_models_excludes_gpt_5_5_pro_denylist(monkeypatch) -> None:
+    """#152: `gpt-5.5-pro` family は cost-safety denylist で除外する (ADR 0005)。
+
+    非 pro の `gpt-5.5` は対象外で一覧に残る。
+    """
+    monkeypatch.setattr(
+        service, "list_available_annotators", lambda: ["gpt-5.5-pro", "gpt-5.5-pro-dated", "gpt-5.5"]
+    )
+    monkeypatch.setattr(
+        service,
+        "get_webapi_metadata",
+        lambda name: {
+            "gpt-5.5-pro": {
+                "provider": "openai",
+                "litellm_model_id": "openai/gpt-5.5-pro",
+                "capabilities": ["tags", "captions", "scores"],
+            },
+            "gpt-5.5-pro-dated": {
+                "provider": "openai",
+                "litellm_model_id": "openai/gpt-5.5-pro-2026-04-23",
+                "capabilities": ["tags", "captions", "scores"],
+            },
+            "gpt-5.5": {
+                "provider": "openai",
+                "litellm_model_id": "openai/gpt-5.5",
+                "capabilities": ["tags", "captions", "scores"],
+            },
+        }.get(name),
+    )
+
+    models = list_batch_capable_models()
+
+    assert {model.litellm_model_id for model in models} == {"openai/gpt-5.5"}
 
 
 def test_list_batch_capable_models_skips_models_without_webapi_metadata(


### PR DESCRIPTION
## 概要

Issue #152 を解決する。batch eligibility 判定を ADR 0005 当初の「LiteLLM batch pricing field ベース」から **adapter-availability gate** に正式変更し、付随する過剰制約 / 未実装項目を解消する。

## 背景: なぜ pricing-field 判定を撤回するか

ADR 0005 (accept 2026-05-25) の当初設計は eligibility を「LiteLLM 同梱 DB に `input_cost_per_token_batches` 等の batch pricing field があるか」で判定する方針だった。検証で次が判明した:

- **direct `anthropic` route (22 model) は LiteLLM DB に batch pricing field を 1 件も持たない** (`vertex_ai/claude-*` route のみ field 有り。Vertex は MVP 対象外)。
- 一方 Anthropic Message Batches API は実在し `AnthropicBatchAdapter` も稼働している。
- よって pricing-field を一律 gate にすると **Anthropic を丸ごと誤除外する (false negative)**。
- eligibility の本質は「実際に dispatch できる」こと = adapter 実装の有無。

このため今回 **例外的に LiteLLM batch pricing field を eligibility 判定に使わない**。

## 変更点

- **`list_batch_capable_models()`** (`webapi/batch/service.py`): gate を `_BATCH_ADAPTERS` registry (adapter 実装済み provider の SSoT) 参照に統一。eligibility gate と `_adapter_for_provider()` dispatch が同 registry を共有し、provider 名ハードコードの重複を解消。
- **OpenAI の RATINGS 必須フィルタを撤去**: OpenAI adapter が当初 moderation endpoint 専用 (#128) で追加された経緯の残存。chat-completions endpoint 対応後は過剰制約で、tags/captions/scores のみの OpenAI モデルを誤除外していた。
- **`gpt-5.5-pro` family cost-safety denylist を実装**: `litellm_model_id` に `gpt-5.5-pro` を含むモデルを除外 (非 pro の `gpt-5.5` は対象外)。
- **ADR 0005 "Model eligibility" を adapter-availability gate に確定**、撤回理由を明記。
- **Google adapter (Phase 3) は #154 に defer** (`_BATCH_ADAPTERS` 未登録のため自動的に eligibility 対象外)。

## Issue #152 follow-up 対応状況

- [x] eligibility を adapter-availability gate に正式変更 (ADR 0005 更新)
- [x] OpenAI RATINGS 必須フィルタ撤去
- [x] `gpt-5.5-pro` family denylist 実装
- [x] Google adapter 実装可否の判断 → defer (#154 起票)

## テスト

CI-equivalent filter (`-m "not downloads_and_runs_model and not calls_real_webapi"`) で検証:

- `tests/unit/webapi/batch/` 全 50 passed
- `tests/unit/webapi/` 全 73 passed
- RATINGS 撤去後の OpenAI 非 ratings モデル包含テスト、`gpt-5.5-pro` denylist テストを追加
- mypy / ruff clean

CI-EQUIV-TESTED

## 関連

- Closes #152
- ADR 0005 (Provider Batch API Contract)
- #154 (Google adapter defer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
