### PR TITLE
refactor(ruff): lint ignore を LoRAIro 側と統一

### DIFF
--- a/benchmarks/benchmark_agent_creation.py
+++ b/benchmarks/benchmark_agent_creation.py
@@ -167,7 +167,7 @@ class TestAgentCreationBenchmark:
         """
         factory = PydanticAIProviderFactory()
 
-        # 初回：プロバイダー生成
+        # 初回:プロバイダー生成
         memory_tracker.start()
         start_time = time.perf_counter()
 
@@ -180,7 +180,7 @@ class TestAgentCreationBenchmark:
         elapsed_time_first = time.perf_counter() - start_time
         memory_info_first = memory_tracker.stop()
 
-        # 2回目：同じプロバイダー
+        # 2回目:同じプロバイダー
         memory_tracker.start()
         start_time = time.perf_counter()
 

--- a/benchmarks/benchmark_memory.py
+++ b/benchmarks/benchmark_memory.py
@@ -110,7 +110,7 @@ class TestMemoryBenchmark:
         """
         factory = PydanticAIProviderFactory()
 
-        # 初回：プロバイダー生成
+        # 初回:プロバイダー生成
         memory_tracker.start()
         agent_1 = factory.get_cached_agent(
             model_id="openai:model1",
@@ -119,7 +119,7 @@ class TestMemoryBenchmark:
         )
         memory_info_1 = memory_tracker.stop()
 
-        # 2回目以降：同じプロバイダー
+        # 2回目以降:同じプロバイダー
         memory_tracker.start()
         agent_2 = factory.get_cached_agent(
             model_id="openai:model2",
@@ -164,7 +164,7 @@ class TestMemoryBenchmark:
             f"\n  3番目（model3）: {memory_info_3['allocated_mb']:.2f}MB"
         )
 
