### PR TITLE
fix(batch): OpenAI responses-mode model を eligibility から除外 (Codex P2, #152)

### DIFF
--- a/docs/decisions/0005-provider-batch-api-contract.md
+++ b/docs/decisions/0005-provider-batch-api-contract.md
@@ -64,6 +64,10 @@ Batch-capable model は以下を満たす model とする (#152 で adapter-avai
 
 - direct provider route である
 - **batch adapter が実装済みの provider に属する** (現状: `anthropic` / `openai`)
+- **adapter がその model を実際に dispatch できる** (OpenAI は adapter が
+  `/v1/chat/completions` / `/v1/moderations` のみ対応のため、LiteLLM `mode` が
+  `chat` / `moderation` の model に限る。`mode == "responses"` の model
+  (`gpt-5-pro` / `o1-pro` / `o3-pro` 等) は除外する)
 - annotation に必要な vision / tool calling / structured output 相当の capability を満たす
 - OpenAI `gpt-5.5-pro` family denylist に含まれない
 
@@ -97,6 +101,14 @@ ADR accept 時点 (2026-05-25) の当初設計は「LiteLLM 同梱 DB に batch 
 旧実装にあった **OpenAI の RATINGS capability 必須フィルタは撤去した** (#152)。これは OpenAI adapter が
 当初 moderation endpoint 専用 (#128) として追加された経緯の残存で、chat-completions endpoint 対応後は
 過剰制約だった。adapter-availability gate では capability に依らず provider の adapter があれば返す。
+
+ただし adapter-availability gate は「adapter がその model を実際に dispatch できる」ことまで含む。
+OpenAI batch adapter は `/v1/chat/completions` / `/v1/moderations` のみ submit し `/v1/responses` は
+非対応のため、LiteLLM `mode == "responses"` の OpenAI model (`gpt-5-pro` / `o1-pro` / `o3-pro` 等) は
+eligibility で除外する (`_OPENAI_BATCH_DISPATCHABLE_MODES`、#152 Codex P2)。これは RATINGS 撤去で
+緩めた capability 制約とは別軸の「dispatch 可否」ゲートで、一覧には出るが submit 時に
+`unsupported_endpoint` で失敗する model を広告しないための制約。`/v1/responses` batch 対応を
+adapter に追加すればこの除外は不要になる。
 
 Google Vertex AI / Gemini batch adapter (Phase 3) は本 ADR では未実装で、#154 に defer する
 (`_BATCH_ADAPTERS` 未登録のため自動的に eligibility 対象外)。

--- a/src/image_annotator_lib/webapi/batch/service.py
+++ b/src/image_annotator_lib/webapi/batch/service.py
@@ -37,6 +37,15 @@ _BATCH_ADAPTERS: dict[str, type[BatchAdapter]] = {
 # `gpt-5.5-pro` / `gpt-5.5-pro-2026-04-23` 等を除外する。非 pro の `gpt-5.5` は対象外。
 _DENYLISTED_MODEL_SUBSTRINGS: frozenset[str] = frozenset({"gpt-5.5-pro"})
 
+# OpenAI batch adapter が dispatch できる LiteLLM `mode`。adapter は /v1/chat/completions と
+# /v1/moderations にのみ submit し、/v1/responses は非対応 (adapters/openai.py
+# `_SUPPORTED_ENDPOINTS`)。LiteLLM discovery が返す mode=="responses" の OpenAI モデル
+# (gpt-5-pro / o1-pro / o3-pro 等) を eligibility で弾かないと、一覧には出るが submit 時に
+# unsupported_endpoint で失敗する (#152 Codex P2)。adapter-availability gate は「provider に
+# adapter がある」だけでなく「adapter がその model を実際に dispatch できる」ことまで意味する。
+# Anthropic Message Batches は chat モデルを一律に扱うため mode 制約は課さない。
+_OPENAI_BATCH_DISPATCHABLE_MODES: frozenset[str] = frozenset({"chat", "moderation"})
+
 
 def _adapter_for_provider(provider: str) -> BatchAdapter:
     normalized = provider.lower()
@@ -77,6 +86,8 @@ def list_batch_capable_models() -> list[BatchModelInfo]:
     eligibility = adapter 実装済み provider か (`_BATCH_ADAPTERS`)。ADR 0005 の通り
     LiteLLM batch pricing field は判定に使わない (direct anthropic route に同 field が
     無く false negative を招くため)。`gpt-5.5-pro` family は cost-safety denylist で除外する。
+    OpenAI は adapter が dispatch できる mode (chat / moderation) のみ返す
+    (mode=="responses" の model は submit 時に失敗するため eligibility で除外、#152)。
     """
     models: list[BatchModelInfo] = []
     for model_name in list_available_annotators():
@@ -91,6 +102,11 @@ def list_batch_capable_models() -> list[BatchModelInfo]:
         if not isinstance(litellm_model_id, str) or not litellm_model_id:
             continue
         if _is_denylisted(litellm_model_id):
+            continue
+        if provider == "openai" and str(metadata.get("mode", "chat")).lower() not in (
+            _OPENAI_BATCH_DISPATCHABLE_MODES
+        ):
+            # mode=="responses" 等 OpenAI adapter が dispatch できない model は除外する (#152)。
             continue
         capabilities = _capabilities_from_metadata(metadata.get("capabilities"))
         models.append(

--- a/tests/unit/webapi/batch/test_batch_public_api.py
+++ b/tests/unit/webapi/batch/test_batch_public_api.py
@@ -123,6 +123,46 @@ def test_list_batch_capable_models_includes_openai_non_ratings_model(monkeypatch
     assert models[0].metadata["provider_batch_api"] == "openai_batch"
 
 
+def test_list_batch_capable_models_excludes_openai_responses_mode(monkeypatch) -> None:
+    """#152 Codex P2: OpenAI の mode=="responses" モデルは eligibility から除外する。
+
+    OpenAI batch adapter は /v1/chat/completions / /v1/moderations のみ dispatch し
+    /v1/responses は非対応。LiteLLM discovery が返す gpt-5-pro / o1-pro / o3-pro 等
+    (mode=="responses") を一覧に出すと submit 時に unsupported_endpoint で失敗する。
+    mode 未指定 (既定 chat) と mode=="chat" は含み、mode=="responses" のみ除外する。
+    """
+    monkeypatch.setattr(
+        service, "list_available_annotators", lambda: ["o3-pro", "gpt-4o", "gpt-chat-explicit"]
+    )
+    monkeypatch.setattr(
+        service,
+        "get_webapi_metadata",
+        lambda name: {
+            "o3-pro": {
+                "provider": "openai",
+                "litellm_model_id": "openai/o3-pro",
+                "mode": "responses",
+                "capabilities": ["tags", "captions", "scores"],
+            },
+            "gpt-4o": {
+                "provider": "openai",
+                "litellm_model_id": "openai/gpt-4o",
+                "capabilities": ["tags", "captions", "scores"],
+            },
+            "gpt-chat-explicit": {
+                "provider": "openai",
+                "litellm_model_id": "openai/gpt-4.1",
+                "mode": "chat",
+                "capabilities": ["tags", "captions", "scores"],
+            },
+        }.get(name),
+    )
+
+    models = list_batch_capable_models()
+
+    assert {model.litellm_model_id for model in models} == {"openai/gpt-4o", "openai/gpt-4.1"}
+
+
 def test_list_batch_capable_models_excludes_gpt_5_5_pro_denylist(monkeypatch) -> None:
     """#152: `gpt-5.5-pro` family は cost-safety denylist で除外する (ADR 0005)。
 


### PR DESCRIPTION
## 概要

#155 (batch eligibility を adapter-availability gate に確定) のフォローアップ。LoRAIro PR #924 の Codex レビューで指摘された **P2** に対応する。

## 問題 (Codex P2)

#155 で eligibility を provider 単位の adapter-availability gate にした結果、LiteLLM discovery が返す **`mode=="responses"` の OpenAI モデル**（`gpt-5-pro` / `o1-pro` / `o3-pro` / `gpt-5.2-pro` / `gpt-5.4-pro` 等）も batch-capable として広告されるようになった。しかし:

- OpenAI batch adapter は `/v1/chat/completions` / `/v1/moderations` のみ対応（`/v1/responses` 非対応、`adapters/openai.py` `_SUPPORTED_ENDPOINTS`）
- LoRAIro も OpenAI を `/v1/chat/completions` に射影（`provider_batch_workflow_service.py`）

→ responses-only モデルは discovery を通過するが **submit 時に `unsupported_endpoint` で失敗**する。「dispatch 不能を広告しない」という adapter-gate 本来意図の漏れ。

実データ: discovery 済み OpenAI 56モデル中 **12モデルが mode=="responses"**。

## 修正

`list_batch_capable_models()` の adapter-availability gate を「provider に adapter がある」だけでなく「**adapter がその model を実際に dispatch できる**」まで含める:

- OpenAI は LiteLLM `mode` が `chat` / `moderation` の model のみ返す（`_OPENAI_BATCH_DISPATCHABLE_MODES`）。`mode == "responses"` を除外
- Anthropic Message Batches は chat モデルを一律に扱うため mode 制約なし
- RATINGS 撤去で緩めた capability 制約とは別軸の「dispatch 可否」ゲート
- ADR 0005 "Model eligibility" に明記
- `/v1/responses` batch 対応を adapter に追加すればこの除外は不要になる

## テスト

- `test_list_batch_capable_models_excludes_openai_responses_mode` 追加（responses 除外 / mode 未指定=chat 既定は包含 / mode=="chat" 明示も包含）
- CI-equivalent filter (`-m "not downloads_and_runs_model and not calls_real_webapi"`): `tests/unit/webapi/batch/` 52 passed
- 実データ検証: OpenAI batch-capable 56→44（responses-only 12件除外、うち gpt-5.5-pro は denylist と重複）
- mypy / ruff clean

CI-EQUIV-TESTED

## 関連

- #152 / #155 (eligibility gate 確定)
- LoRAIro #924 (pin bump PR、本修正で再 pin する)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
