### PR TITLE
docs: OKF YAML frontmatter ポリシーを全ドキュメントへ適用 (#158)

### DIFF
--- a/.agents/skills/okf-bundle/SKILL.md
+++ b/.agents/skills/okf-bundle/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: okf-bundle
+version: "1.0.0"
+description: "Maintain a directory of markdown docs as an Open Knowledge Format (OKF) bundle in any project: ensure each concept file has valid OKF frontmatter (required `type`, plus optional title/description/tags/timestamp), keep frontmatter the single source of truth, and regenerate the derived index.md (and an optional human-readable table) from it. Use when adding/editing concept docs (ADRs, knowledge bases, glossaries) or when a bundle's index looks stale. Project-specific drift detection stays in the project."
+metadata:
+  short-description: 任意プロジェクトの md 群を OKF バンドルとして保守（frontmatter=SSoT → index/表を生成・検証）。
+---
+
+# OKF Bundle Maintenance
+
+Markdown ファイルのディレクトリを [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+バンドルとして保守する汎用スキル。**frontmatter を唯一の正準ソース (SSoT)** とし、
+`index.md` や人間向けテーブルは frontmatter から生成する派生物として扱う。
+
+プロジェクト非依存・stdlib only。`--bundle-root` で対象ディレクトリを受け取るので、
+ADR・知識ベース・用語集など任意の OKF バンドルに使える。
+
+## OKF の必須ルール (SPEC v0.1)
+
+- frontmatter の必須キーは **`type` のみ**。`title` / `description` / `tags` / `timestamp` は任意。
+- スカラー値メタデータ (status / timestamp 等) は **frontmatter に置く**。本文の散文に書かない。
+- `index.md` / `log.md` は予約ファイル名。概念ドキュメントには使わない。`log.md` の日付は ISO 8601。
+- `index.md` / 生成テーブルは**生成物**。手編集しない。
+
+## スクリプト (scripts/)
+
+すべて `python3` 単体 (依存なし) で動く。
+
+| スクリプト | 役割 |
+|---|---|
+| `okf_validate.py --bundle-root DIR` | frontmatter 検証 (必須 `type` / ISO `timestamp` / `--require`・`--exclude`・`--skip-missing` 可) |
+| `okf_index.py --bundle-root DIR --index` | OKF `index.md` (箇条書き) を生成 |
+| `okf_index.py --bundle-root DIR --table --columns ... --link-column ...` | 列を frontmatter キーで指定する Markdown テーブルを生成 |
+
+`okf_index.py` の `--check` は書き込まず「生成物が最新か」だけ検証する (drift 検出)。
+`--table-output` 先に `<!-- OKF-TABLE:START -->` / `<!-- OKF-TABLE:END -->` マーカーがあれば、
+その間だけ置換するのでテーブル前後の散文を保持できる。
+
+`okf_validate.py --skip-missing` は frontmatter が無いファイルを違反にせず除外する
+(段階的移行 / lazy migration 用)。frontmatter 未付与の既存ドキュメントを許容しつつ、
+付与済みのものだけ `type` 必須 / ISO `timestamp` を強制したいバンドルで使う。
+全件 frontmatter 必須のバンドル (例: ADR) には付けない。
+
+## Workflow (Agent が判断で起動)
+
+概念ドキュメントを追加・編集・改番したら:
+
+1. **検証**: `python3 <skill>/scripts/okf_validate.py --bundle-root <DIR> [--exclude README.md]`
+   — frontmatter 欠落や必須キー漏れを補う。
+2. **再生成**: `python3 <skill>/scripts/okf_index.py --bundle-root <DIR> --index ...`
+   (必要なら `--table ...` も) で派生ビューを更新する。
+3. **コミット**: 生成物を含めてコミットする (docs chore は main 直 push 可なプロジェクトもある)。
+
+CI 自走に頼らず Agent の判断で回す。許容するのは「実行漏れ (索引が一時的に古い)」だけで、
+生成は決定論なので内容ドリフトは発生しない。**索引やテーブルを手で書き起こさない**
+(書式ブレ・転記ミスの温床)。
+
+## プロジェクト固有の責務 (スキル外)
+
+「その概念を参照しているコードが概念より新しい」式の drift 検出 (REFERENCE-DRIFT) は
+各プロジェクトの enactment surface に依存するため、本スキルには含めない。プロジェクト側の
+ツール (例: LoRAIro `scripts/check_adr_drift.py`) が担う。
+
+## LoRAIro での使用例
+
+```bash
+# ADR バンドル検証 (全件 frontmatter 必須)
+python3 .claude/skills/okf-bundle/scripts/okf_validate.py --bundle-root docs/decisions --exclude README.md
+# index.md + README テーブルを再生成
+make adr-index   # 内部で okf_index.py を呼ぶ
+
+# 通常ドキュメント検証 (lazy migration: 未付与は skip、付与済みのみ検証。ADR 0082)
+make docs-okf    # docs / iam-lib docs / genai-tag docs を --skip-missing で検証
+```

--- a/.agents/skills/okf-bundle/scripts/_okf.py
+++ b/.agents/skills/okf-bundle/scripts/_okf.py
@@ -1,0 +1,137 @@
+"""OKF (Open Knowledge Format) バンドル操作の共有ユーティリティ。
+
+stdlib のみで動作する。frontmatter のパースとバンドル走査を提供し、
+``okf_validate.py`` / ``okf_index.py`` から import される。
+
+OKF SPEC: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+
+frontmatter パーサは YAML 全体ではなく、OKF が想定する素直な部分集合だけを扱う:
+
+- ``key: value`` のスカラー (前後の引用符は除去)
+- ``key: [a, b, c]`` のインラインリスト
+- 次行以降に ``  - item`` が並ぶブロックリスト
+
+ネストした map やフロースタイル map は対象外 (OKF concept frontmatter には不要)。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+# 任意の階層に置けて、概念ドキュメントには使えない予約ファイル名 (OKF SPEC §3.1)。
+RESERVED_FILENAMES = frozenset({"index.md", "log.md"})
+
+
+def split_frontmatter(text: str) -> tuple[str, str]:
+    """先頭の ``---`` で囲まれた frontmatter ブロックと本文を分離して返す。
+
+    Args:
+        text: Markdown ファイル全体の文字列。
+
+    Returns:
+        ``(frontmatter_block, body)`` のタプル。frontmatter が無ければ
+        ``("", text)`` を返す。frontmatter_block は ``---`` 区切り行を含まない。
+    """
+    if not text.startswith("---"):
+        return "", text
+    # 開始 --- 行の直後から、次の --- 行までを frontmatter とする。
+    # rstrip() で CRLF (``---\r``) や末尾空白も区切りとして認識する。
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].rstrip() != "---":
+        return "", text
+    for i in range(1, len(lines)):
+        if lines[i].rstrip() == "---":
+            block = "".join(lines[1:i])
+            body = "".join(lines[i + 1 :])
+            return block, body
+    return "", text
+
+
+def _strip_scalar(value: str) -> str:
+    """スカラー値の前後空白と一重/二重引用符を除去する。"""
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def _parse_inline_list(value: str) -> list[str]:
+    """``[a, b, c]`` 形式のインラインリストを要素リストへ変換する。"""
+    inner = value.strip()[1:-1].strip()
+    if not inner:
+        return []
+    return [_strip_scalar(item) for item in inner.split(",") if item.strip()]
+
+
+def parse_frontmatter(text: str) -> dict[str, str | list[str]]:
+    """Markdown の frontmatter をパースして key/value の dict を返す。
+
+    OKF が想定する素直な部分集合のみ対応 (モジュール docstring 参照)。
+
+    Args:
+        text: Markdown ファイル全体の文字列。
+
+    Returns:
+        frontmatter の key/value。値はスカラー (str) かリスト (list[str])。
+        frontmatter が無ければ空 dict。
+    """
+    block, _ = split_frontmatter(text)
+    if not block:
+        return {}
+    result: dict[str, str | list[str]] = {}
+    lines = block.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        i += 1
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, raw = line.partition(":")
+        key = key.strip()
+        raw = raw.strip()
+        if raw.startswith("[") and raw.endswith("]"):
+            result[key] = _parse_inline_list(raw)
+        elif raw == "":
+            # ブロックリストの可能性: 次行以降の "  - item" を集める。
+            items: list[str] = []
+            while i < len(lines) and lines[i].lstrip().startswith("- "):
+                items.append(_strip_scalar(lines[i].lstrip()[2:]))
+                i += 1
+            result[key] = items
+        else:
+            result[key] = _strip_scalar(raw)
+    return result
+
+
+def iter_concept_files(
+    bundle_root: Path, *, extra_excludes: frozenset[str] = frozenset()
+) -> Iterator[Path]:
+    """バンドル配下の概念ドキュメント (*.md) を名前順に列挙する。
+
+    予約ファイル名 (``index.md`` / ``log.md``) と ``extra_excludes`` の
+    ファイル名は除外する。
+
+    Args:
+        bundle_root: バンドルのルートディレクトリ。
+        extra_excludes: 追加で除外するファイル名の集合 (例: ``{"README.md"}``)。
+
+    Yields:
+        概念ドキュメントの Path。
+    """
+    excludes = RESERVED_FILENAMES | extra_excludes
+    for path in sorted(bundle_root.rglob("*.md")):
+        if path.name in excludes:
+            continue
+        yield path
+
+
+def as_scalar(value: str | list[str] | None) -> str:
+    """frontmatter 値を表示用スカラー文字列へ正規化する。"""
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return ", ".join(value)
+    return value

--- a/.agents/skills/okf-bundle/scripts/_okf.py
+++ b/.agents/skills/okf-bundle/scripts/_okf.py
@@ -32,6 +32,11 @@ def split_frontmatter(text: str) -> tuple[str, str]:
     Returns:
         ``(frontmatter_block, body)`` のタプル。frontmatter が無ければ
         ``("", text)`` を返す。frontmatter_block は ``---`` 区切り行を含まない。
+
+    Raises:
+        ValueError: 開始 ``---`` 区切りがあるのに閉じ ``---`` が無い
+            (unterminated frontmatter) 場合。``--skip-missing`` で malformed を
+            「未付与」と取り違えないための guardrail。
     """
     if not text.startswith("---"):
         return "", text
@@ -45,7 +50,7 @@ def split_frontmatter(text: str) -> tuple[str, str]:
             block = "".join(lines[1:i])
             body = "".join(lines[i + 1 :])
             return block, body
-    return "", text
+    raise ValueError("frontmatter の閉じ '---' が無い (unterminated)")
 
 
 def _strip_scalar(value: str) -> str:
@@ -100,7 +105,12 @@ def parse_frontmatter(text: str) -> dict[str, str | list[str]]:
         key, _, raw = line.partition(":")
         key = key.strip()
         raw = raw.strip()
-        if raw.startswith("[") and raw.endswith("]"):
+        if raw.startswith("["):
+            # inline list は ']' で閉じる必要がある。未終端 (例: ``[webapi``) は
+            # plain scalar に fall through させず reject する (tags/depends_on は
+            # 機械可読な list である契約。ADR 0010)。
+            if not raw.endswith("]"):
+                raise ValueError(f"不正な inline list (']' 未終端): {raw!r}")
             result[key] = _parse_inline_list(raw)
         elif raw == "":
             # ブロックリストの可能性: 次行以降の "  - item" を集める。

--- a/.agents/skills/okf-bundle/scripts/_okf.py
+++ b/.agents/skills/okf-bundle/scripts/_okf.py
@@ -49,10 +49,18 @@ def split_frontmatter(text: str) -> tuple[str, str]:
 
 
 def _strip_scalar(value: str) -> str:
-    """スカラー値の前後空白と一重/二重引用符を除去する。"""
+    """スカラー値の前後空白と一重/二重引用符を除去する。
+
+    クォートで始まるのに同じクォートで閉じていない値 (例: ``"Broken``) は
+    不正な YAML スカラーとして ``ValueError`` を送出する。frontmatter を契約とする
+    OKF バンドル (ADR 0010 / LoRAIro ADR 0082) で、検証が malformed scalar を
+    silently 通さないための guardrail。
+    """
     value = value.strip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
-        return value[1:-1]
+    if value and value[0] in "\"'":
+        if len(value) >= 2 and value[-1] == value[0]:
+            return value[1:-1]
+        raise ValueError(f"不正な quoted scalar (クォート未終端): {value!r}")
     return value
 
 

--- a/.agents/skills/okf-bundle/scripts/okf_index.py
+++ b/.agents/skills/okf-bundle/scripts/okf_index.py
@@ -1,0 +1,192 @@
+"""OKF バンドルの索引を frontmatter から生成する汎用ツール (stdlib only)。
+
+frontmatter を唯一の正準ソース (SSoT) とみなし、そこから派生ビューを生成する:
+
+- ``--index``  : OKF SPEC §6 の ``index.md`` (箇条書き、progressive disclosure) を生成。
+- ``--table``  : 人間向け Markdown テーブルを生成。列は frontmatter キーで指定するため
+  プロジェクト非依存 (``--columns id,title,timestamp,status`` 等)。
+
+いずれも ``--check`` で「生成結果が既存ファイルと一致するか」だけを検証できる
+(CI/skill が drift を検出する用途)。``--table-output`` 先に
+``<!-- OKF-TABLE:START -->`` / ``<!-- OKF-TABLE:END -->`` マーカーがあれば、その間だけを
+置換するため、テーブル前後の人手の散文 (説明・テンプレ) を保持できる。
+
+特殊列:
+- ``id``   : ファイル名先頭の連番 (例 ``0001-foo.md`` -> ``0001``)。無ければ stem。
+- ``file`` : ファイル名。
+
+使い方:
+    python3 okf_index.py --bundle-root docs/decisions --index --exclude README.md
+    python3 okf_index.py --bundle-root docs/decisions --table \\
+        --columns id,title,timestamp,status --headers "ADR,タイトル,日付,ステータス" \\
+        --link-column id --table-output docs/decisions/README.md
+    python3 okf_index.py --bundle-root docs/decisions --table ... --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from _okf import as_scalar, iter_concept_files, parse_frontmatter
+
+TABLE_START = "<!-- OKF-TABLE:START -->"
+TABLE_END = "<!-- OKF-TABLE:END -->"
+_LEADING_NUM = re.compile(r"^(\d+)")
+
+
+def _id_of(path: Path) -> str:
+    m = _LEADING_NUM.match(path.stem)
+    return m.group(1) if m else path.stem
+
+
+def _cell(path: Path, fm: dict[str, str | list[str]], col: str) -> str:
+    if col == "id":
+        return _id_of(path)
+    if col == "file":
+        return path.name
+    if col == "title":
+        return as_scalar(fm.get("title")) or path.stem
+    return as_scalar(fm.get(col))
+
+
+def _md_escape(text: str) -> str:
+    """テーブルセル内のパイプをエスケープする。"""
+    return text.replace("|", "\\|")
+
+
+def _collect(
+    bundle_root: Path, excludes: frozenset[str], sort_by: str
+) -> list[tuple[Path, dict[str, str | list[str]]]]:
+    rows = [
+        (p, parse_frontmatter(p.read_text(encoding="utf-8")))
+        for p in iter_concept_files(bundle_root, extra_excludes=excludes)
+    ]
+    if sort_by == "file":
+        rows.sort(key=lambda r: r[0].name)
+    else:
+        rows.sort(key=lambda r: _cell(r[0], r[1], sort_by))
+    return rows
+
+
+def build_index(
+    rows: list[tuple[Path, dict[str, str | list[str]]]], bundle_root: Path, title: str, title_key: str
+) -> str:
+    """OKF SPEC §6 形式の index.md 本文を生成する。"""
+    lines = [f"# {title}", ""]
+    for path, fm in rows:
+        rel = path.relative_to(bundle_root).as_posix()
+        label = as_scalar(fm.get(title_key)) or path.stem
+        desc = as_scalar(fm.get("description"))
+        entry = f"* [{label}]({rel})"
+        if desc:
+            entry += f" — {desc}"
+        lines.append(entry)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_table(
+    rows: list[tuple[Path, dict[str, str | list[str]]]],
+    bundle_root: Path,
+    columns: list[str],
+    headers: list[str],
+    link_column: str | None,
+) -> str:
+    """Markdown テーブル本文を生成する。"""
+    out = ["| " + " | ".join(headers) + " |", "|" + "|".join(["---"] * len(columns)) + "|"]
+    for path, fm in rows:
+        cells: list[str] = []
+        rel = path.relative_to(bundle_root).as_posix()
+        for col in columns:
+            value = _md_escape(_cell(path, fm, col))
+            if col == link_column:
+                value = f"[{value}]({rel})"
+            cells.append(value)
+        out.append("| " + " | ".join(cells) + " |")
+    return "\n".join(out)
+
+
+def _inject(existing: str, table: str) -> str:
+    """マーカー間にテーブルを差し込む。無ければテーブルのみを返す。"""
+    if TABLE_START in existing and TABLE_END in existing:
+        pre = existing[: existing.index(TABLE_START) + len(TABLE_START)]
+        post = existing[existing.index(TABLE_END) :]
+        return f"{pre}\n{table}\n{post}"
+    return table + "\n"
+
+
+def _emit(content: str, output: Path | None, check: bool, label: str) -> int:
+    """書き込み or --check 検証。差分があれば 1 を返す。"""
+    if output is None:
+        print(content)
+        return 0
+    current = output.read_text(encoding="utf-8") if output.exists() else ""
+    if check:
+        if current != content:
+            print(f"DRIFT: {output} が最新でない ({label} を再生成してください)", file=sys.stderr)
+            return 1
+        print(f"OK: {output} は最新 ({label})")
+        return 0
+    output.write_text(content, encoding="utf-8")
+    print(f"生成: {output} ({label})")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="OKF バンドルの索引を frontmatter から生成する。")
+    parser.add_argument("--bundle-root", type=Path, required=True)
+    parser.add_argument("--exclude", default="", help="除外ファイル名のカンマ区切り。")
+    parser.add_argument("--sort-by", default="file", help="並び替えに使う列 (既定: file)。")
+    parser.add_argument("--check", action="store_true", help="書き込まず最新かどうか検証する。")
+    # index
+    parser.add_argument("--index", action="store_true", help="index.md を生成する。")
+    parser.add_argument(
+        "--index-output", type=Path, default=None, help="index.md の出力先 (既定: <root>/index.md)。"
+    )
+    parser.add_argument("--index-title", default="Index")
+    parser.add_argument("--title-key", default="title")
+    # table
+    parser.add_argument("--table", action="store_true", help="Markdown テーブルを生成する。")
+    parser.add_argument("--columns", default="id,title,timestamp,status")
+    parser.add_argument("--headers", default="", help="表示ヘッダのカンマ区切り (既定: columns と同じ)。")
+    parser.add_argument("--link-column", default=None, help="リンク化する列名。")
+    parser.add_argument("--table-output", type=Path, default=None)
+    args = parser.parse_args()
+
+    bundle_root: Path = args.bundle_root
+    if not bundle_root.is_dir():
+        print(f"エラー: バンドルが見つからない: {bundle_root}", file=sys.stderr)
+        return 2
+    if not (args.index or args.table):
+        print("エラー: --index か --table のいずれかを指定してください。", file=sys.stderr)
+        return 2
+
+    excludes = frozenset(k.strip() for k in args.exclude.split(",") if k.strip())
+    rows = _collect(bundle_root, excludes, args.sort_by)
+
+    rc = 0
+    if args.index:
+        content = build_index(rows, bundle_root, args.index_title, args.title_key)
+        output = args.index_output or (bundle_root / "index.md")
+        rc |= _emit(content, output, args.check, "index.md")
+    if args.table:
+        columns = [c.strip() for c in args.columns.split(",") if c.strip()]
+        headers = [h.strip() for h in args.headers.split(",")] if args.headers else columns
+        if len(headers) != len(columns):
+            print("エラー: --headers の数が --columns と一致しません。", file=sys.stderr)
+            return 2
+        table = build_table(rows, bundle_root, columns, headers, args.link_column)
+        if args.table_output is not None:
+            existing = args.table_output.read_text(encoding="utf-8") if args.table_output.exists() else ""
+            content = _inject(existing, table)
+        else:
+            content = table
+        rc |= _emit(content, args.table_output, args.check, "table")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/okf-bundle/scripts/okf_validate.py
+++ b/.agents/skills/okf-bundle/scripts/okf_validate.py
@@ -1,0 +1,124 @@
+"""OKF バンドルの frontmatter を検証する汎用ツール (stdlib only)。
+
+OKF SPEC v0.1 が要求する最小の構造規約を機械チェックする:
+
+- 各概念ドキュメントに frontmatter があり、必須キー ``type`` を持つこと。
+- ``timestamp`` があれば ISO 8601 (``YYYY-MM-DD`` または日時) であること。
+- 予約ファイル名 (``index.md`` / ``log.md``) を概念ドキュメントに使っていないこと
+  (本ツールは予約名を概念として走査しないため、混在は ``--require`` の対象外)。
+
+プロジェクト非依存。``--bundle-root`` で対象ディレクトリを受け取り、
+``--require`` で必須キーを追加できる。違反があれば終了コード 1。
+
+段階的移行 (lazy migration) のため ``--skip-missing`` を用意する。frontmatter が
+無いファイルを違反にせず走査から除外するので、既存ドキュメントへ frontmatter を
+徐々に付与しつつ、付与済みのものだけ規約を強制できる。
+
+使い方:
+    python3 okf_validate.py --bundle-root docs/decisions
+    python3 okf_validate.py --bundle-root docs/decisions --require type,title --exclude README.md
+    python3 okf_validate.py --bundle-root docs --skip-missing --exclude README.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+from _okf import iter_concept_files, parse_frontmatter
+
+# OKF SPEC §4.1: frontmatter の必須キーは type のみ。
+DEFAULT_REQUIRED = ("type",)
+
+
+def _is_iso8601(value: str) -> bool:
+    """値が ISO 8601 の日付または日時として解釈できるか判定する。"""
+    for parser in (date.fromisoformat, datetime.fromisoformat):
+        try:
+            parser(value.replace("Z", "+00:00") if parser is datetime.fromisoformat else value)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def validate(
+    bundle_root: Path,
+    required: tuple[str, ...],
+    excludes: frozenset[str],
+    *,
+    skip_missing: bool = False,
+) -> list[str]:
+    """バンドルを検証し、違反メッセージのリストを返す (空なら合格)。
+
+    Args:
+        bundle_root: バンドルのルートディレクトリ。
+        required: 各概念ドキュメントに必須とするキーのタプル。
+        excludes: 走査から除外するファイル名の集合。
+        skip_missing: True なら frontmatter が無いファイルを違反にせず除外する
+            (lazy migration 用)。
+    """
+    problems: list[str] = []
+    count = 0
+    for path in iter_concept_files(bundle_root, extra_excludes=excludes):
+        count += 1
+        rel = path.relative_to(bundle_root).as_posix()
+        text = path.read_text(encoding="utf-8")
+        fm = parse_frontmatter(text)
+        if not fm:
+            if not skip_missing:
+                problems.append(f"{rel}: frontmatter が無い")
+            continue
+        for key in required:
+            if not fm.get(key):
+                problems.append(f"{rel}: 必須キー '{key}' が無い")
+        timestamp = fm.get("timestamp")
+        if isinstance(timestamp, str) and timestamp and not _is_iso8601(timestamp):
+            problems.append(f"{rel}: timestamp '{timestamp}' が ISO 8601 でない")
+    if count == 0:
+        problems.append(f"{bundle_root}: 概念ドキュメント (*.md) が見つからない")
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="OKF バンドルの frontmatter を検証する。")
+    parser.add_argument("--bundle-root", type=Path, required=True, help="バンドルのルートディレクトリ。")
+    parser.add_argument(
+        "--require",
+        default="type",
+        help="必須キーのカンマ区切り (既定: type)。",
+    )
+    parser.add_argument(
+        "--exclude",
+        default="",
+        help="走査から除外するファイル名のカンマ区切り (例: README.md)。",
+    )
+    parser.add_argument(
+        "--skip-missing",
+        action="store_true",
+        help="frontmatter が無いファイルを違反にせず除外する (lazy migration 用)。",
+    )
+    args = parser.parse_args()
+
+    bundle_root: Path = args.bundle_root
+    if not bundle_root.is_dir():
+        print(f"エラー: バンドルが見つからない: {bundle_root}", file=sys.stderr)
+        return 2
+
+    required = tuple(k.strip() for k in args.require.split(",") if k.strip()) or DEFAULT_REQUIRED
+    excludes = frozenset(k.strip() for k in args.exclude.split(",") if k.strip())
+
+    problems = validate(bundle_root, required, excludes, skip_missing=args.skip_missing)
+    if problems:
+        print(f"OKF 検証 NG: {len(problems)} 件の違反")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    print(f"OKF 検証 OK: {bundle_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/okf-bundle/scripts/okf_validate.py
+++ b/.agents/skills/okf-bundle/scripts/okf_validate.py
@@ -66,7 +66,12 @@ def validate(
         count += 1
         rel = path.relative_to(bundle_root).as_posix()
         text = path.read_text(encoding="utf-8")
-        fm = parse_frontmatter(text)
+        try:
+            fm = parse_frontmatter(text)
+        except ValueError as e:
+            # 不正な YAML スカラー (クォート未終端等) は frontmatter があっても違反扱い。
+            problems.append(f"{rel}: frontmatter が不正: {e}")
+            continue
         if not fm:
             if not skip_missing:
                 problems.append(f"{rel}: frontmatter が無い")

--- a/.agents/skills/okf-bundle/scripts/okf_validate.py
+++ b/.agents/skills/okf-bundle/scripts/okf_validate.py
@@ -80,7 +80,10 @@ def validate(
             if not fm.get(key):
                 problems.append(f"{rel}: 必須キー '{key}' が無い")
         timestamp = fm.get("timestamp")
-        if isinstance(timestamp, str) and timestamp and not _is_iso8601(timestamp):
+        if isinstance(timestamp, list):
+            # timestamp は scalar (日付文字列) でなければならない。list は不正。
+            problems.append(f"{rel}: timestamp が scalar でない: {timestamp!r}")
+        elif isinstance(timestamp, str) and timestamp and not _is_iso8601(timestamp):
             problems.append(f"{rel}: timestamp '{timestamp}' が ISO 8601 でない")
     if count == 0:
         problems.append(f"{bundle_root}: 概念ドキュメント (*.md) が見つからない")

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image Annotator Lib Makefile
 # Development task automation
 
-.PHONY: help test lint format install install-dev clean run-example typecheck test-unit test-integration test-webapi test-scorer test-tagger test-cov setup
+.PHONY: help test lint format install install-dev clean run-example typecheck test-unit test-integration test-webapi test-scorer test-tagger test-cov setup adr-okf adr-index docs-okf
 
 # Default target
 help:
@@ -22,6 +22,9 @@ help:
 	@echo "  lint         Run code linting (ruff)"
 	@echo "  format       Format code (ruff format)"
 	@echo "  typecheck    Run type checking (mypy)"
+	@echo "  adr-okf      Validate ADR frontmatter + check index is up to date (ADR 0010)"
+	@echo "  adr-index    Regenerate ADR README table + index.md from frontmatter (ADR 0010)"
+	@echo "  docs-okf     Validate docs OKF frontmatter (lazy: --skip-missing, ADR 0010)"
 	@echo "  clean        Clean build artifacts"
 
 # Setup target
@@ -84,6 +87,35 @@ format:
 typecheck:
 	@echo "Running type checking..."
 	uv run mypy src/
+
+# OKF ドキュメント検証・索引生成 (ADR 0010)
+OKF := .agents/skills/okf-bundle/scripts
+DOCS_OKF_EXCLUDE := README.md,CHANGELOG.md,CLAUDE.md,AGENTS.md,GEMINI.md,SKILL.md
+
+adr-index:
+	@echo "Regenerating ADR index from frontmatter..."
+	python3 $(OKF)/okf_index.py --bundle-root docs/decisions \
+		--table --columns id,title,timestamp,status --headers "ADR,タイトル,日付,ステータス" \
+		--link-column id --exclude README.md --table-output docs/decisions/README.md
+	python3 $(OKF)/okf_index.py --bundle-root docs/decisions \
+		--index --index-output docs/decisions/index.md \
+		--index-title "Architecture Decision Records" --exclude README.md
+
+adr-okf:
+	@echo "Validating ADR frontmatter (OKF)..."
+	python3 $(OKF)/okf_validate.py --bundle-root docs/decisions \
+		--require type,title,status,timestamp --exclude README.md
+	python3 $(OKF)/okf_index.py --bundle-root docs/decisions \
+		--table --columns id,title,timestamp,status --headers "ADR,タイトル,日付,ステータス" \
+		--link-column id --exclude README.md --table-output docs/decisions/README.md --check
+	python3 $(OKF)/okf_index.py --bundle-root docs/decisions \
+		--index --index-output docs/decisions/index.md \
+		--index-title "Architecture Decision Records" --exclude README.md --check
+
+docs-okf:
+	@echo "Validating documentation OKF frontmatter (lazy migration, ADR 0010)..."
+	python3 $(OKF)/okf_validate.py --bundle-root docs \
+		--skip-missing --exclude $(DOCS_OKF_EXCLUDE)
 
 # Cleanup target
 clean:

--- a/docs/decisions/0001-runtime-validation-test-lanes.md
+++ b/docs/decisions/0001-runtime-validation-test-lanes.md
@@ -1,8 +1,11 @@
+---
+type: ADR
+title: "Runtime Validation Test Lanes"
+status: Accepted (amended 2026-05-18)
+timestamp: 2026-05-17
+tags: [validation]
+---
 # ADR 0001: Runtime Validation Test Lanes
-
-- **日付**: 2026-05-17
-- **Amended**: 2026-05-18
-- **ステータス**: Accepted (amended)
 
 ## Context
 

--- a/docs/decisions/0002-score-model-output-contract.md
+++ b/docs/decisions/0002-score-model-output-contract.md
@@ -1,7 +1,12 @@
+---
+type: ADR
+title: "Score Model Output Contract"
+status: Accepted
+timestamp: 2026-05-17
+tags: [scoring, annotation]
+depends_on: [torch]
+---
 # ADR 0002: Score Model Output Contract
-
-- **日付**: 2026-05-17
-- **ステータス**: Accepted
 
 ## Context
 

--- a/docs/decisions/0003-rating-model-output-contract.md
+++ b/docs/decisions/0003-rating-model-output-contract.md
@@ -1,7 +1,12 @@
+---
+type: ADR
+title: "Rating Model Output Contract"
+status: Accepted
+timestamp: 2026-05-21
+tags: [rating, annotation]
+depends_on: [torch]
+---
 # ADR 0003: Rating Model Output Contract
-
-- **日付**: 2026-05-21
-- **ステータス**: Accepted
 
 ## Context
 

--- a/docs/decisions/0004-onnx-tagger-loader-and-model-selection.md
+++ b/docs/decisions/0004-onnx-tagger-loader-and-model-selection.md
@@ -1,7 +1,12 @@
+---
+type: ADR
+title: "ONNX Tagger Loader and Model Selection"
+status: Accepted
+timestamp: 2026-05-21
+tags: [tagging, model-selection]
+depends_on: [onnxruntime]
+---
 # ADR 0004: ONNX Tagger Loader and Model Selection
-
-- **日付**: 2026-05-21
-- **ステータス**: Accepted
 
 ## Context
 

--- a/docs/decisions/0005-provider-batch-api-contract.md
+++ b/docs/decisions/0005-provider-batch-api-contract.md
@@ -1,7 +1,12 @@
+---
+type: ADR
+title: "Provider Batch API Contract"
+status: Accepted
+timestamp: 2026-05-25
+tags: [provider-batch, webapi, annotation]
+depends_on: [openai-api, anthropic-api]
+---
 # ADR 0005: Provider Batch API Contract
-
-- **日付**: 2026-05-25
-- **ステータス**: Accepted
 
 ## Context
 

--- a/docs/decisions/0006-annotation-outcome-contract.md
+++ b/docs/decisions/0006-annotation-outcome-contract.md
@@ -1,7 +1,12 @@
+---
+type: ADR
+title: "Annotation Outcome Contract"
+status: Accepted
+timestamp: 2026-05-25
+tags: [annotation]
+depends_on: [pydantic]
+---
 # ADR 0006: Annotation Outcome Contract
-
-- **日付**: 2026-05-25
-- **ステータス**: Accepted
 
 ## Context
 

--- a/docs/decisions/0007-webapi-dual-endpoint-runtime.md
+++ b/docs/decisions/0007-webapi-dual-endpoint-runtime.md
@@ -1,7 +1,12 @@
+---
+type: ADR
+title: "WebAPI Dual-Endpoint Runtime (Chat + Responses)"
+status: Accepted
+timestamp: 2026-06-01
+tags: [webapi, annotation]
+depends_on: [openai-api, pydanticai]
+---
 # ADR 0007: WebAPI Dual-Endpoint Runtime (Chat + Responses)
-
-- **日付**: 2026-06-01
-- **ステータス**: Accepted
 
 > **Design Authority:**
 > WebAPI 推論経路の責務分離 (PydanticAI / LiteLLM / image-annotator-lib) の上位方針は

--- a/docs/decisions/0008-webapi-bounded-image-concurrency.md
+++ b/docs/decisions/0008-webapi-bounded-image-concurrency.md
@@ -1,10 +1,12 @@
-# 0008. WebAPI Bounded Image Concurrency
-
-Date: 2026-06-03
-
-## Status
-
-Accepted
+---
+type: ADR
+title: "WebAPI Bounded Image Concurrency"
+status: Accepted
+timestamp: 2026-06-03
+tags: [webapi, performance]
+depends_on: [openai-api]
+---
+# ADR 0008: WebAPI Bounded Image Concurrency
 
 ## Context
 

--- a/docs/decisions/0009-scorer-value-range-reference.md
+++ b/docs/decisions/0009-scorer-value-range-reference.md
@@ -1,7 +1,13 @@
+---
+type: ADR
+title: "Scorer Raw Output and Value-Range Reference"
+status: Accepted
+timestamp: 2026-06-05
+tags: [scoring, annotation]
+depends_on: [torch]
+---
 # ADR 0009: Scorer Raw Output and Value-Range Reference
 
-- **日付**: 2026-06-05
-- **ステータス**: Accepted
 - **関連 ADR**: [0002 Score Model Output Contract](0002-score-model-output-contract.md)
 - **関連 Issue**: NEXTAltair/LoRAIro#626 (スコア表示の尺度合わせ方針), NEXTAltair/image-annotator-lib#66 (scorer output contract), NEXTAltair/image-annotator-lib#144 (score_scales 実装)
 

--- a/docs/decisions/0010-okf-frontmatter-for-docs.md
+++ b/docs/decisions/0010-okf-frontmatter-for-docs.md
@@ -1,0 +1,124 @@
+---
+type: ADR
+title: "OKF YAML Frontmatter for Documentation"
+status: Accepted
+timestamp: 2026-06-29
+deciders: NEXTAltair
+tags: [process, config]
+depends_on: [yaml]
+---
+# ADR 0010: OKF YAML Frontmatter for Documentation
+
+## Context
+
+ADR `0001–0009` までは frontmatter を持たず、メタデータ（日付・ステータス）を本文の
+インライン bullet（`- **日付**` / `- **ステータス**`）で表現していた。フォーマットも揺れており
+（`# ADR NNNN:` と `# NNNN.`、`## Status` 節と bullet が混在）、`docs/` 配下の非 ADR
+ドキュメントには共通の frontmatter 規約が無かった。
+
+下流の LoRAIro は **ADR 0069**（ADR を OKF バンドル化）と **ADR 0082**（通常ドキュメントへ
+OKF frontmatter を拡張、LoRAIro#971）で、YAML frontmatter をドキュメントの SSoT として扱い、
+横断検索・索引生成・エージェント参照を揃える方針を採った。姉妹パッケージの
+**genai-tag-db-tools も ADR 0010 で同じ規約に追従**している。本リポジトリは LoRAIro に
+消費される下流パッケージであり、3 リポジトリ横断で種別・ドメイン・依存技術を機械可読に
+するため、同じ OKF frontmatter 規約へ寄せる。
+
+参考: LoRAIro ADR 0069 / ADR 0082（LoRAIro#971）, genai-tag-db-tools ADR 0010。
+
+## Decision
+
+`docs/` 配下の Markdown ドキュメントは、先頭に **YAML frontmatter（`---` で囲む）** を持つ
+ことを規約とする。frontmatter を唯一の正準ソース（SSoT）とし、本文にスカラー値メタデータ
+（日付・ステータス）を置かない。
+
+### フィールド
+
+| キー | 必須 | 説明 |
+|------|------|------|
+| `type` | ✅ | 文書種別（下記語彙） |
+| `title` | 任意 | 表示タイトル |
+| `status` | 任意 | 状態（下記語彙） |
+| `timestamp` | 任意 | 作成日・決定日・最終重要更新日。`YYYY-MM-DD` |
+| `tags` | 任意 | 機能・責務・動作の抽象分類（技術名は入れない） |
+| `depends_on` | 任意 | 強く依存する技術・ライブラリ・外部仕様 |
+| `deciders` | ADR のみ | 決定者 |
+
+- `version` は**持たない**。版・鮮度は `timestamp` と Git 履歴で扱う。
+- `type` と重複する分類は `tags` に入れない。
+- 内部 package 名はファイルパスで判別できるため、`packages` のような frontmatter は持たない。
+- ADR の H1 は `# ADR NNNN: <タイトル>` に統一する。日付/ステータスは frontmatter に集約する。
+
+### 語彙（最小限・拡張は本 ADR を改訂）
+
+**`type`**: `ADR` / `Guide` / `Reference` / `Contract` / `Plan` / `Investigation` / `Report`
+
+**`status`**: `Draft` / `Proposed` で始め、`Accepted` / `Implemented` / `Deprecated` /
+`Superseded` / `Rejected` のいずれかで始める。詳細は ` (…)` で付与してよい。
+
+**`tags`**（機能・責務・動作。技術名は禁止）:
+`annotation` / `tagging` / `scoring` / `rating` / `captioning` / `model-selection` /
+`model-registry` / `provider-batch` / `webapi` / `memory-management` / `validation` /
+`performance` / `error-handling` / `config` / `process`
+
+**`depends_on`**（技術・ライブラリ・外部仕様）:
+`torch` / `transformers` / `onnxruntime` / `tensorflow` / `pydanticai` / `litellm` /
+`openai-api` / `anthropic-api` / `google-genai` / `huggingface-hub` / `pydantic` / `yaml`
+
+語彙は最小限から始め、必要が出たら本 ADR を改訂して追加する（語彙ドリフトを防ぐ）。
+
+### 適用範囲
+
+**必須対象**: `docs/**/*.md`（`docs/decisions/*.md` は全件 frontmatter 必須）。
+
+**対象外**: `README.md` / `CHANGELOG.md` / `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` /
+`index.md` / `log.md`（OKF 予約）/ 生成ドキュメント / 外部ツールが固有フォーマットを
+要求するファイル（例: `SKILL.md`）。
+
+### 移行戦略
+
+- `docs/decisions/0001–0009` は本 ADR 導入時に frontmatter へ移行する（インライン日付/
+  ステータスを frontmatter へ吸収）。
+- 非 ADR の中核ドキュメント（`docs/integrations.md` 等）は eager に付与し、一過性・履歴的な
+  ドキュメントは新規作成・実質更新時に lazy 付与する。
+
+### 検証・索引生成（CI 自走しない）
+
+LoRAIro ADR 0069 / 0082 と同様、検証は CI で強制せず**エージェントが判断で起動**する。
+汎用スキル `okf-bundle`（stdlib only）の `okf_validate.py` / `okf_index.py` を vendor し、
+`Makefile` の target で回す:
+
+- `adr-okf`: `docs/decisions` を全件 frontmatter 必須で検証 + index 最新チェック。
+- `adr-index`: frontmatter から `docs/decisions/README.md`（表）+ `index.md` を生成。
+- `docs-okf`: `docs` を `--skip-missing` で検証（lazy migration）。
+
+## Rationale
+
+| 選択肢 | 概要 | 採否 |
+|-------|------|------|
+| A. frontmatter=SSoT + okf-bundle 検証 (本 ADR) | LoRAIro / genai-tag と同一規約に揃える | **採用** |
+| B. 現状維持（インライン bullet メタ） | 規約なし・フォーマット揺れ継続 | 却下: 横断検索・索引化できない |
+| C. 独自 frontmatter 規約 | iam-lib 専用キーで定義 | 却下: 3 リポジトリ横断の一貫性を失う |
+
+- **下流契約としての一貫性**: 本リポジトリは LoRAIro に消費される。同じ OKF 規約に揃えると
+  下流・エージェントが 3 リポジトリを同じ方法で索引・参照できる。
+- **既存資産の再利用**: `okf-bundle` は `--bundle-root` で任意ディレクトリに使える stdlib ツール。
+
+## Consequences
+
+### 良い点
+
+- ◎ ドキュメントの種別・ドメイン・依存技術が機械可読になり横断検索できる。
+- ◎ `docs/decisions/README.md` / `index.md` が frontmatter からの生成物になり手動同期が不要。
+- ◎ LoRAIro / genai-tag-db-tools と運用が揃う。
+
+### トレードオフ
+
+- △ ドキュメント新規作成・実質更新のたびに frontmatter 付与が必要（エージェントが判断）。
+- △ 語彙が固定されるため、新ドメイン/新技術の登場時は本 ADR の改訂が要る。
+
+## Related
+
+- [Open Knowledge Format SPEC v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+- LoRAIro ADR 0069（ADR を OKF バンドル化）/ ADR 0082（LoRAIro#971）
+- genai-tag-db-tools ADR 0010（OKF YAML Frontmatter for Documentation）
+- Issue #158

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,10 +1,20 @@
+---
+type: Reference
+title: Architecture Decision Records
+status: Accepted
+timestamp: 2026-06-29
+tags: [process]
+---
 # Architecture Decision Records
 
-image-annotator-lib の重要な設計判断を記録するドキュメント群。
+image-annotator-lib の重要な設計判断を記録するドキュメント群。各 ADR は先頭に YAML
+frontmatter（`type` / `title` / `status` / `timestamp` / 任意 `tags` / `depends_on`）を持つ。
+docs 全体の frontmatter 規約は [ADR 0010](0010-okf-frontmatter-for-docs.md) を参照。
 
+<!-- OKF-TABLE:START -->
 | ADR | タイトル | 日付 | ステータス |
-|-----|---------|------|-----------|
-| [0001](0001-runtime-validation-test-lanes.md) | Runtime Validation Test Lanes | 2026-05-17 | Accepted |
+|---|---|---|---|
+| [0001](0001-runtime-validation-test-lanes.md) | Runtime Validation Test Lanes | 2026-05-17 | Accepted (amended 2026-05-18) |
 | [0002](0002-score-model-output-contract.md) | Score Model Output Contract | 2026-05-17 | Accepted |
 | [0003](0003-rating-model-output-contract.md) | Rating Model Output Contract | 2026-05-21 | Accepted |
 | [0004](0004-onnx-tagger-loader-and-model-selection.md) | ONNX Tagger Loader and Model Selection | 2026-05-21 | Accepted |
@@ -13,14 +23,23 @@ image-annotator-lib の重要な設計判断を記録するドキュメント群
 | [0007](0007-webapi-dual-endpoint-runtime.md) | WebAPI Dual-Endpoint Runtime (Chat + Responses) | 2026-06-01 | Accepted |
 | [0008](0008-webapi-bounded-image-concurrency.md) | WebAPI Bounded Image Concurrency | 2026-06-03 | Accepted |
 | [0009](0009-scorer-value-range-reference.md) | Scorer Raw Output and Value-Range Reference | 2026-06-05 | Accepted |
+| [0010](0010-okf-frontmatter-for-docs.md) | OKF YAML Frontmatter for Documentation | 2026-06-29 | Accepted |
+<!-- OKF-TABLE:END -->
+
+> このテーブルは `make adr-index` が frontmatter から生成する。手編集しない。
 
 ## ADR テンプレート
 
 ```markdown
+---
+type: ADR
+title: "タイトル"
+status: Proposed | Accepted | Deprecated | Superseded
+timestamp: YYYY-MM-DD
+tags: []
+depends_on: []
+---
 # ADR XXXX: タイトル
-
-- **日付**: YYYY-MM-DD
-- **ステータス**: Proposed | Accepted | Deprecated | Superseded by [XXXX]
 
 ## Context
 

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records
+
+* [Runtime Validation Test Lanes](0001-runtime-validation-test-lanes.md)
+* [Score Model Output Contract](0002-score-model-output-contract.md)
+* [Rating Model Output Contract](0003-rating-model-output-contract.md)
+* [ONNX Tagger Loader and Model Selection](0004-onnx-tagger-loader-and-model-selection.md)
+* [Provider Batch API Contract](0005-provider-batch-api-contract.md)
+* [Annotation Outcome Contract](0006-annotation-outcome-contract.md)
+* [WebAPI Dual-Endpoint Runtime (Chat + Responses)](0007-webapi-dual-endpoint-runtime.md)
+* [WebAPI Bounded Image Concurrency](0008-webapi-bounded-image-concurrency.md)
+* [Scorer Raw Output and Value-Range Reference](0009-scorer-value-range-reference.md)
+* [OKF YAML Frontmatter for Documentation](0010-okf-frontmatter-for-docs.md)

--- a/docs/evaluation-criteria.md
+++ b/docs/evaluation-criteria.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: PydanticAI Model Factory 実装評価基準
+status: Accepted
+timestamp: 2026-02-12
+tags: [webapi, validation]
+depends_on: [pydanticai]
+---
 # PydanticAI Model Factory 実装評価基準
 
 ## 概要

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,3 +1,11 @@
+---
+type: Guide
+title: LiteLLM 統合ガイド
+status: Accepted
+timestamp: 2026-05-26
+tags: [webapi, model-registry]
+depends_on: [litellm, pydanticai]
+---
 # LiteLLM 統合ガイド
 
 本ライブラリは [LiteLLM](https://github.com/BerriAI/litellm) を使用して WebAPI モデルを自動的に検出・管理します。

--- a/docs/model-specs/rating-model-candidates.md
+++ b/docs/model-specs/rating-model-candidates.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Rating Model Candidates
+status: Accepted
+timestamp: 2026-05-21
+tags: [rating, model-selection]
+depends_on: [torch]
+---
 # Rating Model Candidates
 
 This document records model-specific facts for rating-capable annotators. The output contract is


### PR DESCRIPTION
## 概要

Issue #158。下流 LoRAIro（ADR 0069/0082, LoRAIro#971）と姉妹 genai-tag-db-tools（ADR 0010）と同じ OKF YAML frontmatter 規約へ揃える。frontmatter を SSoT とし、3 リポジトリ横断で種別・ドメイン・依存技術を機械可読にする。

## 変更内容

- **ADR 0010**（OKF YAML Frontmatter for Documentation）新規追加: 語彙・適用範囲・移行戦略・検証ツールを明文化（iam-lib 固有 vocab: tagging/scoring/rating/captioning 等）
- **ADR 0001–0009 を frontmatter 化**: インラインメタデータ（`- **日付**` / `- **ステータス**` / `Date:` / `## Status`）を frontmatter へ集約。H1 を `# ADR NNNN:` に統一（0008 の `# 0008.` を修正）
- **okf-bundle スクリプト**（stdlib only）を `.agents/skills/okf-bundle/` へ vendor
- **Makefile に target 追加**: `adr-okf` / `adr-index` / `docs-okf`
- `docs/decisions/README.md` を OKF-TABLE マーカー方式の生成物へ + ADR テンプレートを frontmatter 形式に更新、`docs/decisions/index.md` を生成
- 中核 non-ADR docs（integrations / evaluation-criteria / rating-model-candidates）に frontmatter を eager 付与

## 検証

```
make adr-okf    # OKF 検証 OK + README/index は最新
make docs-okf   # docs OK（--skip-missing）
```

いずれも pass。CI（test.yml）は pytest のみで `src/` 不変のため影響なし（vendor スクリプトは `.agents/` 配下で pytest 非収集）。

## 完了条件 (#158)

- [x] OKF ポリシー ADR が存在し index に載る
- [x] ADR 0001–0010 全件が frontmatter を持ち `make adr-okf` が pass
- [x] 中核 docs に frontmatter、`make docs-okf` が pass
- [x] README/index が frontmatter からの生成物

Refs #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)