-        # 共有効果：2回目以降はメモリ増加が少ないはず
+        # 共有効果:2回目以降はメモリ増加が少ないはず
         assert memory_info_2["allocated_mb"] < memory_info_1["allocated_mb"]
         assert memory_info_3["allocated_mb"] < memory_info_1["allocated_mb"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,10 +109,19 @@ exclude = [
 
 ignore = [
     "E501",   # Line too long (handled by formatter)
-    "RUF002", # docstring 内のカタカナ `ノ` 等 ambiguous unicode 警告を回避
-    "RUF003", # comment 内のカタカナ `ノ` / 全角括弧等 ambiguous unicode 警告を回避
 ]
+
+# confusable 警告を許可する文字。日本語表記のカタカナ ノ (U+30CE)・全角括弧 （ ）・
+# UI/乗算で使う × (U+00D7)。残る全角記号は RUF001/002/003 で検出・半角化させる。
+allowed-confusables = ["ノ", "（", "）", "×"]
+
 fixable = ["ALL"]
+
+[tool.ruff.lint.per-file-ignores]
+# 複雑度は高いが分割の費用対効果が低い既存関数を個別に除外 (C901)
+"prototypes/pydanticai_integration/pydantic_ai_agent.py" = ["C901"]
+"src/image_annotator_lib/core/base/tensorflow.py" = ["C901"]
+"src/image_annotator_lib/model_class/tagger_tensorflow.py" = ["C901"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/image_annotator_lib/model_class/pipeline_scorers.py
+++ b/src/image_annotator_lib/model_class/pipeline_scorers.py
@@ -17,7 +17,7 @@ class AestheticShadow(PipelineBaseAnnotator):
     Hugging Face Pipeline を使用して美的スコアを計算します。
     """
 
-    # ADR 0009: hq/lq は softmax 確率 (各 0–1)。lq は値が小さいほど良い。
+    # ADR 0009: hq/lq は softmax 確率 (各 0-1)。lq は値が小さいほど良い。
     SCORE_SCALE: ClassVar[dict[str, ScoreScale]] = {
         "hq": ScoreScale((0.0, 1.0), higher_is_better=True),
         "lq": ScoreScale((0.0, 1.0), higher_is_better=False),
@@ -99,7 +99,7 @@ class CafePredictor(PipelineBaseAnnotator):
     Hugging Face Pipeline を使用して美的スコアを計算します。
     """
 
-    # ADR 0009: aesthetic/not_aesthetic は softmax 確率 (各 0–1、sum=1)。
+    # ADR 0009: aesthetic/not_aesthetic は softmax 確率 (各 0-1、sum=1)。
     # not_aesthetic は値が小さいほど良い。
     SCORE_SCALE: ClassVar[dict[str, ScoreScale]] = {
         "aesthetic": ScoreScale((0.0, 1.0), higher_is_better=True),

--- a/src/image_annotator_lib/model_class/scorer_clip.py
+++ b/src/image_annotator_lib/model_class/scorer_clip.py
@@ -17,7 +17,7 @@ from ..core.utils import logger
 class ImprovedAesthetic(ClipBaseAnnotator):
     """Improved Aesthetic Predictor v2 モデル (1-10 系 regression)。"""
 
-    # ADR 0009: AVA MOS 訓練の非有界 regression。理論値域 1–10、clamp なし。
+    # ADR 0009: AVA MOS 訓練の非有界 regression。理論値域 1-10、clamp なし。
     SCORE_SCALE: ClassVar[dict[str, ScoreScale]] = {
         "aesthetic": ScoreScale((1.0, 10.0), higher_is_better=True),
     }
@@ -31,7 +31,7 @@ class ImprovedAesthetic(ClipBaseAnnotator):
 class WaifuAesthetic(ClipBaseAnnotator):
     """Waifu Diffusion Aesthetic Predictor v2 モデル (0-1 系 regression)。"""
 
-    # ADR 0009: Sigmoid 出力の有界 regression。値域 0–1。
+    # ADR 0009: Sigmoid 出力の有界 regression。値域 0-1。
     SCORE_SCALE: ClassVar[dict[str, ScoreScale]] = {
         "aesthetic": ScoreScale((0.0, 1.0), higher_is_better=True),
     }

--- a/tests/unit/model_class/test_scorer_models.py
+++ b/tests/unit/model_class/test_scorer_models.py
@@ -820,7 +820,7 @@ def test_cafe_format_predictions_score_scales(
 def test_improved_aesthetic_format_predictions_score_scales(
     mock_clip_scorer_config, mock_clip_components, test_image, mock_capabilities_regression_scorer
 ):
-    """ADR 0009: ImprovedAesthetic は非有界 regression (1–10) の値域を返す。"""
+    """ADR 0009: ImprovedAesthetic は非有界 regression (1-10) の値域を返す。"""
     import torch
 
     with patch("image_annotator_lib.core.model_factory.ModelLoad.load_clip_components") as mock_load:
@@ -848,7 +848,7 @@ def test_improved_aesthetic_format_predictions_score_scales(
 
 @pytest.mark.unit
 def test_waifu_aesthetic_score_scale_class_attr():
-    """ADR 0009: WaifuAesthetic は有界 regression (0–1) の値域を宣言する。
+    """ADR 0009: WaifuAesthetic は有界 regression (0-1) の値域を宣言する。
 
     クラス属性 SCORE_SCALE を直接検証する (重みロードを伴わない軽量検証)。
     """


### PR DESCRIPTION
## 概要

LoRAIro 本体・genai-tag-db-tools との Ruff lint ignore のズレを解消する3パッケージ統一の一環 (iam-lib 分)。

## 変更

- **RUF002/RUF003** (ambiguous unicode) の包括 ignore を解除し `allowed-confusables = ["ノ", "（", "）", "×"]` に統一。日本語表記として自然なカタカナ ノ・全角括弧・UI/乗算の × のみ許可し、残る全角記号は検出させる。
- **C901** (複雑度) を `per-file-ignores` に移行。既存の複雑関数3件 (`prototypes` の `main_annotator_logic`、`core/base/tensorflow.py` / `model_class/tagger_tensorflow.py` の `_format_predictions` 系) を個別除外。新規コードには複雑度チェックを効かせる。
- 上記解除で表面化したコメント/docstring の全角 `：` `–` を半角化 (5ファイル)。

## スコープ外

既存の F841/RUF012/B007 等の lint 債務 (本変更とは無関係に存在) は別途。

## テスト

ローカルは libcudnn 不在で torch import 不可のため CI 検証。本変更は ruff config + コメント半角化のみで実行時挙動に影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)