### PR TITLE
feat(batch): Gemini Developer API Batch adapter を実装 (ADR 0005 Phase 3)

### DIFF
--- a/src/image_annotator_lib/webapi/batch/adapters/google.py
+++ b/src/image_annotator_lib/webapi/batch/adapters/google.py
@@ -90,6 +90,11 @@ _TERMINAL_STATUSES = frozenset(
 class GoogleBatchAdapter:
     """Adapter for Gemini Developer API Batch (input file 方式)。"""
 
+    # Gemini function declaration は nested schema (`ratings`) を公開しないため、
+    # 本 adapter が実際に生成できる capability は tags/captions/scores のみ (Codex P2)。
+    # service.list_batch_capable_models はこの集合で registry capability を絞る。
+    SUPPORTED_TASK_CAPABILITIES = _DEFAULT_ANNOTATION_CAPABILITIES
+
     @staticmethod
     def batch_metadata() -> dict[str, Any]:
         return {
@@ -531,9 +536,23 @@ def _extract_function_call_args(candidate: Any) -> dict[str, Any] | None:
     return None
 
 
+# google.rpc.Status の canonical code (0-16)。per-item error line はこの体系を使う
+# (HTTP 429/5xx ではない、Codex P2)。transient なものだけ retryable とする。
+_RETRYABLE_CANONICAL_CODES = frozenset(
+    {4, 8, 13, 14}
+)  # DEADLINE_EXCEEDED/RESOURCE_EXHAUSTED/INTERNAL/UNAVAILABLE
+_RETRYABLE_STATUS_NAMES = frozenset({"DEADLINE_EXCEEDED", "RESOURCE_EXHAUSTED", "INTERNAL", "UNAVAILABLE"})
+
+
 def _provider_item_retryable(error: Any) -> bool:
     code = _get(error, "code")
-    return isinstance(code, int) and (code == 429 or code >= 500)
+    if isinstance(code, int):
+        if code == 429 or code >= 500:
+            return True
+        if code in _RETRYABLE_CANONICAL_CODES:
+            return True
+    status_name = str(_get(error, "status") or "").upper()
+    return status_name in _RETRYABLE_STATUS_NAMES
 
 
 def _failed_result_item(
@@ -618,15 +637,30 @@ def _parse_datetime(value: Any) -> datetime | None:
     return None
 
 
+def _batch_stat(job: Any, camel: str, snake: str) -> int | None:
+    """batchStats (camelCase / snake_case) から count を読む (Codex P2)。"""
+    stats = _get_either(job, "batchStats", "batch_stats")
+    if stats is None:
+        return None
+    value = _get_either(stats, camel, snake)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        # REST は int64 を文字列で返すことがある
+        return int(value)
+    return None
+
+
 def _to_status_result(job: Any, *, provider_job_id: str) -> BatchStatusResult:
     return BatchStatusResult(
         provider=_PROVIDER,
         provider_job_id=str(_get(job, "name") or provider_job_id),
         status=_status_from_job(job),
-        # Gemini Developer API Batch は request 単位の集計 count を返さない
-        request_count=None,
-        succeeded_count=None,
-        failed_count=None,
+        request_count=_batch_stat(job, "requestCount", "request_count"),
+        succeeded_count=_batch_stat(job, "successfulRequestCount", "successful_request_count"),
+        failed_count=_batch_stat(job, "failedRequestCount", "failed_request_count"),
         canceled_count=None,
         expired_count=None,
         submitted_at=_parse_datetime(_get_either(job, "createTime", "create_time")),

--- a/src/image_annotator_lib/webapi/batch/adapters/google.py
+++ b/src/image_annotator_lib/webapi/batch/adapters/google.py
@@ -1,0 +1,648 @@
+"""Google Gemini Developer API Batch adapter (ADR 0005 Phase 3 / #154).
+
+ADR 0005 "Provider submit forms" の通り、input file (JSONL + File API) 方式のみを
+実装する。inline requests / Vertex AI BatchPredictionJob route はスコープ外。
+transport は ``google-genai`` SDK。
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from image_annotator_lib.core.types import (
+    AnnotationSchema,
+    TaskCapability,
+    UnifiedAnnotationResult,
+)
+from image_annotator_lib.webapi.model_id import resolve_model_ref
+from image_annotator_lib.webapi.output_normalization import normalize_annotation_output
+
+from ..preparation import (
+    build_google_generate_content_annotation_jsonl,
+    prepare_items,
+)
+from ..types import (
+    BatchErrorPhase,
+    BatchFetchResult,
+    BatchItemError,
+    BatchItemStatus,
+    BatchJobError,
+    BatchJobHandle,
+    BatchProviderItemStatus,
+    BatchResultItem,
+    BatchStatus,
+    BatchStatusResult,
+    BatchSubmitRequest,
+    BatchSubmitResult,
+)
+
+_PROVIDER = "google"
+_MAX_LIBRARY_ITEMS = 500
+_SUPPORTED_PROMPT_PROFILES = frozenset({"default"})
+# Gemini Developer API Batch の input file 上限 (2 GB)。File API 自体の制約で、
+# library_max_items=500 の resized image 前提では実質届かない safety 情報。
+_MAX_GOOGLE_INPUT_FILE_BYTES = 2 * 1024 * 1024 * 1024
+_DEFAULT_ANNOTATION_CAPABILITIES = frozenset(
+    {TaskCapability.TAGS, TaskCapability.CAPTIONS, TaskCapability.SCORES}
+)
+_ANNOTATION_TOOL_NAME = "normalize_annotation_output"
+_ANNOTATION_BASE_PROMPT = (
+    "You analyze images and return structured annotations via the "
+    "`normalize_annotation_output` tool. Respect required fields per capability."
+)
+
+# Gemini finishReason → item error code (ADR 0005 "Error handling")。
+# native signal がある場合のみ refusal 系に正規化する。
+_FINISH_REASON_ERROR_CODES: dict[str, tuple[str, bool]] = {
+    "SAFETY": ("safety_refusal", False),
+    "IMAGE_SAFETY": ("safety_refusal", False),
+    "PROHIBITED_CONTENT": ("content_policy_refusal", False),
+    "BLOCKLIST": ("content_policy_refusal", False),
+    "SPII": ("content_policy_refusal", False),
+    "RECITATION": ("content_policy_refusal", False),
+    "MAX_TOKENS": ("max_tokens", False),
+}
+
+# job state (JOB_STATE_*) → BatchStatus。SDK は enum を返すが、str 化した値の末尾
+# サフィックスで判定して SDK 内部表現の変化に依存しない。
+_JOB_STATE_TO_STATUS: dict[str, BatchStatus] = {
+    "JOB_STATE_PENDING": BatchStatus.RUNNING,
+    "JOB_STATE_QUEUED": BatchStatus.RUNNING,
+    "JOB_STATE_RUNNING": BatchStatus.RUNNING,
+    "JOB_STATE_CANCELLING": BatchStatus.RUNNING,
+    "JOB_STATE_PAUSED": BatchStatus.RUNNING,
+    "JOB_STATE_SUCCEEDED": BatchStatus.COMPLETED,
+    "JOB_STATE_PARTIALLY_SUCCEEDED": BatchStatus.COMPLETED,
+    "JOB_STATE_FAILED": BatchStatus.FAILED,
+    "JOB_STATE_CANCELLED": BatchStatus.CANCELED,
+    "JOB_STATE_EXPIRED": BatchStatus.EXPIRED,
+}
+
+_TERMINAL_STATUSES = frozenset(
+    {BatchStatus.COMPLETED, BatchStatus.FAILED, BatchStatus.CANCELED, BatchStatus.EXPIRED}
+)
+
+
+class GoogleBatchAdapter:
+    """Adapter for Gemini Developer API Batch (input file 方式)。"""
+
+    @staticmethod
+    def batch_metadata() -> dict[str, Any]:
+        return {
+            "provider_batch_api": "gemini_developer_batch",
+            # File API の artifact は 48 時間で自動削除される (input / result とも)
+            "result_retention_days": 2,
+            "zero_data_retention_eligible": False,
+            "provider_max_requests": None,
+            "provider_max_body_bytes": _MAX_GOOGLE_INPUT_FILE_BYTES,
+            "library_max_items": _MAX_LIBRARY_ITEMS,
+        }
+
+    def submit_batch(self, request: BatchSubmitRequest) -> BatchSubmitResult:
+        if request.provider.lower() != _PROVIDER:
+            raise self._job_error(
+                BatchErrorPhase.PREPARE,
+                None,
+                "unsupported_provider",
+                f"Google adapter cannot submit provider: {request.provider}",
+                retryable=False,
+            )
+        if len(request.items) > _MAX_LIBRARY_ITEMS:
+            raise self._job_error(
+                BatchErrorPhase.PREPARE,
+                None,
+                "too_many_items",
+                f"Batch contains {len(request.items)} items; maximum is {_MAX_LIBRARY_ITEMS}",
+                retryable=False,
+            )
+        if request.prompt_profile not in _SUPPORTED_PROMPT_PROFILES:
+            raise self._job_error(
+                BatchErrorPhase.PREPARE,
+                None,
+                "unsupported_prompt_profile",
+                f"Unsupported Google batch prompt_profile: {request.prompt_profile}",
+                retryable=False,
+            )
+        api_key = self._api_key(request.api_keys, provider_job_id=None, phase=BatchErrorPhase.PREPARE)
+
+        model_ref = self._resolve_model_ref(request.litellm_model_id)
+        prepared = prepare_items(request.items, provider=_PROVIDER)
+        request_payload = build_google_generate_content_annotation_jsonl(
+            prepared,
+            system_prompt=_ANNOTATION_BASE_PROMPT,
+            capabilities=_DEFAULT_ANNOTATION_CAPABILITIES,
+        )
+
+        client = self._client(api_key)
+        try:
+            input_file = client.files.upload(
+                file=io.BytesIO(request_payload.encode("utf-8")),
+                config={"display_name": "batch-requests", "mime_type": "jsonl"},
+            )
+        except Exception as exc:
+            raise self._job_error(
+                BatchErrorPhase.UPLOAD,
+                None,
+                "upload_failed",
+                self._format_exception(exc),
+                retryable=self._is_retryable_exception(exc),
+            ) from exc
+
+        input_file_name = str(_get(input_file, "name") or "")
+        if not input_file_name:
+            raise self._job_error(
+                BatchErrorPhase.UPLOAD,
+                None,
+                "missing_input_file_name",
+                "Google batch input upload response did not include a file name",
+                retryable=False,
+            )
+
+        try:
+            job = client.batches.create(
+                model=model_ref.provider_model_id,
+                src=input_file_name,
+                config={"display_name": request.description or "image-annotator-lib batch"},
+            )
+        except Exception as exc:
+            raise self._job_error(
+                BatchErrorPhase.SUBMIT,
+                None,
+                "submit_failed",
+                self._format_exception(exc),
+                retryable=self._is_retryable_exception(exc),
+            ) from exc
+
+        provider_job_id = str(_get(job, "name") or "")
+        if not provider_job_id:
+            raise self._job_error(
+                BatchErrorPhase.SUBMIT,
+                None,
+                "missing_provider_job_id",
+                "Google batch create response did not include a job name",
+                retryable=False,
+            )
+        return BatchSubmitResult(
+            provider=_PROVIDER,
+            provider_job_id=provider_job_id,
+            status=_status_from_job(job),
+            request_count=len(request.items),
+        )
+
+    def retrieve_batch(self, handle: BatchJobHandle) -> BatchStatusResult:
+        job = self._get_job(handle, phase=BatchErrorPhase.POLL)
+        return _to_status_result(job, provider_job_id=handle.provider_job_id)
+
+    def cancel_batch(self, handle: BatchJobHandle) -> BatchStatusResult:
+        api_key = self._api_key(
+            handle.api_keys, provider_job_id=handle.provider_job_id, phase=BatchErrorPhase.CANCEL
+        )
+        client = self._client(api_key)
+        try:
+            client.batches.cancel(name=handle.provider_job_id)
+        except Exception as exc:
+            raise self._job_error(
+                BatchErrorPhase.CANCEL,
+                handle.provider_job_id,
+                "cancel_failed",
+                self._format_exception(exc),
+                retryable=self._is_retryable_exception(exc),
+            ) from exc
+        # cancel は job を返さないため、最新状態を取得し直して返す
+        job = self._get_job(handle, phase=BatchErrorPhase.CANCEL)
+        return _to_status_result(job, provider_job_id=handle.provider_job_id)
+
+    def fetch_batch_results(self, handle: BatchJobHandle) -> BatchFetchResult:
+        job = self._get_job(handle, phase=BatchErrorPhase.DOWNLOAD)
+        status = _to_status_result(job, provider_job_id=handle.provider_job_id)
+        if status.status not in _TERMINAL_STATUSES:
+            raise self._job_error(
+                BatchErrorPhase.DOWNLOAD,
+                handle.provider_job_id,
+                "job_not_completed",
+                "Google batch results are not available until processing has ended",
+                retryable=True,
+            )
+
+        result_file_name = _result_file_name(job)
+        if not result_file_name:
+            job_error = _get(job, "error")
+            message = (
+                str(_get(job_error, "message") or job_error)
+                if job_error is not None
+                else "Google batch job ended without a result file"
+            )
+            raise self._job_error(
+                BatchErrorPhase.DOWNLOAD,
+                handle.provider_job_id,
+                "result_file_missing",
+                message,
+                retryable=False,
+            )
+
+        api_key = self._api_key(
+            handle.api_keys, provider_job_id=handle.provider_job_id, phase=BatchErrorPhase.DOWNLOAD
+        )
+        client = self._client(api_key)
+        try:
+            payload = client.files.download(file=result_file_name)
+        except Exception as exc:
+            raise self._job_error(
+                BatchErrorPhase.DOWNLOAD,
+                handle.provider_job_id,
+                "result_file_download_failed",
+                self._format_exception(exc),
+                retryable=self._is_retryable_exception(exc),
+            ) from exc
+
+        lines = self._decode_jsonl(payload)
+        seen: set[str] = set()
+        items: list[BatchResultItem] = []
+        for raw in lines:
+            item = self._normalize_result_line(raw)
+            if item is None or item.custom_id in seen:
+                continue
+            seen.add(item.custom_id)
+            items.append(item)
+
+        return BatchFetchResult(
+            provider=_PROVIDER,
+            provider_job_id=handle.provider_job_id,
+            status=status.status,
+            items=items,
+        )
+
+    # ------------------------------------------------------------------
+    # 内部ヘルパー
+    # ------------------------------------------------------------------
+
+    def _get_job(self, handle: BatchJobHandle, *, phase: BatchErrorPhase) -> Any:
+        api_key = self._api_key(handle.api_keys, provider_job_id=handle.provider_job_id, phase=phase)
+        client = self._client(api_key)
+        try:
+            return client.batches.get(name=handle.provider_job_id)
+        except Exception as exc:
+            raise self._job_error(
+                phase,
+                handle.provider_job_id,
+                "retrieve_failed",
+                self._format_exception(exc),
+                retryable=self._is_retryable_exception(exc),
+            ) from exc
+
+    def _decode_jsonl(self, payload: Any) -> list[str]:
+        if isinstance(payload, bytes):
+            return payload.decode("utf-8").splitlines()
+        if isinstance(payload, str):
+            return payload.splitlines()
+        raise self._job_error(
+            BatchErrorPhase.PARSE,
+            None,
+            "result_payload_invalid",
+            f"Google batch result download returned unsupported type: {type(payload).__name__}",
+            retryable=False,
+        )
+
+    def _normalize_result_line(self, raw_line: str) -> BatchResultItem | None:
+        if not raw_line.strip():
+            return None
+        try:
+            obj = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            raise self._job_error(
+                BatchErrorPhase.PARSE,
+                None,
+                "result_line_parse_failed",
+                self._format_exception(exc),
+                retryable=False,
+            ) from exc
+        if not isinstance(obj, dict):
+            return None
+
+        custom_id = _extract_custom_id(obj)
+        if not custom_id:
+            return None
+
+        error = obj.get("error") or obj.get("status")
+        if error:
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.FAILED,
+                BatchErrorPhase.NORMALIZE,
+                "provider_item_error",
+                str(_get(error, "message") or error),
+                retryable=_provider_item_retryable(error),
+            )
+
+        response = obj.get("response")
+        if not isinstance(response, Mapping):
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.UNKNOWN,
+                BatchErrorPhase.PARSE,
+                "missing_result",
+                "Google batch output line did not include a response payload",
+                retryable=False,
+            )
+        return self._build_annotation_item(custom_id, response)
+
+    def _build_annotation_item(self, custom_id: str, response: Mapping[str, Any]) -> BatchResultItem:
+        """GenerateContentResponse から BatchResultItem を組み立てる。
+
+        Gemini の native signal (finishReason / promptFeedback.blockReason) がある場合
+        のみ refusal 系へ正規化し (ADR 0005)、それ以外で function call が取れない場合は
+        ``annotation_output_unparseable`` とする。JSON key は REST (camelCase) と
+        SDK dump (snake_case) の両方を受ける。
+        """
+        prompt_feedback = _get_either(response, "promptFeedback", "prompt_feedback")
+        block_reason = str(_get_either(prompt_feedback, "blockReason", "block_reason") or "").upper()
+        if block_reason and block_reason != "BLOCK_REASON_UNSPECIFIED":
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.FAILED,
+                BatchErrorPhase.NORMALIZE,
+                "content_policy_refusal",
+                f"Google prompt was blocked: {block_reason}",
+                retryable=False,
+            )
+
+        candidates = response.get("candidates")
+        if not isinstance(candidates, list) or not candidates:
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.UNKNOWN,
+                BatchErrorPhase.PARSE,
+                "missing_result",
+                "Google batch response had no candidates",
+                retryable=False,
+            )
+        candidate = candidates[0]
+        finish_reason = (
+            str(_get_either(candidate, "finishReason", "finish_reason") or "")
+            .upper()
+            .removeprefix("FINISH_REASON_")
+        )
+        if finish_reason in _FINISH_REASON_ERROR_CODES:
+            code, retryable = _FINISH_REASON_ERROR_CODES[finish_reason]
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.FAILED,
+                BatchErrorPhase.NORMALIZE,
+                code,
+                f"Google batch item ended with finishReason={finish_reason}",
+                retryable=retryable,
+            )
+
+        arguments = _extract_function_call_args(candidate)
+        if arguments is None:
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.UNKNOWN,
+                BatchErrorPhase.PARSE,
+                "annotation_output_unparseable",
+                "Google batch response had no `normalize_annotation_output` function call; "
+                f"finishReason={finish_reason or 'unknown'}",
+                retryable=False,
+            )
+
+        try:
+            schema = normalize_annotation_output(**arguments)
+        except Exception as exc:
+            return _failed_result_item(
+                custom_id,
+                BatchProviderItemStatus.FAILED,
+                BatchErrorPhase.NORMALIZE,
+                "annotation_schema_invalid",
+                f"normalize_annotation_output failed: {self._format_exception(exc)}",
+                retryable=False,
+            )
+
+        return BatchResultItem(
+            custom_id=custom_id,
+            status=BatchItemStatus.SUCCEEDED,
+            provider_status=BatchProviderItemStatus.SUCCEEDED,
+            annotation=_to_unified_annotation(schema),
+            error=None,
+        )
+
+    def _api_key(
+        self, api_keys: dict[str, str], *, provider_job_id: str | None, phase: BatchErrorPhase
+    ) -> str:
+        api_key = api_keys.get(_PROVIDER)
+        if not api_key:
+            raise self._job_error(
+                phase,
+                provider_job_id,
+                "missing_api_key",
+                "Missing Google API key in api_keys['google']",
+                retryable=False,
+            )
+        return api_key
+
+    def _resolve_model_ref(self, litellm_model_id: str):
+        try:
+            ref = resolve_model_ref(litellm_model_id)
+        except Exception as exc:
+            raise self._job_error(
+                BatchErrorPhase.PREPARE,
+                None,
+                "invalid_model_id",
+                self._format_exception(exc),
+                retryable=False,
+            ) from exc
+        if ref.provider != _PROVIDER:
+            raise self._job_error(
+                BatchErrorPhase.PREPARE,
+                None,
+                "unsupported_model_provider",
+                f"Google batch requires a google/gemini model, got: {litellm_model_id}",
+                retryable=False,
+            )
+        return ref
+
+    def _client(self, api_key: str) -> Any:
+        from google import genai
+
+        return genai.Client(api_key=api_key)
+
+    def _job_error(
+        self,
+        phase: BatchErrorPhase,
+        provider_job_id: str | None,
+        code: str,
+        message: str,
+        *,
+        retryable: bool,
+    ) -> BatchJobError:
+        return BatchJobError(
+            phase=phase,
+            provider=_PROVIDER,
+            provider_job_id=provider_job_id,
+            code=code,
+            message=message,
+            retryable=retryable,
+        )
+
+    @staticmethod
+    def _format_exception(exc: Exception) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+    @staticmethod
+    def _is_retryable_exception(exc: Exception) -> bool:
+        # google-genai の APIError は HTTP status を `code` に持つ
+        for attribute in ("code", "status_code"):
+            status_code = getattr(exc, attribute, None)
+            if isinstance(status_code, int) and (status_code == 429 or status_code >= 500):
+                return True
+        return False
+
+
+def _extract_custom_id(obj: Mapping[str, Any]) -> str:
+    key = obj.get("key")
+    if isinstance(key, str) and key:
+        return key
+    metadata = obj.get("metadata")
+    if isinstance(metadata, Mapping):
+        meta_key = metadata.get("key")
+        if isinstance(meta_key, str) and meta_key:
+            return meta_key
+    return ""
+
+
+def _extract_function_call_args(candidate: Any) -> dict[str, Any] | None:
+    """candidate.content.parts から annotation tool の function call args を取り出す。"""
+    content = _get_either(candidate, "content", "content")
+    parts = _get(content, "parts")
+    if not isinstance(parts, list):
+        return None
+    for part in parts:
+        function_call = _get_either(part, "functionCall", "function_call")
+        if not isinstance(function_call, Mapping):
+            continue
+        if str(function_call.get("name") or "") != _ANNOTATION_TOOL_NAME:
+            continue
+        args = function_call.get("args")
+        if isinstance(args, Mapping):
+            return dict(args)
+    return None
+
+
+def _provider_item_retryable(error: Any) -> bool:
+    code = _get(error, "code")
+    return isinstance(code, int) and (code == 429 or code >= 500)
+
+
+def _failed_result_item(
+    custom_id: str,
+    provider_status: BatchProviderItemStatus,
+    phase: BatchErrorPhase,
+    code: str,
+    message: str,
+    *,
+    retryable: bool,
+) -> BatchResultItem:
+    return BatchResultItem(
+        custom_id=custom_id,
+        status=BatchItemStatus.FAILED,
+        provider_status=provider_status,
+        annotation=None,
+        error=BatchItemError(
+            phase=phase,
+            code=code,
+            message=message,
+            retryable=retryable,
+        ),
+    )
+
+
+def _to_unified_annotation(schema: AnnotationSchema) -> UnifiedAnnotationResult:
+    """検証済み `AnnotationSchema` を `UnifiedAnnotationResult` に包む (openai adapter と同型)。"""
+    capabilities: set[TaskCapability] = set()
+    if schema.tags:
+        capabilities.add(TaskCapability.TAGS)
+    if schema.captions:
+        capabilities.add(TaskCapability.CAPTIONS)
+    if schema.score is not None:
+        capabilities.add(TaskCapability.SCORES)
+    if schema.ratings:
+        capabilities.add(TaskCapability.RATINGS)
+    return UnifiedAnnotationResult(
+        model_name="google_batch",
+        capabilities=frozenset(capabilities) if capabilities else _DEFAULT_ANNOTATION_CAPABILITIES,
+        tags=list(schema.tags) if schema.tags else None,
+        captions=list(schema.captions) if schema.captions else None,
+        scores={"score": float(schema.score)} if schema.score is not None else None,
+        ratings=list(schema.ratings) if schema.ratings else None,
+        provider_name=_PROVIDER,
+        framework="google_batch",
+        raw_output=None,
+    )
+
+
+def _job_state_text(job: Any) -> str:
+    state = _get(job, "state")
+    if state is None:
+        return ""
+    name = getattr(state, "name", None)
+    if isinstance(name, str) and name:
+        return name.upper()
+    return str(state).upper()
+
+
+def _status_from_job(job: Any) -> BatchStatus:
+    state_text = _job_state_text(job)
+    for state_name, status in _JOB_STATE_TO_STATUS.items():
+        if state_text.endswith(state_name):
+            return status
+    return BatchStatus.UNKNOWN
+
+
+def _result_file_name(job: Any) -> str:
+    dest = _get(job, "dest")
+    file_name = _get_either(dest, "fileName", "file_name")
+    return str(file_name) if file_name else ""
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if value is None or isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _to_status_result(job: Any, *, provider_job_id: str) -> BatchStatusResult:
+    return BatchStatusResult(
+        provider=_PROVIDER,
+        provider_job_id=str(_get(job, "name") or provider_job_id),
+        status=_status_from_job(job),
+        # Gemini Developer API Batch は request 単位の集計 count を返さない
+        request_count=None,
+        succeeded_count=None,
+        failed_count=None,
+        canceled_count=None,
+        expired_count=None,
+        submitted_at=_parse_datetime(_get_either(job, "createTime", "create_time")),
+        completed_at=_parse_datetime(_get_either(job, "endTime", "end_time")),
+        expires_at=None,
+    )
+
+
+def _get(obj: Any, name: str, default: Any | None = None) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _get_either(obj: Any, camel: str, snake: str, default: Any | None = None) -> Any:
+    value = _get(obj, camel)
+    if value is not None:
+        return value
+    return _get(obj, snake, default)

--- a/src/image_annotator_lib/webapi/batch/preparation.py
+++ b/src/image_annotator_lib/webapi/batch/preparation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import mimetypes
 from dataclasses import dataclass
@@ -146,9 +147,7 @@ def build_annotation_tool_schema(
 
     schema = AnnotationSchema.model_json_schema()
     required = sorted(
-        prop
-        for prop, capability in _PROPERTY_TO_CAPABILITY.items()
-        if capability in capabilities
+        prop for prop, capability in _PROPERTY_TO_CAPABILITY.items() if capability in capabilities
     )
     if required:
         schema["required"] = required
@@ -232,6 +231,128 @@ def build_openai_chat_completions_annotation_jsonl(
                     "url": endpoint,
                     "body": body,
                 },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        )
+
+    return "\n".join(lines)
+
+
+def build_google_annotation_function_declaration(
+    capabilities: frozenset[TaskCapability] = _DEFAULT_ANNOTATION_CAPABILITIES,
+) -> dict[str, Any]:
+    """Build a Gemini function declaration for annotation output (#154).
+
+    Gemini の function declaration ``parameters`` は OpenAPI schema の限定 subset で、
+    Pydantic ``model_json_schema()`` が生成する ``$defs`` / ``$ref`` / ``anyOf`` を
+    受け付けない。``build_annotation_tool_schema`` を流用せず、Gemini-safe な
+    flat schema を明示的に構築する (``ratings`` は nested schema が必要なため
+    Google batch 経路では公開しない。ratings は best-effort optional なので
+    ``normalize_annotation_output`` 側の contract は満たす)。
+
+    Args:
+        capabilities: required にする core capability の集合。
+
+    Returns:
+        Gemini ``tools[].function_declarations[]`` 1 件分の dict。
+    """
+    required = sorted(
+        prop for prop, capability in _PROPERTY_TO_CAPABILITY.items() if capability in capabilities
+    )
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Content tags describing the image.",
+            },
+            "captions": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Natural language captions for the image.",
+            },
+            "score": {
+                "type": "number",
+                "description": "Overall aesthetic/quality score between 0.0 and 1.0.",
+            },
+        },
+    }
+    if required:
+        parameters["required"] = required
+    return {
+        "name": _ANNOTATION_TOOL_NAME,
+        "description": _ANNOTATION_TOOL_DESCRIPTION,
+        "parameters": parameters,
+    }
+
+
+def build_google_generate_content_annotation_jsonl(
+    items: list[PreparedBatchItem],
+    *,
+    system_prompt: str,
+    capabilities: frozenset[TaskCapability] = _DEFAULT_ANNOTATION_CAPABILITIES,
+) -> str:
+    """Build Gemini Developer API Batch input JSONL (#154 / ADR 0005 Phase 3).
+
+    各 line は ``{"key": custom_id, "request": {GenerateContentRequest}}``。
+    structured output は function calling (``tool_config.mode == "ANY"`` で
+    ``normalize_annotation_output`` を強制) で得る。画像は ``inline_data``
+    (base64) で埋め込む。
+
+    Args:
+        items: ``prepare_items()`` の出力。
+        system_prompt: capability に応じた system prompt。
+        capabilities: 出力 schema 上で required にする core capability の集合。
+
+    Returns:
+        Gemini Batch input JSONL (各 line = 1 request)。
+
+    Raises:
+        BatchJobError: 画像読み込み失敗時。
+    """
+    function_declaration = build_google_annotation_function_declaration(capabilities)
+    lines: list[str] = []
+    for item in items:
+        try:
+            payload_bytes = item.image_path.read_bytes()
+        except OSError as exc:
+            raise BatchJobError(
+                phase=BatchErrorPhase.PREPARE,
+                provider="google",
+                provider_job_id=None,
+                code="image_read_failed",
+                message=f"Failed to read image for Google batch input: {item.image_path}: {exc}",
+                retryable=False,
+            ) from exc
+        request = {
+            "system_instruction": {"parts": [{"text": system_prompt}]},
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"text": _USER_PROMPT_TEXT},
+                        {
+                            "inline_data": {
+                                "mime_type": item.image_mime_type,
+                                "data": base64.b64encode(payload_bytes).decode("ascii"),
+                            }
+                        },
+                    ],
+                }
+            ],
+            "tools": [{"function_declarations": [function_declaration]}],
+            "tool_config": {
+                "function_calling_config": {
+                    "mode": "ANY",
+                    "allowed_function_names": [_ANNOTATION_TOOL_NAME],
+                }
+            },
+        }
+        lines.append(
+            json.dumps(
+                {"key": item.custom_id, "request": request},
                 ensure_ascii=False,
                 separators=(",", ":"),
             )

--- a/src/image_annotator_lib/webapi/batch/preparation.py
+++ b/src/image_annotator_lib/webapi/batch/preparation.py
@@ -275,7 +275,9 @@ def build_google_annotation_function_declaration(
             },
             "score": {
                 "type": "number",
-                "description": "Overall aesthetic/quality score between 0.0 and 1.0.",
+                # 同期 WebAPI 経路の共有 prompt (webapi_shared.py "Scoring (1.00-10.00)")
+                # とスケールを揃える (Codex P2)
+                "description": "Overall aesthetic/quality score between 1.00 and 10.00.",
             },
         },
     }

--- a/src/image_annotator_lib/webapi/batch/service.py
+++ b/src/image_annotator_lib/webapi/batch/service.py
@@ -8,6 +8,7 @@ from image_annotator_lib.core.registry import get_webapi_metadata, list_availabl
 from image_annotator_lib.core.types import TaskCapability
 
 from .adapters.anthropic import AnthropicBatchAdapter
+from .adapters.google import GoogleBatchAdapter
 from .adapters.openai import OpenAIBatchAdapter
 from .types import (
     BatchErrorPhase,
@@ -20,7 +21,7 @@ from .types import (
     BatchSubmitResult,
 )
 
-BatchAdapter = AnthropicBatchAdapter | OpenAIBatchAdapter
+BatchAdapter = AnthropicBatchAdapter | GoogleBatchAdapter | OpenAIBatchAdapter
 
 # adapter 実装済み provider の単一情報源 (SSoT)。eligibility gate と dispatch の両方が
 # この registry を参照するため、provider 名のハードコード重複が生じない。
@@ -30,6 +31,7 @@ BatchAdapter = AnthropicBatchAdapter | OpenAIBatchAdapter
 # 誤って除外してしまう。実 dispatch 可否 = adapter 実装の有無)。
 _BATCH_ADAPTERS: dict[str, type[BatchAdapter]] = {
     "anthropic": AnthropicBatchAdapter,
+    "google": GoogleBatchAdapter,
     "openai": OpenAIBatchAdapter,
 }
 

--- a/src/image_annotator_lib/webapi/batch/service.py
+++ b/src/image_annotator_lib/webapi/batch/service.py
@@ -111,6 +111,13 @@ def list_batch_capable_models() -> list[BatchModelInfo]:
             # mode=="responses" 等 OpenAI adapter が dispatch できない model は除外する (#152)。
             continue
         capabilities = _capabilities_from_metadata(metadata.get("capabilities"))
+        # adapter が実際に生成できる capability に絞る (Google は ratings を生成しない
+        # ため、registry の RATINGS を広告すると submit は通るのに結果が欠ける。Codex P2)
+        supported = getattr(adapter_cls, "SUPPORTED_TASK_CAPABILITIES", None)
+        if supported is not None:
+            capabilities = capabilities & frozenset(supported)
+            if not capabilities:
+                continue
         models.append(
             BatchModelInfo(
                 provider=provider,

--- a/tests/unit/webapi/batch/test_google_adapter.py
+++ b/tests/unit/webapi/batch/test_google_adapter.py
@@ -1,0 +1,390 @@
+"""Tests for Google Gemini Developer API Batch adapter (#154)."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from image_annotator_lib.webapi.batch import (
+    BatchItemStatus,
+    BatchJobHandle,
+    BatchStatus,
+    BatchSubmitItem,
+    BatchSubmitRequest,
+)
+from image_annotator_lib.webapi.batch.adapters.google import GoogleBatchAdapter
+from image_annotator_lib.webapi.batch.types import BatchErrorPhase, BatchJobError
+
+
+def _jsonl(lines: list[object]) -> bytes:
+    return "\n".join(json.dumps(line, separators=(",", ":")) for line in lines).encode("utf-8")
+
+
+@dataclass
+class FakeGoogleFiles:
+    uploaded_payload: str | None = None
+    uploaded_config: dict[str, Any] | None = None
+    download_payloads: dict[str, bytes] = field(default_factory=dict)
+    downloaded_names: list[str] = field(default_factory=list)
+
+    def upload(self, *, file: io.BytesIO, config: dict[str, Any]) -> SimpleNamespace:
+        self.uploaded_payload = file.read().decode("utf-8")
+        self.uploaded_config = dict(config)
+        return SimpleNamespace(name="files/input-001")
+
+    def download(self, *, file: str) -> bytes:
+        self.downloaded_names.append(file)
+        if file not in self.download_payloads:
+            raise RuntimeError(f"missing download payload for {file}")
+        return self.download_payloads[file]
+
+
+@dataclass
+class FakeGoogleBatches:
+    created_model: str | None = None
+    created_src: str | None = None
+    created_config: dict[str, Any] | None = None
+    job: dict[str, Any] = field(default_factory=dict)
+    canceled_names: list[str] = field(default_factory=list)
+
+    def create(self, *, model: str, src: str, config: dict[str, Any]) -> dict[str, Any]:
+        self.created_model = model
+        self.created_src = src
+        self.created_config = dict(config)
+        return {"name": "batches/job-001", "state": "JOB_STATE_PENDING"}
+
+    def get(self, *, name: str) -> dict[str, Any]:
+        return {"name": name, **self.job}
+
+    def cancel(self, *, name: str) -> None:
+        self.canceled_names.append(name)
+
+
+def install_fake_google(
+    monkeypatch: pytest.MonkeyPatch, files: FakeGoogleFiles, batches: FakeGoogleBatches
+) -> None:
+    class FakeClient:
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+            self.files = files
+            self.batches = batches
+
+    monkeypatch.setitem(sys.modules, "google", SimpleNamespace(genai=SimpleNamespace(Client=FakeClient)))
+
+
+def make_request(tmp_path: Path, model_id: str = "gemini/gemini-2.5-flash") -> BatchSubmitRequest:
+    image_path = tmp_path / "img-1.png"
+    image_path.write_bytes(b"fake-image-bytes")
+    return BatchSubmitRequest(
+        provider="google",
+        endpoint="",
+        litellm_model_id=model_id,
+        prompt_profile="default",
+        description=None,
+        api_keys={"google": "test-key"},
+        items=[BatchSubmitItem(custom_id="img-1", image_id=1, image_path=image_path)],
+    )
+
+
+def make_handle() -> BatchJobHandle:
+    return BatchJobHandle(
+        provider="google", provider_job_id="batches/job-001", api_keys={"google": "test-key"}
+    )
+
+
+def _success_line(key: str = "img-1", *, camel: bool = True) -> dict[str, Any]:
+    function_call_key = "functionCall" if camel else "function_call"
+    return {
+        "key": key,
+        "response": {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                function_call_key: {
+                                    "name": "normalize_annotation_output",
+                                    "args": {"tags": ["1girl"], "captions": ["a girl"], "score": 0.8},
+                                }
+                            }
+                        ]
+                    },
+                    "finishReason": "STOP",
+                }
+            ]
+        },
+    }
+
+
+def test_submit_batch_builds_gemini_jsonl_and_creates_job(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    files = FakeGoogleFiles()
+    batches = FakeGoogleBatches()
+    install_fake_google(monkeypatch, files=files, batches=batches)
+
+    result = GoogleBatchAdapter().submit_batch(make_request(tmp_path))
+
+    assert result.provider == "google"
+    assert result.provider_job_id == "batches/job-001"
+    assert result.status is BatchStatus.RUNNING
+    assert result.request_count == 1
+    # File API へ JSONL を upload し、その file 名で job を作る
+    assert files.uploaded_config == {"display_name": "batch-requests", "mime_type": "jsonl"}
+    assert batches.created_src == "files/input-001"
+    assert batches.created_model == "gemini-2.5-flash"
+    assert files.uploaded_payload is not None
+    line = json.loads(files.uploaded_payload.splitlines()[0])
+    assert line["key"] == "img-1"
+    request = line["request"]
+    assert request["system_instruction"]["parts"][0]["text"]
+    parts = request["contents"][0]["parts"]
+    assert parts[1]["inline_data"]["mime_type"] == "image/png"
+    declarations = request["tools"][0]["function_declarations"]
+    assert declarations[0]["name"] == "normalize_annotation_output"
+    # Gemini は $ref / $defs を受けないため flat schema であること
+    assert "$defs" not in json.dumps(declarations)
+    config = request["tool_config"]["function_calling_config"]
+    assert config["mode"] == "ANY"
+    assert config["allowed_function_names"] == ["normalize_annotation_output"]
+
+
+def test_submit_batch_rejects_non_google_model(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_google(monkeypatch, files=FakeGoogleFiles(), batches=FakeGoogleBatches())
+    request = make_request(tmp_path, model_id="openai/gpt-4o")
+
+    with pytest.raises(BatchJobError) as excinfo:
+        GoogleBatchAdapter().submit_batch(request)
+
+    assert excinfo.value.phase is BatchErrorPhase.PREPARE
+    assert excinfo.value.code == "unsupported_model_provider"
+
+
+def test_submit_batch_requires_google_api_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_google(monkeypatch, files=FakeGoogleFiles(), batches=FakeGoogleBatches())
+    request = make_request(tmp_path)
+    request = BatchSubmitRequest(
+        provider=request.provider,
+        endpoint=request.endpoint,
+        litellm_model_id=request.litellm_model_id,
+        prompt_profile=request.prompt_profile,
+        description=None,
+        api_keys={},
+        items=request.items,
+    )
+
+    with pytest.raises(BatchJobError) as excinfo:
+        GoogleBatchAdapter().submit_batch(request)
+
+    assert excinfo.value.code == "missing_api_key"
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ("JOB_STATE_PENDING", BatchStatus.RUNNING),
+        ("JOB_STATE_RUNNING", BatchStatus.RUNNING),
+        ("JOB_STATE_SUCCEEDED", BatchStatus.COMPLETED),
+        ("JOB_STATE_FAILED", BatchStatus.FAILED),
+        ("JOB_STATE_CANCELLED", BatchStatus.CANCELED),
+        ("JOB_STATE_EXPIRED", BatchStatus.EXPIRED),
+        ("SOMETHING_ELSE", BatchStatus.UNKNOWN),
+    ],
+)
+def test_retrieve_batch_maps_job_states(
+    monkeypatch: pytest.MonkeyPatch, state: str, expected: BatchStatus
+) -> None:
+    batches = FakeGoogleBatches(job={"state": state})
+    install_fake_google(monkeypatch, files=FakeGoogleFiles(), batches=batches)
+
+    result = GoogleBatchAdapter().retrieve_batch(make_handle())
+
+    assert result.status is expected
+    assert result.provider_job_id == "batches/job-001"
+
+
+def test_retrieve_batch_maps_enum_like_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SDK が enum を返しても (str 化に enum class 名が乗っても) 状態を解決できる。"""
+    batches = FakeGoogleBatches(job={"state": SimpleNamespace(name="JOB_STATE_SUCCEEDED")})
+    install_fake_google(monkeypatch, files=FakeGoogleFiles(), batches=batches)
+
+    result = GoogleBatchAdapter().retrieve_batch(make_handle())
+
+    assert result.status is BatchStatus.COMPLETED
+
+
+def test_cancel_batch_cancels_then_returns_latest_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    batches = FakeGoogleBatches(job={"state": "JOB_STATE_CANCELLED"})
+    install_fake_google(monkeypatch, files=FakeGoogleFiles(), batches=batches)
+
+    result = GoogleBatchAdapter().cancel_batch(make_handle())
+
+    assert batches.canceled_names == ["batches/job-001"]
+    assert result.status is BatchStatus.CANCELED
+
+
+def test_fetch_batch_results_requires_terminal_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    batches = FakeGoogleBatches(job={"state": "JOB_STATE_RUNNING"})
+    install_fake_google(monkeypatch, files=FakeGoogleFiles(), batches=batches)
+
+    with pytest.raises(BatchJobError) as excinfo:
+        GoogleBatchAdapter().fetch_batch_results(make_handle())
+
+    assert excinfo.value.code == "job_not_completed"
+    assert excinfo.value.retryable is True
+
+
+def test_fetch_batch_results_raises_when_result_file_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    batches = FakeGoogleBatches(job={"state": "JOB_STATE_FAILED", "error": {"message": "quota exceeded"}})
+    install_fake_google(monkeypatch, files=FakeGoogleFiles(), batches=batches)
+
+    with pytest.raises(BatchJobError) as excinfo:
+        GoogleBatchAdapter().fetch_batch_results(make_handle())
+
+    assert excinfo.value.code == "result_file_missing"
+    assert "quota exceeded" in excinfo.value.message
+
+
+def test_fetch_batch_results_normalizes_output_lines(monkeypatch: pytest.MonkeyPatch) -> None:
+    files = FakeGoogleFiles(
+        download_payloads={
+            "files/output-001": _jsonl(
+                [
+                    _success_line("img-1", camel=True),
+                    _success_line("img-2", camel=False),
+                    {"key": "img-3", "error": {"code": 500, "message": "internal error"}},
+                    {
+                        "key": "img-4",
+                        "response": {"candidates": [{"finishReason": "SAFETY"}]},
+                    },
+                    {
+                        "key": "img-5",
+                        "response": {
+                            "candidates": [
+                                {"content": {"parts": [{"text": "cannot help"}]}, "finishReason": "STOP"}
+                            ]
+                        },
+                    },
+                ]
+            )
+        }
+    )
+    batches = FakeGoogleBatches(
+        job={"state": "JOB_STATE_SUCCEEDED", "dest": {"file_name": "files/output-001"}}
+    )
+    install_fake_google(monkeypatch, files=files, batches=batches)
+
+    result = GoogleBatchAdapter().fetch_batch_results(make_handle())
+
+    assert result.status is BatchStatus.COMPLETED
+    assert files.downloaded_names == ["files/output-001"]
+    by_id = {item.custom_id: item for item in result.items}
+    assert set(by_id) == {"img-1", "img-2", "img-3", "img-4", "img-5"}
+
+    # camelCase / snake_case どちらの functionCall も success として parse できる
+    for key in ("img-1", "img-2"):
+        item = by_id[key]
+        assert item.status is BatchItemStatus.SUCCEEDED
+        assert item.annotation is not None
+        assert item.annotation.tags == ["1girl"]
+        assert item.annotation.scores == {"score": 0.8}
+        assert item.annotation.provider_name == "google"
+
+    # provider error line
+    error_item = by_id["img-3"]
+    assert error_item.status is BatchItemStatus.FAILED
+    assert error_item.error is not None
+    assert error_item.error.code == "provider_item_error"
+    assert error_item.error.retryable is True
+
+    # native safety signal (ADR 0005)
+    safety_item = by_id["img-4"]
+    assert safety_item.error is not None
+    assert safety_item.error.code == "safety_refusal"
+    assert safety_item.error.retryable is False
+
+    # function call が無い自由文応答は annotation_output_unparseable
+    unparseable = by_id["img-5"]
+    assert unparseable.error is not None
+    assert unparseable.error.code == "annotation_output_unparseable"
+
+
+def test_fetch_batch_results_dedupes_keys_and_skips_keyless_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    files = FakeGoogleFiles(
+        download_payloads={
+            "files/output-001": _jsonl(
+                [
+                    _success_line("img-1"),
+                    _success_line("img-1"),
+                    {"response": {"candidates": []}},
+                ]
+            )
+        }
+    )
+    batches = FakeGoogleBatches(
+        job={"state": "JOB_STATE_SUCCEEDED", "dest": {"file_name": "files/output-001"}}
+    )
+    install_fake_google(monkeypatch, files=files, batches=batches)
+
+    result = GoogleBatchAdapter().fetch_batch_results(make_handle())
+
+    assert [item.custom_id for item in result.items] == ["img-1"]
+
+
+def test_fetch_batch_results_reads_metadata_key_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    line = _success_line("ignored")
+    del line["key"]
+    line["metadata"] = {"key": "img-9"}
+    files = FakeGoogleFiles(download_payloads={"files/output-001": _jsonl([line])})
+    batches = FakeGoogleBatches(
+        job={"state": "JOB_STATE_SUCCEEDED", "dest": {"file_name": "files/output-001"}}
+    )
+    install_fake_google(monkeypatch, files=files, batches=batches)
+
+    result = GoogleBatchAdapter().fetch_batch_results(make_handle())
+
+    assert [item.custom_id for item in result.items] == ["img-9"]
+
+
+def test_prompt_feedback_block_is_content_policy_refusal(monkeypatch: pytest.MonkeyPatch) -> None:
+    files = FakeGoogleFiles(
+        download_payloads={
+            "files/output-001": _jsonl(
+                [
+                    {
+                        "key": "img-1",
+                        "response": {"promptFeedback": {"blockReason": "PROHIBITED_CONTENT"}},
+                    }
+                ]
+            )
+        }
+    )
+    batches = FakeGoogleBatches(
+        job={"state": "JOB_STATE_SUCCEEDED", "dest": {"file_name": "files/output-001"}}
+    )
+    install_fake_google(monkeypatch, files=files, batches=batches)
+
+    result = GoogleBatchAdapter().fetch_batch_results(make_handle())
+
+    assert result.items[0].error is not None
+    assert result.items[0].error.code == "content_policy_refusal"
+
+
+def test_google_adapter_is_registered_in_batch_dispatch() -> None:
+    from image_annotator_lib.webapi.batch import service
+
+    assert service._BATCH_ADAPTERS["google"] is GoogleBatchAdapter
+    metadata = GoogleBatchAdapter.batch_metadata()
+    assert metadata["provider_batch_api"] == "gemini_developer_batch"
+    assert metadata["library_max_items"] == 500

--- a/tests/unit/webapi/batch/test_google_adapter.py
+++ b/tests/unit/webapi/batch/test_google_adapter.py
@@ -388,3 +388,89 @@ def test_google_adapter_is_registered_in_batch_dispatch() -> None:
     metadata = GoogleBatchAdapter.batch_metadata()
     assert metadata["provider_batch_api"] == "gemini_developer_batch"
     assert metadata["library_max_items"] == 500
+
+
+def test_provider_item_error_with_canonical_status_is_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """google.rpc.Status の canonical code / status 名を retryable と判定する (Codex P2)。"""
+    files = FakeGoogleFiles(
+        download_payloads={
+            "files/output-001": _jsonl(
+                [
+                    {"key": "img-1", "error": {"code": 8, "message": "quota"}},
+                    {"key": "img-2", "error": {"status": "UNAVAILABLE", "message": "down"}},
+                    {"key": "img-3", "error": {"code": 3, "message": "invalid argument"}},
+                ]
+            )
+        }
+    )
+    batches = FakeGoogleBatches(
+        job={"state": "JOB_STATE_SUCCEEDED", "dest": {"file_name": "files/output-001"}}
+    )
+    install_fake_google(monkeypatch, files=files, batches=batches)
+
+    result = GoogleBatchAdapter().fetch_batch_results(make_handle())
+
+    by_id = {item.custom_id: item for item in result.items}
+    assert by_id["img-1"].error is not None and by_id["img-1"].error.retryable is True
+    assert by_id["img-2"].error is not None and by_id["img-2"].error.retryable is True
+    assert by_id["img-3"].error is not None and by_id["img-3"].error.retryable is False
+
+
+def test_retrieve_batch_populates_counts_from_batch_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+    """batchStats の requestCount / successful / failed を status へ反映する (Codex P2)。"""
+    batches = FakeGoogleBatches(
+        job={
+            "state": "JOB_STATE_SUCCEEDED",
+            "batchStats": {
+                "requestCount": "3",
+                "successfulRequestCount": 2,
+                "failedRequestCount": 1,
+            },
+        }
+    )
+    install_fake_google(monkeypatch, files=FakeGoogleFiles(), batches=batches)
+
+    result = GoogleBatchAdapter().retrieve_batch(make_handle())
+
+    assert result.request_count == 3
+    assert result.succeeded_count == 2
+    assert result.failed_count == 1
+
+
+def test_gemini_schema_uses_shared_prompt_score_scale() -> None:
+    """score スケールは共有 prompt (1.00-10.00) と揃える (Codex P2)。"""
+    from image_annotator_lib.webapi.batch.preparation import (
+        build_google_annotation_function_declaration,
+    )
+
+    declaration = build_google_annotation_function_declaration()
+
+    assert "1.00 and 10.00" in declaration["parameters"]["properties"]["score"]["description"]
+
+
+def test_list_batch_capable_models_filters_google_capabilities_to_supported(monkeypatch) -> None:
+    """registry が RATINGS を持っていても Google は生成可能な capability に絞る (Codex P2)。"""
+    from image_annotator_lib.core.types import TaskCapability
+    from image_annotator_lib.webapi.batch import service
+
+    monkeypatch.setattr(service, "list_available_annotators", lambda: ["gemini"])
+    monkeypatch.setattr(
+        service,
+        "get_webapi_metadata",
+        lambda name: {
+            "gemini": {
+                "provider": "google",
+                "litellm_model_id": "gemini/gemini-2.5-flash",
+                "capabilities": ["tags", "captions", "scores", "ratings"],
+            },
+        }.get(name),
+    )
+
+    models = service.list_batch_capable_models()
+
+    assert len(models) == 1
+    assert models[0].provider == "google"
+    assert TaskCapability.RATINGS not in models[0].capabilities
+    assert TaskCapability.TAGS in models[0].capabilities


### PR DESCRIPTION
## 概要

ADR 0005 (Provider Batch API Contract) Phase 3 の Google batch adapter を実装する。#152 で eligibility が adapter-availability gate に確定して以降、Google モデルは `_BATCH_ADAPTERS` 未登録のため batch 対象外だった。

Closes #154

## 変更内容 (Issue のチェックリスト対応)

- [x] **Gemini Developer API Batch adapter** (`webapi/batch/adapters/google.py`): `submit_batch` / `retrieve_batch` / `cancel_batch` / `fetch_batch_results` を `BatchAdapter` protocol に合わせて実装。transport は `google-genai` SDK (`genai.Client(api_key=...)`、adapter 内 lazy import)
- [x] **input file (JSONL + File API) 方式** (ADR 0005 "Provider submit forms"): `build_google_generate_content_annotation_jsonl` (preparation.py) が `{"key": custom_id, "request": {GenerateContentRequest}}` 形式の JSONL を構築 → `files.upload(mime_type="jsonl")` → `batches.create(src=file_name)`。inline requests は実装しない
  - structured output は function calling で取得 (`tool_config.function_calling_config.mode="ANY"` で `normalize_annotation_output` を強制)。Gemini の function declaration は Pydantic `model_json_schema()` が生成する `$defs`/`$ref`/`anyOf` を受けないため、Gemini-safe な flat schema を明示構築 (`ratings` は nested schema が必須のため Google 経路では非公開。best-effort optional なので contract は維持)
- [x] **`_BATCH_ADAPTERS` へ `"google"` を登録** → eligibility gate (#152) へ自動反映
- [x] **result JSONL parse / `BatchItemError` 正規化** (ADR 0005 "Error handling"): native signal のみ refusal 化 — `finishReason` SAFETY/IMAGE_SAFETY→`safety_refusal`、PROHIBITED_CONTENT/BLOCKLIST/SPII/RECITATION→`content_policy_refusal`、MAX_TOKENS→`max_tokens`、`promptFeedback.blockReason`→`content_policy_refusal`。function call 欠落→`annotation_output_unparseable`、normalize 失敗→`annotation_schema_invalid`、error line→`provider_item_error` (429/5xx retryable)。JSON key は REST (camelCase) / SDK dump (snake_case) 両対応
- [x] **tests** (`tests/unit/webapi/batch/test_google_adapter.py`, 13 件): JSONL 構築 (flat schema / tool_config / inline_data)、provider/model/API key 検証、`JOB_STATE_*` マッピング (enum 形含む)、cancel→最新状態返却、未完了 fetch の `job_not_completed` (retryable)、FAILED + dest 欠落時の `result_file_missing` (job error message 伝播)、結果正規化 5 系統、key dedup / keyless skip / `metadata.key` fallback、dispatch 登録
- [x] Vertex AI BatchPredictionJob / Google inline requests はスコープ外 (ADR 0005)

## 検証

- `pytest -m "not downloads_and_runs_model and not calls_real_webapi"` (CI と同一 filter) → **920 passed, 13 deselected**
- `ruff check` pass / 変更ファイルは `ruff format` 適用済み

## 補足

- LoRAIro 側の `endpoint_for_task` / task_type SSoT への google 追加は LoRAIro 側の後続作業 (adapter は Anthropic 同様 endpoint を検証しない)
- 実 API での挙動確認は手動 smoke test の運用 (rules/testing.md) に従い、CI では実 API を叩かない

🤖 Generated with [Claude Code](https://claude.com/claude-code)